### PR TITLE
Com 2347 - npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,20 +20,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -66,39 +66,39 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
-      "integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+      "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.14.5.tgz",
-      "integrity": "sha512-YTA/Twn0vBXDVGJuAX6PwW7x5zQei1luDDo2Pl6q1qZ7hVNl0RZrhHCQG/ArGpR29Vl7ETiB8eJyrvpuRp300w==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.15.4.tgz",
+      "integrity": "sha512-P8o7JP2Mzi0SdC6eWr1zF+AEYvrsZa7GSY1lTayjF5XJhVH0kjLYUZPvTMflP7tBgZoe9gIhTa60QwFpqh/E0Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-explode-assignable-expression": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.15.0",
@@ -116,17 +116,17 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
-      "integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz",
+      "integrity": "sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.14.5",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-split-export-declaration": "^7.14.5"
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
@@ -179,84 +179,84 @@
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz",
-      "integrity": "sha512-Htb24gnGJdIGT4vnRKMdoXiOIlqOLmdiUYpAQ0mYfgVT/GDm8GOYhgi4GL+hMKrkiPRohO4ts34ELFsGAPQLDQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.15.4.tgz",
+      "integrity": "sha512-J14f/vq8+hdC2KoWLIQSsGrC9EFBKE4NFts8pfMpymfApds+fPqR30AOUWc4tyr56h9l/GA1Sxv2q3dLZWbQ/g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
         "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -266,53 +266,53 @@
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz",
-      "integrity": "sha512-rLQKdQU+HYlxBwQIj8dk4/0ENOUEhA/Z0l4hN8BexpvmSMN9oA9EagjnhnDpNsRdWCfjwa4mn/HyBXO9yhQP6A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.15.4.tgz",
+      "integrity": "sha512-v53MxgvMK/HCwckJ1bZrq6dNKlmwlyRNYM6ypaRTdXWGOE2c1/SCa6dL/HimhPulGhZKw9W0QhREM583F/t0vQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.14.5",
-        "@babel/helper-wrap-function": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-wrap-function": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
-      "integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.15.4.tgz",
+      "integrity": "sha512-BMRLsdh+D1/aap19TycS4eD1qELGrCBJwzaY9IE8LrpJtJb+H7rQkPIdsfgnMtLBA6DJls7X9z93Z4U8h7xw0A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -328,26 +328,26 @@
       "dev": true
     },
     "@babel/helper-wrap-function": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.14.5.tgz",
-      "integrity": "sha512-YEdjTCq+LNuNS1WfxsDCNpgXkJaIyqco6DAelTUjT4f2KIWC1nBcaCaSdHTBqQVLnTBexBcVcFhLSU1KnYuePQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.15.4.tgz",
+      "integrity": "sha512-Y2o+H/hRV5W8QhIfTpRIBwl57y8PrZt6JM3V8FOo5qarjshHItyH5lXlpMfBfmBefOqSCpKZs/6Dxqp0E/U+uw==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helpers": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/highlight": {
@@ -375,30 +375,30 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
       "dev": true
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.14.5.tgz",
-      "integrity": "sha512-ZoJS2XCKPBfTmL122iP6NM9dOg+d4lc9fFk3zxc8iDjvt8Pk4+TlsHSKhIPf6X+L5ORCdBzqMZDjL/WHj7WknQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.15.4.tgz",
+      "integrity": "sha512-eBnpsl9tlhPhpI10kU06JHnrYXwg3+V6CaP2idsCXNef0aeslpqyITXQ74Vfk5uHgY7IG7XP0yIH8b42KSzHog==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4",
         "@babel/plugin-proposal-optional-chaining": "^7.14.5"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.9.tgz",
-      "integrity": "sha512-d1lnh+ZnKrFKwtTYdw320+sQWCTwgkB9fmUhNXRADA4akR6wLjaruSGnIEUjpt9HCOwTr4ynFTKu19b7rFRpmw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.4.tgz",
+      "integrity": "sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-remap-async-to-generator": "^7.14.5",
+        "@babel/helper-remap-async-to-generator": "^7.15.4",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
@@ -413,23 +413,23 @@
       }
     },
     "@babel/plugin-proposal-class-static-block": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.5.tgz",
-      "integrity": "sha512-KBAH5ksEnYHCegqseI5N9skTdxgJdmDoAOc0uXa+4QMYKeZD0w5IARh4FMlTNtaHhbB8v+KzMdTgxMMzsIy6Yg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.15.4.tgz",
+      "integrity": "sha512-M682XWrrLNk3chXCjoPUQWOyYsB93B9z3mRyjtqqYJWDf2mfCdIYgDrA11cgNVhAQieaq6F2fn2f3wI0U4aTjA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-create-class-features-plugin": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       }
     },
     "@babel/plugin-proposal-decorators": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.14.5.tgz",
-      "integrity": "sha512-LYz5nvQcvYeRVjui1Ykn28i+3aUiXwQ/3MGoEy0InTaz1pJo/lAzmIDXX+BQny/oufgHzJ6vnEEiXQ8KZjEVFg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.15.4.tgz",
+      "integrity": "sha512-WNER+YLs7avvRukEddhu5PSfSaMMimX2xBFgLQS7Bw16yrUxJGWidO9nQp+yLy9MVybg5Ba3BlhAw+BkdhpDmg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-create-class-features-plugin": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-decorators": "^7.14.5"
       }
@@ -506,16 +506,16 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
-      "integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.15.6.tgz",
+      "integrity": "sha512-qtOHo7A1Vt+O23qEAX+GdBpqaIuD3i9VRrWgCJeq7WO6H2d14EK3q11urj5Te2MAeK97nMiIdRpwd/ST4JFbNg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.7",
-        "@babel/helper-compilation-targets": "^7.14.5",
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.14.5"
+        "@babel/plugin-transform-parameters": "^7.15.4"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -550,13 +550,13 @@
       }
     },
     "@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-62EyfyA3WA0mZiF2e2IV9mc9Ghwxcg8YTu8BS4Wss4Y3PY725OmS9M0qLORbJwLqFtGh+jiE4wAmocK2CTUK2Q==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.15.4.tgz",
+      "integrity": "sha512-X0UTixkLf0PCCffxgu5/1RQyGGbgZuKoI+vXP4iSbJSYwPb7hu06omsFGBvQ9lJEvwgrxHdS8B5nbfcd8GyUNA==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.14.5",
-        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-create-class-features-plugin": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       }
@@ -782,17 +782,17 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.9.tgz",
-      "integrity": "sha512-NfZpTcxU3foGWbl4wxmZ35mTsYJy8oQocbeIMoDAGGFarAmSQlL+LWMkDx/tj6pNotpbX3rltIA4dprgAPOq5A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.15.4.tgz",
+      "integrity": "sha512-Yjvhex8GzBmmPQUvpXRPWQ9WnxXgAFuZSrqOK/eJlOGIXwvv8H3UEdUigl1gb/bnjTrln+e8bkZUYCBt/xYlBg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.14.5",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
         "globals": "^11.1.0"
       }
     },
@@ -844,9 +844,9 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.14.5.tgz",
-      "integrity": "sha512-CfmqxSUZzBl0rSjpoQSFoR9UEj3HzbGuGNL21/iFTmjb5gFggJp3ph0xR1YBhexmLoKRHzgxuFvty2xdSt6gTA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.15.4.tgz",
+      "integrity": "sha512-DRTY9fA751AFBDh2oxydvVm4SYevs5ILTWLs6xKXps4Re/KG5nfUkr+TdHCrRWB8C69TlzVgA9b3RmGWmgN9LA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -892,27 +892,27 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.0.tgz",
-      "integrity": "sha512-3H/R9s8cXcOGE8kgMlmjYYC9nqr5ELiPkJn4q0mypBrjhYQoc+5/Maq69vV4xRPWnkzZuwJPf5rArxpB/35Cig==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.4.tgz",
+      "integrity": "sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.15.0",
+        "@babel/helper-module-transforms": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-simple-access": "^7.14.8",
+        "@babel/helper-simple-access": "^7.15.4",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.14.5.tgz",
-      "integrity": "sha512-mNMQdvBEE5DcMQaL5LbzXFMANrQjd2W7FPzg34Y4yEz7dBgdaC+9B84dSO+/1Wba98zoDbInctCDo4JGxz1VYA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.15.4.tgz",
+      "integrity": "sha512-fJUnlQrl/mezMneR72CKCgtOoahqGJNVKpompKwzv3BrEXdlPspTcyxrZ1XmDTIr9PpULrgEQo3qNKp6dW7ssw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
@@ -955,9 +955,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
-      "integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
+      "integrity": "sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1078,30 +1078,30 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.0.tgz",
-      "integrity": "sha512-FhEpCNFCcWW3iZLg0L2NPE9UerdtsCR6ZcsGHUX6Om6kbCQeL5QZDqFDmeNHC6/fy6UH3jEge7K4qG5uC9In0Q==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.6.tgz",
+      "integrity": "sha512-L+6jcGn7EWu7zqaO2uoTDjjMBW+88FXzV8KvrBl2z6MtRNxlsmUNRlZPaNNPUTgqhyC5DHNFk/2Jmra+ublZWw==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
-        "@babel/plugin-proposal-async-generator-functions": "^7.14.9",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
+        "@babel/plugin-proposal-async-generator-functions": "^7.15.4",
         "@babel/plugin-proposal-class-properties": "^7.14.5",
-        "@babel/plugin-proposal-class-static-block": "^7.14.5",
+        "@babel/plugin-proposal-class-static-block": "^7.15.4",
         "@babel/plugin-proposal-dynamic-import": "^7.14.5",
         "@babel/plugin-proposal-export-namespace-from": "^7.14.5",
         "@babel/plugin-proposal-json-strings": "^7.14.5",
         "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
+        "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
         "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
         "@babel/plugin-proposal-optional-chaining": "^7.14.5",
         "@babel/plugin-proposal-private-methods": "^7.14.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.14.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.15.4",
         "@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1120,25 +1120,25 @@
         "@babel/plugin-transform-arrow-functions": "^7.14.5",
         "@babel/plugin-transform-async-to-generator": "^7.14.5",
         "@babel/plugin-transform-block-scoped-functions": "^7.14.5",
-        "@babel/plugin-transform-block-scoping": "^7.14.5",
-        "@babel/plugin-transform-classes": "^7.14.9",
+        "@babel/plugin-transform-block-scoping": "^7.15.3",
+        "@babel/plugin-transform-classes": "^7.15.4",
         "@babel/plugin-transform-computed-properties": "^7.14.5",
         "@babel/plugin-transform-destructuring": "^7.14.7",
         "@babel/plugin-transform-dotall-regex": "^7.14.5",
         "@babel/plugin-transform-duplicate-keys": "^7.14.5",
         "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
-        "@babel/plugin-transform-for-of": "^7.14.5",
+        "@babel/plugin-transform-for-of": "^7.15.4",
         "@babel/plugin-transform-function-name": "^7.14.5",
         "@babel/plugin-transform-literals": "^7.14.5",
         "@babel/plugin-transform-member-expression-literals": "^7.14.5",
         "@babel/plugin-transform-modules-amd": "^7.14.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.15.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.14.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.15.4",
+        "@babel/plugin-transform-modules-systemjs": "^7.15.4",
         "@babel/plugin-transform-modules-umd": "^7.14.5",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
         "@babel/plugin-transform-new-target": "^7.14.5",
         "@babel/plugin-transform-object-super": "^7.14.5",
-        "@babel/plugin-transform-parameters": "^7.14.5",
+        "@babel/plugin-transform-parameters": "^7.15.4",
         "@babel/plugin-transform-property-literals": "^7.14.5",
         "@babel/plugin-transform-regenerator": "^7.14.5",
         "@babel/plugin-transform-reserved-words": "^7.14.5",
@@ -1150,7 +1150,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.14.5",
         "@babel/plugin-transform-unicode-regex": "^7.14.5",
         "@babel/preset-modules": "^0.1.4",
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.6",
         "babel-plugin-polyfill-corejs2": "^0.2.2",
         "babel-plugin-polyfill-corejs3": "^0.2.2",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
@@ -1180,38 +1180,38 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1234,9 +1234,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -1560,6 +1560,12 @@
         }
       }
     },
+    "@gar/promisify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
+      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
+      "dev": true
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1695,6 +1701,16 @@
         "fastq": "^1.6.0"
       }
     },
+    "@npmcli/fs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
+      "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
+      "dev": true,
+      "requires": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
     "@npmcli/move-file": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
@@ -1706,9 +1722,9 @@
       }
     },
     "@polka/url": {
-      "version": "1.0.0-next.17",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.17.tgz",
-      "integrity": "sha512-0p1rCgM3LLbAdwBnc7gqgnvjHg9KpbhcSphergHShlkWz8EdPawoMJ3/VbezI0mGC5eKCDzMaPgF9Yca6cKvrg==",
+      "version": "1.0.0-next.20",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.20.tgz",
+      "integrity": "sha512-88p7+M0QGxKpmnkfXjS4V26AnoC/eiqZutE8GLdaI5X12NY75bXSdTY9NkmYb2Xyk1O+MmkuO6Frmsj84V6I8Q==",
       "dev": true
     },
     "@positron/stack-trace": {
@@ -1952,9 +1968,9 @@
       }
     },
     "@quasar/extras": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@quasar/extras/-/extras-1.10.11.tgz",
-      "integrity": "sha512-/zJiT8iExl0j2k1zA21Eho8SPMtG5ehcYayszunrq/z7zDp728oWSteI9AfQFnF8/+M06f5HUzy+Vssf6IKH/g=="
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/@quasar/extras/-/extras-1.10.12.tgz",
+      "integrity": "sha512-CVSxLw/Z6kaEYrooJX7mpby6YDm0eSa8D9/1+KEfiTYfLrPE4wTRuNGKN5liuLtVhFMdGrEkj6T6DInKpQWW9A=="
     },
     "@quasar/fastclick": {
       "version": "1.1.4",
@@ -2281,9 +2297,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
-      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3800,9 +3816,9 @@
       "dev": true
     },
     "acorn-walk": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
-      "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
     "address": {
@@ -4285,11 +4301,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "babel-eslint": {
@@ -4591,16 +4607,16 @@
       "optional": true
     },
     "boxen": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
-      "integrity": "sha512-49VBlw+PrWEF51aCmy7QIteYPIFZxSpvqBdP/2itCPPlJ49kj9zg/XPRFrdkne2W+CfwXUls8exMvu1RysZpKA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.1.tgz",
+      "integrity": "sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==",
       "dev": true,
       "requires": {
         "ansi-align": "^3.0.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.0",
         "cli-boxes": "^2.2.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.2",
         "type-fest": "^0.20.2",
         "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
@@ -4779,14 +4795,14 @@
       }
     },
     "browserslist": {
-      "version": "4.16.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
-      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
+      "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001251",
+        "caniuse-lite": "^1.0.30001254",
         "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.811",
+        "electron-to-chromium": "^1.3.830",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.75"
       }
@@ -4871,11 +4887,12 @@
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cacache": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.2.0.tgz",
-      "integrity": "sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
       "dev": true,
       "requires": {
+        "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -5051,9 +5068,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001257",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
+      "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
       "dev": true
     },
     "canvas-exif-orientation": {
@@ -5719,9 +5736,9 @@
       }
     },
     "colorette": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true
     },
     "colors": {
@@ -6065,18 +6082,18 @@
       }
     },
     "core-js": {
-      "version": "3.16.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-      "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+      "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.16.3",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.3.tgz",
-      "integrity": "sha512-A/OtSfSJQKLAFRVd4V0m6Sep9lPdjD8bpN8v3tCCGwE0Tmh0hOiVDm9tw6mXmWOKOSZIyr3EkywPo84cJjGvIQ==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.3.tgz",
+      "integrity": "sha512-+in61CKYs4hQERiADCJsdgewpdl/X0GhEX77pjKgbeibXviIt2oxEjTc8O2fqHX8mDdBrDvX8MYD/RYsBv4OiA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.8",
+        "browserslist": "^4.17.0",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -6089,9 +6106,9 @@
       }
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "cors": {
@@ -6733,9 +6750,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
-      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
       "dev": true
     },
     "de-indent": {
@@ -6970,9 +6987,9 @@
       "dev": true
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "deepmerge": {
@@ -7262,9 +7279,9 @@
       "dev": true
     },
     "domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.2.0"
@@ -7631,9 +7648,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.817",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.817.tgz",
-      "integrity": "sha512-Vw0Faepf2Id9Kf2e97M/c99qf168xg86JLKDxivvlpBQ9KDtjSeX0v+TiuSE25PqeQfTz+NJs375b64ca3XOIQ==",
+      "version": "1.3.838",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.838.tgz",
+      "integrity": "sha512-65O6UJiyohFAdX/nc6KJ0xG/4zOn7XCO03kQNNbCeMRGxlWTLzc6Uyi0tFNQuuGWqySZJi8CD2KXPXySVYmzMA==",
       "dev": true
     },
     "elegant-spinner": {
@@ -7788,22 +7805,23 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-      "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.3",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
+        "is-regex": "^1.1.4",
+        "is-string": "^1.0.7",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -8380,9 +8398,9 @@
       "dev": true
     },
     "eslint-plugin-vue": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.16.0.tgz",
-      "integrity": "sha512-0E2dVvVC7I2Xm1HXyx+ZwPj9CNX4NJjs4K4r+GVsHWyt5Pew3JLD4fI7A91b2jeL0TXE7LlszrwLSTJU9eqehw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.17.0.tgz",
+      "integrity": "sha512-Rq5R2QetDCgC+kBFQw1+aJ5B93tQ4xqZvoCUxuIzwTonngNArsdP8ChM8PowIzsJvRtWl4ltGh/bZcN3xhFWSw==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.1.0",
@@ -8958,9 +8976,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
-      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -9126,9 +9144,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -9214,9 +9232,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
-      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -9621,6 +9639,16 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "get-value": {
@@ -10172,9 +10200,9 @@
           },
           "dependencies": {
             "domhandler": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-              "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+              "version": "4.2.2",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+              "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
               "dev": true,
               "requires": {
                 "domelementtype": "^2.2.0"
@@ -10198,9 +10226,9 @@
           }
         },
         "domutils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
           "dev": true,
           "requires": {
             "dom-serializer": "^1.0.1",
@@ -10209,9 +10237,9 @@
           },
           "dependencies": {
             "domhandler": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-              "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+              "version": "4.2.2",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+              "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
               "dev": true,
               "requires": {
                 "domelementtype": "^2.2.0"
@@ -10372,9 +10400,9 @@
           "dev": true
         },
         "domutils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
           "dev": true,
           "requires": {
             "dom-serializer": "^1.0.1",
@@ -13486,14 +13514,13 @@
       }
     },
     "plist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.3.tgz",
-      "integrity": "sha512-ghdOKN99hh1oEmAlwBmPYo4L+tSQ7O3jRpkhWqOrMz86CWotpVzMevvQ+czo7oPDpOZyA6K06Ci7QVHpoh9gaA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.4.tgz",
+      "integrity": "sha512-ksrr8y9+nXOxQB2osVNqrgvX/XQPOXaU4BQMKjYq8PvaY1U18mo+fKgBSwzK+luSyinOuPae956lSVcBwxlAMg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.5.1",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "^0.6.0"
+        "xmlbuilder": "^9.0.7"
       }
     },
     "pnp-webpack-plugin": {
@@ -14812,9 +14839,9 @@
           "dev": true
         },
         "domutils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
           "dev": true,
           "requires": {
             "dom-serializer": "^1.0.1",
@@ -15514,12 +15541,12 @@
       }
     },
     "sirv": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.14.tgz",
-      "integrity": "sha512-czTFDFjK9lXj0u9mJ3OmJoXFztoilYS+NdRPcJoT182w44wSEkHSiO7A2517GLJ8wKM4GjCm2OXE66Dhngbzjg==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.17.tgz",
+      "integrity": "sha512-qx9go5yraB7ekT7bCMqUHJ5jEaOC/GXBxUWv+jeWnb7WzHUFdcQPGWk7YmAwFBaQBrogpuSqd/azbC2lZRqqmw==",
       "dev": true,
       "requires": {
-        "@polka/url": "^1.0.0-next.17",
+        "@polka/url": "^1.0.0-next.20",
         "mime": "^2.3.1",
         "totalist": "^1.0.0"
       },
@@ -15787,9 +15814,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -15967,9 +15994,9 @@
       "dev": true
     },
     "start-server-and-test": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.13.1.tgz",
-      "integrity": "sha512-wZjksmjG5scEHXmV/3HWzImxNzUgaNQ6W8kkqL2GbiOldM+nqiqh7niimlC9ZGNopTGj16kheWZnZtSWgdBZNQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.14.0.tgz",
+      "integrity": "sha512-on5ELuxO2K0t8EmNj9MtVlFqwBMxfWOhu4U7uZD1xccVpFlOQKR93CSe0u98iQzfNxRyaNTb/CdadbNllplTsw==",
       "dev": true,
       "requires": {
         "bluebird": "3.7.2",
@@ -16475,9 +16502,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -16518,9 +16545,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.10.tgz",
-      "integrity": "sha512-kvvfiVvjGMxeUNB6MyYv5z7vhfFRwbwCXJAeL0/lnbrttBVqcMOnpHUf0X42LrPMR8mMpgapkJMchFH4FSHzNA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -16605,14 +16632,14 @@
           "dev": true
         },
         "terser": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
-          "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
+          "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
+          "integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
             "source-map": "~0.7.2",
-            "source-map-support": "~0.5.19"
+            "source-map-support": "~0.5.20"
           },
           "dependencies": {
             "source-map": {
@@ -17015,9 +17042,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
-      "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
+      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
       "dev": true
     },
     "unbox-primitive": {
@@ -17415,6 +17442,14 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        }
       }
     },
     "vm-browserify": {
@@ -17443,9 +17478,9 @@
       }
     },
     "vue-clipboard2": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/vue-clipboard2/-/vue-clipboard2-0.3.1.tgz",
-      "integrity": "sha512-H5S/agEDj0kXjUb5GP2c0hCzIXWRBygaWLN3NEFsaI9I3uWin778SFEMt8QRXiPG+7anyjqWiw2lqcxWUSfkYg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/vue-clipboard2/-/vue-clipboard2-0.3.2.tgz",
+      "integrity": "sha512-JUllOtw16qO0RF224eqN2kr9n21Xb7nCrbAehiJDTpX8eP00DKcdoYPbaT1dcs0vKou1D6hA42sJIte0Mm71IQ==",
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -17460,9 +17495,9 @@
       }
     },
     "vue-eslint-parser": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.10.0.tgz",
-      "integrity": "sha512-7tc/ewS9Vq9Bn741pvpg8op2fWJPH3k32aL+jcIcWGCTzh/zXSdh7pZ5FV3W2aJancP9+ftPAv292zY5T5IPCg==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
+      "integrity": "sha512-qh3VhDLeh773wjgNTl7ss0VejY9bMMa0GoDG2fQVyDzRFdiU3L7fw74tWZDHNQXdZqxO3EveQroa9ct39D2nqg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -18383,9 +18418,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
           "dev": true
         },
         "commander": {
@@ -19177,9 +19212,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true
     },
     "xdg-basedir": {
@@ -19192,12 +19227,6 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
       "dev": true
     },
     "xtend": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45166809/133221988-a8ae0369-6557-4d2b-a014-6457e487a06f.png)


@casl/vue : non maj car il faut mettre quasar et vue a jour avant

@quasar/app : sera mis a jour en meme temps que quasar

chart.js : non maj car la version 2 est compatible avec Vue3. Pour Vue2 il faut rester sur la v1

date-holidays :  non maj car quasar ne supporte pas les es modules

eslint-webpack-plugin : non maj car ne supporte plus webpack4 et quasar1 est sur webpack4 - il faut passer a quasar 2 pour avoir webpack5 -> https://github.com/webpack-contrib/eslint-webpack-plugin/blob/master/CHANGELOG.md

html-loader : non maj car ne supporte plus webpack4 et quasar1 est sur webpack4 - il faut passer a quasar 2 pour avoir webpack5

quasar : sera mis a jour d'ici la fin de l'année a priori dans une PR a part