### PR TITLE
Com 2165 

### DIFF
--- a/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
+++ b/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
@@ -155,7 +155,7 @@ export default {
       this.smsModal = true;
     },
     goToPlanning () {
-      this.$router.push({ name: 'ni planning auxiliaries', params: { targetedAuxiliary: this.userProfile } });
+      this.$router.push({ name: 'ni planning auxiliaries', params: { targetedAuxiliaryId: this.userProfile._id } });
     },
     async sendMessage () {
       this.loading = true;

--- a/src/modules/client/components/customers/CustomerProfileHeader.vue
+++ b/src/modules/client/components/customers/CustomerProfileHeader.vue
@@ -96,7 +96,7 @@ export default {
   methods: {
     goToPlanning () {
       if (this.customer.subscriptions.length) {
-        return this.$router.push({ name: 'ni planning customers', params: { targetedCustomer: this.customer } });
+        return this.$router.push({ name: 'ni planning customers', params: { targetedCustomerId: this.customer._id } });
       }
 
       return NotifyWarning('Le/la bénéficiaire n\'a pas de souscription.');

--- a/src/modules/client/components/planning/ChipsAutocomplete.vue
+++ b/src/modules/client/components/planning/ChipsAutocomplete.vue
@@ -1,11 +1,11 @@
 <template>
-    <q-select dense borderless bg-color="white" multiple behavior="menu" use-chips use-input ref="refFilter" emit-value
-      :value="value" :options="options" @filter="search" @input="input" @add="addEvent" @remove="removeEvent"
-      input-debounce="0" :style="disable && { width: '40px'}" :data-cy="dataCy" map-options>
-      <template #prepend>
-        <q-icon name="search" size="xs" />
-      </template>
-    </q-select>
+  <q-select dense borderless bg-color="white" multiple behavior="menu" use-chips use-input ref="refFilter"
+    :value="value" :options="options" @filter="search" @input="input" @add="addEvent" @remove="removeEvent"
+    input-debounce="0" :style="disable && { width: '40px'}" :data-cy="dataCy" map-options>
+    <template #prepend>
+      <q-icon name="search" size="xs" />
+    </template>
+  </q-select>
 </template>
 
 <script>
@@ -35,15 +35,15 @@ export default {
   },
   methods: {
     addEvent (el) {
-      this.$store.dispatch('planning/setElementToAdd', this.filters.find(elem => elem.value === el.value));
+      this.$store.dispatch('planning/setElementToAdd', this.filters.find(elem => elem.value === el.value.value));
       this.$refs.refFilter.hidePopup();
       this.$refs.refFilter.inputValue = '';
     },
-    input (el) {
-      this.$emit('input', el);
+    input (list) {
+      this.$emit('input', list);
     },
     removeEvent (el) {
-      this.$store.dispatch('planning/setElementToRemove', this.filters.find(elem => elem.value === el.value));
+      this.$store.dispatch('planning/setElementToRemove', this.filters.find(elem => elem.value === el.value.value));
     },
     async search (terms, done) {
       try {

--- a/src/modules/client/components/planning/ChipsAutocomplete.vue
+++ b/src/modules/client/components/planning/ChipsAutocomplete.vue
@@ -45,15 +45,11 @@ export default {
     removeEvent (el) {
       this.$store.dispatch('planning/setElementToRemove', this.filters.find(elem => elem.value === el.value.value));
     },
-    async search (terms, done) {
-      try {
-        const formattedString = escapeRegExp(removeDiacritics(terms));
-        this.options = this.noDiacriticFilters
-          .filter(el => el.noDiacriticsLabel.match(new RegExp(formattedString, 'i')));
-        done(this.options);
-      } catch (e) {
-        done([]);
-      }
+    search (terms, done) {
+      const formattedString = escapeRegExp(removeDiacritics(terms));
+      this.options = this.noDiacriticFilters
+        .filter(el => el.noDiacriticsLabel.match(new RegExp(formattedString, 'i')));
+      done(this.options);
     },
     add (el) {
       this.$store.dispatch('planning/setElementToAdd', this.filters.find(elem => elem.value === el));

--- a/src/modules/client/components/planning/ChipsAutocomplete.vue
+++ b/src/modules/client/components/planning/ChipsAutocomplete.vue
@@ -1,11 +1,11 @@
 <template>
-  <q-select dense borderless bg-color="white" multiple behavior="menu" use-chips use-input ref="refFilter" emit-value
-    :value="value" :options="options" @filter="search" @input="input" @add="addEvent" @remove="removeEvent"
-    input-debounce="0" :style="disable && { width: '40px'}" :data-cy="dataCy">
-    <template #prepend>
-      <q-icon name="search" size="xs" />
-    </template>
-  </q-select>
+    <q-select dense borderless bg-color="white" multiple behavior="menu" use-chips use-input ref="refFilter" emit-value
+      :value="value" :options="options" @filter="search" @input="input" @add="addEvent" @remove="removeEvent"
+      input-debounce="0" :style="disable && { width: '40px'}" :data-cy="dataCy" map-options>
+      <template #prepend>
+        <q-icon name="search" size="xs" />
+      </template>
+    </q-select>
 </template>
 
 <script>
@@ -30,7 +30,7 @@ export default {
   computed: {
     ...mapState('planning', ['elementToAdd']),
     noDiacriticFilters () {
-      return this.filters.map(el => ({ ...el, noDiacriticsValue: removeDiacritics(el.value) }));
+      return this.filters.map(el => ({ ...el, noDiacriticsLabel: removeDiacritics(el.label) }));
     },
   },
   methods: {
@@ -49,7 +49,7 @@ export default {
       try {
         const formattedString = escapeRegExp(removeDiacritics(terms));
         this.options = this.noDiacriticFilters
-          .filter(el => el.noDiacriticsValue.match(new RegExp(formattedString, 'i')));
+          .filter(el => el.noDiacriticsLabel.match(new RegExp(formattedString, 'i')));
         done(this.options);
       } catch (e) {
         done([]);

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -170,9 +170,9 @@ export default {
   beforeDestroy () {
     if (this.isCoach) {
       if (!this.isCustomerPlanning) {
-        this.$q.localStorage.set('lastSearchAuxiliaries', JSON.stringify(this.terms));
+        this.$q.localStorage.set('lastSearchAuxiliaries', JSON.stringify(this.termIds));
       } else {
-        this.$q.localStorage.set('lastSearchCustomers', JSON.stringify(this.terms));
+        this.$q.localStorage.set('lastSearchCustomers', JSON.stringify(this.termIds));
       }
     }
     clearTimeout(this.timeout);
@@ -196,6 +196,9 @@ export default {
     uniqPersons () {
       return uniqBy(this.persons, '_id');
     },
+    termIds () {
+      return this.terms.map(t => t._id || t);
+    },
   },
   methods: {
     hideDeleteEventsModal () {
@@ -210,17 +213,19 @@ export default {
         this.customersWithInterventions = [];
         this.deleteEventsModal = false;
         console.error(e);
-        NotifyNegative('Error lors de la récupération des bénéficiaires.');
+        NotifyNegative('Erreur lors de la récupération des bénéficiaires.');
       }
     },
     toggleAllSectors () {
-      this.$emit('toggle-all-sectors', this.terms);
+      this.$emit('toggle-all-sectors', this.termIds);
       this.terms = [];
     },
     getSector (sectorId) {
       return this.filteredSectors.find(s => s._id === sectorId);
     },
-    restoreFilter (terms) {
+    restoreFilter (termIds) {
+      const terms = this.filters.filter(f => termIds.find(t => t === f._id));
+
       for (const term of terms) {
         setTimeout(() => this.$refs.refFilter.add(term), 100);
       }

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -197,7 +197,7 @@ export default {
       return uniqBy(this.persons, '_id');
     },
     termIds () {
-      return this.terms.map(t => t._id || t);
+      return this.terms.map(t => t._id);
     },
   },
   methods: {

--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -142,12 +142,18 @@ export default {
     // Filters
     initFilters () {
       if (this.targetedAuxiliary) {
-        this.$refs.planningManager.restoreFilter([formatIdentity(this.targetedAuxiliary.identity, 'FL')]);
+        const formattedTargetedAuxiliary = {
+          value: this.targetedAuxiliary._id,
+          label: formatIdentity(this.targetedAuxiliary.identity, 'FL'),
+          ...this.targetedAuxiliary,
+        };
+
+        this.$refs.planningManager.restoreFilter([formattedTargetedAuxiliary]);
       } else if (COACH_ROLES.includes(this.clientRole)) {
         this.addSavedTerms('Auxiliaries');
       } else {
         const userSector = this.filters.find(filter => filter.type === SECTOR && filter._id === this.loggedUser.sector);
-        if (userSector && this.$refs.planningManager) this.$refs.planningManager.restoreFilter([userSector.label]);
+        if (userSector && this.$refs.planningManager) this.$refs.planningManager.restoreFilter([userSector]);
       }
     },
     // History

--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -49,7 +49,7 @@ export default {
     'ni-event-edition-modal': EventEditionModal,
   },
   props: {
-    targetedAuxiliary: { type: Object, default: null },
+    targetedAuxiliaryId: { type: String, default: '' },
   },
   data () {
     return {
@@ -121,7 +121,7 @@ export default {
         .filter(f => f.type === SECTOR ||
           this.hasContractOnEvent(f, moment(this.startOfWeek), this.endOfWeek) ||
           // add targeted auxiliary even if not active on strat of week to display future events
-          (this.targetedAuxiliary && f._id === this.targetedAuxiliary._id));
+          (this.targetedAuxiliaryId && f._id === this.targetedAuxiliaryId));
     },
   },
   methods: {
@@ -140,7 +140,7 @@ export default {
     },
     // Filters
     initFilters () {
-      if (this.targetedAuxiliary) this.$refs.planningManager.restoreFilter([this.targetedAuxiliary._id]);
+      if (this.targetedAuxiliaryId) this.$refs.planningManager.restoreFilter([this.targetedAuxiliaryId]);
       else if (COACH_ROLES.includes(this.clientRole)) {
         this.addSavedTerms('Auxiliaries');
       } else {

--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -33,7 +33,6 @@ import Events from '@api/Events';
 import EventHistories from '@api/EventHistories';
 import { NotifyNegative, NotifyWarning } from '@components/popup/notify';
 import { INTERVENTION, NEVER, PERSON, AUXILIARY, SECTOR, COACH_ROLES, DAILY } from '@data/constants';
-import { formatIdentity } from '@helpers/utils';
 import moment from '@helpers/moment';
 import EventCreationModal from 'src/modules/client/components/planning/EventCreationModal';
 import EventEditionModal from 'src/modules/client/components/planning/EventEditionModal';
@@ -141,19 +140,12 @@ export default {
     },
     // Filters
     initFilters () {
-      if (this.targetedAuxiliary) {
-        const formattedTargetedAuxiliary = {
-          value: this.targetedAuxiliary._id,
-          label: formatIdentity(this.targetedAuxiliary.identity, 'FL'),
-          ...this.targetedAuxiliary,
-        };
-
-        this.$refs.planningManager.restoreFilter([formattedTargetedAuxiliary]);
-      } else if (COACH_ROLES.includes(this.clientRole)) {
+      if (this.targetedAuxiliary) this.$refs.planningManager.restoreFilter([this.targetedAuxiliary._id]);
+      else if (COACH_ROLES.includes(this.clientRole)) {
         this.addSavedTerms('Auxiliaries');
       } else {
         const userSector = this.filters.find(filter => filter.type === SECTOR && filter._id === this.loggedUser.sector);
-        if (userSector && this.$refs.planningManager) this.$refs.planningManager.restoreFilter([userSector]);
+        if (userSector && this.$refs.planningManager) this.$refs.planningManager.restoreFilter([userSector._id]);
       }
     },
     // History

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -126,7 +126,7 @@ export default {
     // Filters
     initFilters () {
       if (this.targetedCustomer) {
-        this.$refs.planningManager.restoreFilter([formatIdentity(this.targetedCustomer.identity, 'FL')]);
+        this.$refs.planningManager.restoreFilter([this.targetedCustomer._id]);
       } else if (COACH_ROLES.includes(this.clientRole)) {
         this.addSavedTerms('Customers');
       } else {

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -126,7 +126,13 @@ export default {
     // Filters
     initFilters () {
       if (this.targetedCustomer) {
-        this.$refs.planningManager.restoreFilter([this.targetedCustomer._id]);
+        const formatedTargetedCustomer = {
+          value: this.targetedCustomer._id,
+          label: formatIdentity(this.targetedCustomer.identity, 'FL'),
+          ...this.targetedCustomer,
+        };
+
+        this.$refs.planningManager.restoreFilter([formatedTargetedCustomer]);
       } else if (COACH_ROLES.includes(this.clientRole)) {
         this.addSavedTerms('Customers');
       } else {

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -137,7 +137,7 @@ export default {
         this.addSavedTerms('Customers');
       } else {
         const userSector = this.filters.find(filter => filter.type === SECTOR && filter._id === this.loggedUser.sector);
-        if (userSector && this.$refs.planningManager) this.$refs.planningManager.restoreFilter([userSector.label]);
+        if (userSector && this.$refs.planningManager) this.$refs.planningManager.restoreFilter([userSector]);
       }
     },
     // Refresh

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -53,7 +53,7 @@ export default {
     'ni-planning-manager': Planning,
   },
   props: {
-    targetedCustomer: { type: Object, default: null },
+    targetedCustomerId: { type: String, default: '' },
   },
   data () {
     return {
@@ -124,7 +124,7 @@ export default {
     },
     // Filters
     initFilters () {
-      if (this.targetedCustomer) this.$refs.planningManager.restoreFilter([this.targetedCustomer._id]);
+      if (this.targetedCustomerId) this.$refs.planningManager.restoreFilter([this.targetedCustomerId]);
       else if (COACH_ROLES.includes(this.clientRole)) {
         this.addSavedTerms('Customers');
       } else {

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -36,7 +36,6 @@ import {
   SECTOR,
   COACH_ROLES,
 } from '@data/constants';
-import { formatIdentity } from '@helpers/utils';
 import moment from '@helpers/moment';
 import { isAfter } from '@helpers/date';
 import { planningActionMixin } from 'src/modules/client/mixins/planningActionMixin';
@@ -125,19 +124,12 @@ export default {
     },
     // Filters
     initFilters () {
-      if (this.targetedCustomer) {
-        const formatedTargetedCustomer = {
-          value: this.targetedCustomer._id,
-          label: formatIdentity(this.targetedCustomer.identity, 'FL'),
-          ...this.targetedCustomer,
-        };
-
-        this.$refs.planningManager.restoreFilter([formatedTargetedCustomer]);
-      } else if (COACH_ROLES.includes(this.clientRole)) {
+      if (this.targetedCustomer) this.$refs.planningManager.restoreFilter([this.targetedCustomer._id]);
+      else if (COACH_ROLES.includes(this.clientRole)) {
         this.addSavedTerms('Customers');
       } else {
         const userSector = this.filters.find(filter => filter.type === SECTOR && filter._id === this.loggedUser.sector);
-        if (userSector && this.$refs.planningManager) this.$refs.planningManager.restoreFilter([userSector]);
+        if (userSector && this.$refs.planningManager) this.$refs.planningManager.restoreFilter([userSector._id]);
       }
     },
     // Refresh

--- a/src/modules/client/store/planning.js
+++ b/src/modules/client/store/planning.js
@@ -28,14 +28,18 @@ export default {
       const filterPromises = await Promise.all(rawPromises);
       const sectors = filterPromises[0];
       for (let i = 0, l = sectors.length; i < l; i++) {
-        elems.push({ label: sectors[i].name, value: sectors[i].name, _id: sectors[i]._id, type: SECTOR });
+        elems.push({ label: sectors[i].name, value: sectors[i]._id, _id: sectors[i]._id, type: SECTOR });
       }
 
       if (roleToSearch) {
         const persons = filterPromises[1];
         for (let i = 0, l = persons.length; i < l; i++) {
-          const value = formatIdentity(persons[i].identity, 'FL');
-          elems.push({ label: value, value, ...persons[i], type: PERSON });
+          elems.push({
+            label: formatIdentity(persons[i].identity, 'FL'),
+            value: persons[i]._id,
+            ...persons[i],
+            type: PERSON,
+          });
         }
       }
 


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : outil

- Périmetre roles : coach admin et aux

- Cas d'usage : fix du bug d'affichage. 

-----
Comment tester : 
  - ETQ Coach admin : 
     -  tester le planning aux : 
        - créer deux auxiliaire avec le meme nom dans deux secteurs differents (ou renommer une auxiliaire avec le meme nom qu'une autre)
        - ajout, suppression de tag des deux auxiliaires doublons
        - avec le tag secteur, verifier que la bonne auxiliaire est dans le bon secteur, qu'elle apparait pas en double, que son homonyme peut etre ajouté/enlevé
     - tester le chemin fiche aux -> Planning aux
        - on arrive bien sur le planning de la bonne aux
        - on peut ajouter son homonyme, son secteur et tout se passe bien
     - tester la sauvegarde de la recherche si on sort et on revient sur la page

     - MEME CHOSE POUR PLANNING BENEF : reprend les mm points un par un

  - ETQ Aux : 
     - tester le planning aux
         - mon secteur est present par default
         - je peux voir mon planning et celui de mon homologue

    - MEME CHOSE POUR PLANNING BENEF 
-----
J’ai du supprimer le emit-value car c’est pas compatible avec map-option 
 https://github.com/quasarframework/quasar/issues/4567

Du coup, je me retrouve avec des objets (auxiliairy, customer, sector) dans le process de sauvegarde de filtre. Et non pas un tableau d’id comme prevu. 

On pourrai faire en sorte que store.planning.filter soit un tableau plus concis:  { value : ObjectId, label: “nom benef ou aux ou secteur”} mais il faudrait faire des appel a l’api dans CustomerPlanning et AuxiliaryPlanning pour re-mapper planning.filter pour les customer et les auxiliaries genre : `Auxiliaryfilter = this.planning.filters.filter(f => f.type === AUXILIARY).map( f => { …auxiliaryListFromAPI.find(aux => aux._id === f.value), ...f)`  ca m’a l’air relou a faire
