### PR TITLE
COM-2276 - do not add auxiliary in array if already inside

### DIFF
--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -27,6 +27,7 @@
 <script>
 import { mapGetters, mapActions, mapState } from 'vuex';
 import cloneDeep from 'lodash/cloneDeep';
+import uniqBy from 'lodash/uniqBy';
 import pick from 'lodash/pick';
 import Customers from '@api/Customers';
 import Events from '@api/Events';
@@ -172,20 +173,9 @@ export default {
       }
     },
     updateAuxiliariesList () {
-      const auxiliaries = [];
-      for (const sector of this.filteredSectors) {
-        auxiliaries.push(...this.getAuxBySector(sector).reduce(
-          (acc, aux) => (!acc.some(a => a._id === aux._id) ? [...acc, this.formatAuxiliaryWithSector(aux)] : acc),
-          []
-        ));
-      }
-
-      auxiliaries.push(...this.filteredAuxiliaries.reduce(
-        (acc, aux) => (!acc.some(a => a._id === aux._id) ? [...acc, this.formatAuxiliaryWithSector(aux)] : acc),
-        []
-      ));
-
-      this.auxiliaries = auxiliaries;
+      const auxFromSector = this.filteredSectors.map(this.getAuxBySector).flat();
+      this.auxiliaries = uniqBy([...this.filteredAuxiliaries, ...auxFromSector], '_id')
+        .map(this.formatAuxiliaryWithSector);
     },
     async refresh () {
       const params = { startDate: this.startOfWeek, endDate: this.endOfWeek, groupBy: AUXILIARY };

--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -314,6 +314,8 @@ export default {
       await this.updateDisplayedEventHistories();
     },
     async updateDisplayedEventHistories () {
+      if (!this.displayHistory) return;
+
       this.eventHistories = this.eventHistories
         .filter(history => this.auxiliaries.some(aux => history.auxiliaries.map(a => a._id).includes(aux._id)));
       if (this.auxiliaries.length) await this.getEventHistories();


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Client

- Périmetre roles : Coach et Auxiliaire

- Cas d'usage : Sur le planning, je peux selectionner un auxiliaire et son equipe dans le selecteur en haut :
je ne vois qu'une fois le planning de l'auxiliaire concernée
je peux accéder a l'historique du planning
si je supprime l'equipe je vois toujours le planing de l'auxiliaire (qui reste selectionné)
si je supprime l'auxiliaire je vois toujours son planning car l'équipe reste selectionnée
