### PR TITLE
COM-2312 fix dashboard when connected as auxiliary

### DIFF
--- a/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Dashboard.vue
@@ -202,7 +202,7 @@ export default {
     initFilters () {
       if (AUXILIARY_ROLES.includes(this.clientRole)) {
         const userSector = this.filters.find(filter => filter._id === this.loggedUser.sector);
-        if (userSector) this.$refs.teamAutocomplete.add(userSector.label);
+        if (userSector) this.$refs.teamAutocomplete.add(userSector);
       }
     },
     formatHours,


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np[

- Périmetre interface : client

- Périmetre roles : auxiliaire

- Cas d'usage : Quand j'arrive sur le tableau de bord, mon equipe est selectionnée et l'affichage se passe bien. 
Verifier aussi cote coach + quand on modifie le mois/le secteur 
