### PR TITLE
COM-2298 - fix to display correctly exclTaxesPrice

### DIFF
--- a/src/core/helpers/utils.js
+++ b/src/core/helpers/utils.js
@@ -75,12 +75,7 @@ export const roundFrenchPercentage = (number, digits = 2) => (number
   : '0%'
 );
 
-export const formatPrice = (val) => {
-  if (!val) return roundFrenchPrice(0);
-  const result = roundFrenchPrice(val);
-  if (Number.parseFloat(result) === 0) return roundFrenchPrice(0);
-  return result;
-};
+export const formatPrice = val => (val ? roundFrenchPrice(val) : roundFrenchPrice(0));
 
 export const formatIdentity = (identity, format) => {
   if (!identity) return '';

--- a/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
+++ b/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
@@ -88,7 +88,9 @@ export default {
       deep: true,
       handler () {
         this.totalExclTaxes = this.newManualBill.billingItemList
-          .reduce((acc, bi) => acc + this.getExclTaxes(bi.unitInclTaxes, bi.vat) * bi.count, 0);
+          .reduce(
+            (acc, bi) => (bi.billingItem ? acc + this.getExclTaxes(bi.unitInclTaxes, bi.vat) * bi.count : acc), 0
+          );
       },
     },
   },
@@ -103,8 +105,9 @@ export default {
 
       return '';
     },
-    hide (partialReset, type) {
-      this.$emit('hide', { partialReset, type });
+    hide () {
+      this.totalExclTaxes = 0;
+      this.$emit('hide');
     },
     input (event) {
       this.$emit('input', event);

--- a/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
+++ b/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
@@ -107,6 +107,7 @@ export default {
     },
     hide () {
       this.totalExclTaxes = 0;
+      this.selectedBillingItem = null;
       this.$emit('hide');
     },
     input (event) {

--- a/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
+++ b/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
@@ -89,7 +89,8 @@ export default {
       handler () {
         this.totalExclTaxes = this.newManualBill.billingItemList
           .reduce(
-            (acc, bi) => (bi.billingItem ? acc + this.getExclTaxes(bi.unitInclTaxes, bi.vat) * bi.count : acc), 0
+            (acc, bi) => (bi.billingItem ? acc + this.getExclTaxes(bi.unitInclTaxes, bi.vat) * bi.count : acc),
+            0
           );
       },
     },


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client 

- Périmetre roles : admin

- Cas d'usage : 
    - Lors de la creation d'une facture manuelle, lorsque l'utilisateur ajoute plusieurs articles de facturation le total hors taxe s'affiche correctement 
    - Sur la page Factures manuelles, les prix s'affichent correctement 

La methode `formatPrice` a été modifie, vérifier que l'affichage des prix est correct sur: 
- la page des avoirs
- le profil d'un beneficiaire (l'affichage des montants correspondant aux factures)
- la page bordereaux tiers-payeurs
- la page suivi des plans d'aide
- la page balances clients