### PR TITLE
Com 2315

### DIFF
--- a/src/core/api/GoogleDrive.js
+++ b/src/core/api/GoogleDrive.js
@@ -1,4 +1,5 @@
 import { alenviAxios } from '@api/ressources/alenviAxios';
+import { downloadFile } from '@helpers/file';
 
 export default {
   async getFileById (params) {
@@ -32,6 +33,6 @@ export default {
       ...(!getHtmlFile && { responseType: 'blob' }),
     });
 
-    return file;
+    downloadFile(file, `download-${Date.now()}`, file.headers['content-type']);
   },
 };

--- a/src/core/api/GoogleDrive.js
+++ b/src/core/api/GoogleDrive.js
@@ -25,8 +25,13 @@ export default {
   getUploadUrl (driveId) {
     return `${process.env.API_HOSTNAME}/gdrive/${driveId}/upload`;
   },
-  async downloadFileById (driveId) {
-    const file = await alenviAxios.get(`${process.env.API_HOSTNAME}/gdrive/file/${driveId}/download`);
+  async downloadFileById (driveId, getHtmlFile = false) {
+    const file = await alenviAxios({
+      url: `${process.env.API_HOSTNAME}/gdrive/file/${driveId}/download`,
+      method: 'GET',
+      ...(!getHtmlFile && { responseType: 'blob' }),
+    });
+
     return file;
   },
 };

--- a/src/core/api/GoogleDrive.js
+++ b/src/core/api/GoogleDrive.js
@@ -33,6 +33,7 @@ export default {
       ...(!getHtmlFile && { responseType: 'blob' }),
     });
 
-    downloadFile(file, `download-${Date.now()}`, file.headers['content-type']);
+    if (getHtmlFile) return file;
+    return downloadFile(file, `download-${Date.now()}`, file.headers['content-type']);
   },
 };

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -439,7 +439,7 @@ export default {
         const gcsDriveId = get(this.helper, 'company.customersConfig.templates.gcs.driveId');
         if (!gcsDriveId) return;
 
-        const file = await Drive.downloadFileById(gcsDriveId);
+        const file = await Drive.downloadFileById(gcsDriveId, true);
 
         this.gcs = file.data;
       } catch (e) {

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -97,9 +97,9 @@
                   :style="col.style">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <ni-button @click="downloadDriveDoc(getAdministrativeDocumentId(props.row))"
-                        :disable="!getAdministrativeDocumentId(props.row)" icon="file_download" />
-                      <ni-button :disable="!getAdministrativeDocumentId(props.row)"
+                      <ni-button @click="downloadDriveDoc(getAdministrativeDocumentId(props.row))" icon="file_download"
+                        :disable="!getAdministrativeDocumentId(props.row) || disableAdministrativeDocument" />
+                      <ni-button :disable="!getAdministrativeDocumentId(props.row) || disableAdministrativeDocument"
                          icon="delete" @click="validateAdministrativeDocumentDeletion(props.row)" />
                     </div>
                   </template>
@@ -218,6 +218,7 @@ export default {
         { name: 'actions', label: '', align: 'center' },
       ],
       administrativeDocumentsLoading: false,
+      disableAdministrativeDocument: false,
       administrativeDocumentCreationModal: false,
       administrativeDocumentsPagination: { rowsPerPage: 0 },
       newAdministrativeDocument: { name: '', file: null },
@@ -436,9 +437,12 @@ export default {
     },
     async downloadDriveDoc (id) {
       try {
+        this.disableAdministrativeDocument = true;
         await GoogleDrive.downloadFileById(id);
       } catch (e) {
         console.error(e);
+      } finally {
+        this.disableAdministrativeDocument = false;
       }
     },
     async getAdministrativeDocuments () {

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -97,9 +97,9 @@
                   :style="col.style">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <ni-button :href="getAdministrativeDocumentLink(props.row)" type="a"
-                        :disable="!getAdministrativeDocumentLink(props.row)" icon="file_download" />
-                      <ni-button :disable="!getAdministrativeDocumentLink(props.row)"
+                      <ni-button @click="downloadDriveDoc(getAdministrativeDocumentId(props.row))"
+                        :disable="!getAdministrativeDocumentId(props.row)" icon="file_download" />
+                      <ni-button :disable="!getAdministrativeDocumentId(props.row)"
                          icon="delete" @click="validateAdministrativeDocumentDeletion(props.row)" />
                     </div>
                   </template>
@@ -166,6 +166,7 @@ import { required, maxValue } from 'vuelidate/lib/validators';
 import Companies from '@api/Companies';
 import Sectors from '@api/Sectors';
 import AdministrativeDocument from '@api/AdministrativeDocuments';
+import GoogleDrive from '@api/GoogleDrive';
 import InternalHours from '@api/InternalHours';
 import TitleHeader from '@components/TitleHeader';
 import Button from '@components/Button';
@@ -430,8 +431,15 @@ export default {
         .onCancel(() => NotifyPositive('Suppression annulée.'));
     },
     // Administrative document
-    getAdministrativeDocumentLink (doc) {
-      return get(doc, 'driveFile.link') || '';
+    getAdministrativeDocumentId (doc) {
+      return get(doc, 'driveFile.driveId') || '';
+    },
+    async downloadDriveDoc (id) {
+      try {
+        await GoogleDrive.downloadFileById(id);
+      } catch (e) {
+        console.error(e);
+      }
     },
     async getAdministrativeDocuments () {
       try {


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : admin (non gere cote auxiliaire pour l'instant)

- Cas d'usage : quand j'appuie sur le bouton de telechargement d'un document administratif (config rh), le document se telecharge effectivement. 
A tester sur plusieurs navigateurs, avec plusieurs types de fichier. 

C'est une premiere pr sur la refacto du drive pour que vous validiez la facon de faire. 
La route est un peu complique a cause des gcs mais je me suis dit que ca ne vallait pas le coup de faire deux routes car on s'etait dit qu'il faudrait probablement revoir les cgs a un moment pour autoriser d'autres fichiers que les html. 

Note: sur firefox j'ai un message etrange lorsque j'ouvre le fichier mais j'aimerais voir quel est le message qui s'affiche autrement qu'en local avant de gerer ce cas. 