### PR TITLE
COM-2358 fix border

### DIFF
--- a/src/core/components/form/OptionGroup.vue
+++ b/src/core/components/form/OptionGroup.vue
@@ -47,4 +47,5 @@ export default {
 
   /deep/ .q-field__control
     min-height: 25px !important
+    border: 0
 </style>


### PR DESCRIPTION
- ~J'ai ajouté une variable d'environnement :~
  - [ ] ~J'ai précisé sur le slite de MES et MEP les modifications faites~

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : toute la webapp

- Périmetre roles : tous les roles

- Cas d'usage : je ne veux plus voir la bordure autour d'un group-option. 

- Le pb vient de : input.styl > ligne 35 : 
```
.modal-padding
  .q-field__control
    border: 1px solid $copper-grey-300
    border-radius: 3px
```
