### PR TITLE
COM-2300-fix hide compoany for intra

### DIFF
--- a/src/core/components/courses/TraineeTable.vue
+++ b/src/core/components/courses/TraineeTable.vue
@@ -163,8 +163,8 @@ export default {
           value: pt._id,
           label: formatIdentity(pt.identity, 'FL'),
           email: pt.local.email || '',
-          company: pt.company.name || '',
           picture: get(pt, 'picture.link') || DEFAULT_AVATAR,
+          ...(!this.isIntraCourse && { company: pt.company.name || '' }),
         }))
         .sort((a, b) => a.label.localeCompare(b.label));
     },


### PR DESCRIPTION
- ~J'ai ajouté une variable d'environnement~ :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : outils / formation

- Périmetre roles : coach, rof

- Cas d'usage : etq coach quand j;ajoute des stagiaires a une formation INTRA, je ne vois pas leur structure dans le select (car c'est celle de la formation, pas besoin de le rajouter) 
