### PR TITLE
COM-2358-border no-border option in select and input

### DIFF
--- a/src/core/components/form/Input.vue
+++ b/src/core/components/form/Input.vue
@@ -142,7 +142,4 @@ export default {
 
   /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
     color: $copper-grey-900
-
-  /deep/ .no-border > .q-field__inner > .q-field__control
-    border: none !important
 </style>

--- a/src/core/components/form/Input.vue
+++ b/src/core/components/form/Input.vue
@@ -24,7 +24,8 @@
         :upper-case="upperCase" :lower-case="lowerCase" :type="inputType" :rows="rows" :suffix="suffix" :error="error"
         @blur="onBlur" @input="update" @keyup.enter="$emit('keyup-enter')" :error-message="errorMessage" :mask="mask"
         :autogrow="this.type === 'textarea'" :readonly="readOnly" :debounce="debounce" :placeholder="placeholder"
-        :data-cy="dataCy" @click="onClick" :hide-bottom-space="readOnly" :input-class="inputClass">
+        :data-cy="dataCy" @click="onClick" :hide-bottom-space="readOnly" :input-class="inputClass"
+        :class="{ 'no-border': noBorder }">
         <template v-if="icon" #prepend>
           <q-icon size="xs" :name="icon" />
         </template>
@@ -69,6 +70,7 @@ export default {
     mask: { type: String, default: '' },
     dataCy: { type: String, default: '' },
     inputClass: { type: [Array, String, Object], default: '' },
+    noBorder: { type: Boolean, default: false },
   },
   data () {
     return {
@@ -140,4 +142,7 @@ export default {
 
   /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
     color: $copper-grey-900
+
+  /deep/ .no-border > .q-field__inner > .q-field__control
+    border: none !important
 </style>

--- a/src/core/components/form/Select.vue
+++ b/src/core/components/form/Select.vue
@@ -5,10 +5,10 @@
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
     <q-select dense borderless :value="model" :bg-color="bgColor" :options="innerOptions" :multiple="multiple"
-      :disable="disable" @focus="onFocus" @blur="onBlur" @input="onInput" behavior="menu" @filter="onFilter"
-      :class="{ 'borders': inModal, 'no-bottom': noError }" :error="error" :error-message="errorMessage" use-input
+      :disable="disable" @focus="onFocus" @blur="onBlur" @input="onInput" behavior="menu" @filter="onFilter" use-input
+      :class="{ 'no-border': noBorder, 'borders': inModal && !noBorder , 'no-bottom': noError }" :error="error"
       :display-value="displayedValue" hide-selected fill-input :input-debounce="0" emit-value ref="selectInput"
-      :option-disable="optionDisable" :data-cy="dataCy" :hide-dropdown-icon="!!icon">
+      :option-disable="optionDisable" :data-cy="dataCy" :hide-dropdown-icon="!!icon" :error-message="errorMessage">
       <template #append>
         <ni-button v-if="value && !disable && clearable" icon="close" @click.stop="resetValue" size="sm" />
         <ni-button v-if="icon" :icon="icon" class="select-icon primary-icon"
@@ -47,6 +47,7 @@ export default {
     optionDisable: { type: String, default: 'disable' },
     dataCy: { type: String, default: '' },
     optionSlot: { type: Boolean, default: false },
+    noBorder: { type: Boolean, default: false },
   },
   components: {
     'ni-button': Button,
@@ -108,4 +109,7 @@ export default {
 
   /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
     color: $copper-grey-900
+
+  /deep/ .no-border > .q-field__inner > .q-field__control
+    border: none !important
 </style>

--- a/src/core/components/form/Select.vue
+++ b/src/core/components/form/Select.vue
@@ -109,7 +109,4 @@ export default {
 
   /deep/ .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__input
     color: $copper-grey-900
-
-  /deep/ .no-border > .q-field__inner > .q-field__control
-    border: none !important
 </style>

--- a/src/css/input.styl
+++ b/src/css/input.styl
@@ -48,6 +48,9 @@
     border: 1px solid $copper-grey-300
     border-radius: 3px
 
+.no-border > .q-field__inner > .q-field__control
+  border: none !important
+
 .q-input
 .q-textarea
   .q-field__control

--- a/src/modules/client/components/customers/infos/CustomerNoteEditionModal.vue
+++ b/src/modules/client/components/customers/infos/CustomerNoteEditionModal.vue
@@ -4,7 +4,7 @@
       <div class="flex-row">
         <ni-input in-modal :value="editedNote.title" @input="update($event, 'title')" :read-only="readOnly"
           @blur="validations.title.$touch" :error="validations.title.$error" @click="removeReadOnly"
-          :input-class="['bold-title', { 'cursor-pointer': readOnly }]" />
+          :input-class="['bold-title', { 'cursor-pointer': readOnly }]" :no-border="readOnly" />
         <div class="cursor-pointer edit-btn">
           <q-icon v-if="readOnly" @click="removeReadOnly" name="edit" data-cy="edit" size="sm" />
         </div>
@@ -13,7 +13,7 @@
     </template>
     <ni-input in-modal :value="editedNote.description" @input="update($event, 'description')" type="textarea"
       @blur="validations.description.$touch" :error="validations.description.$error" :read-only="readOnly"
-      @click="removeReadOnly" :input-class="{ 'cursor-pointer': readOnly }" />
+      @click="removeReadOnly" :input-class="{ 'cursor-pointer': readOnly }" :no-border="readOnly" />
     <customer-note-history-container v-if="readOnly && get(this.editedNote, 'histories.length')"
       :histories="this.editedNote.histories" />
     <template v-if="!readOnly" slot="footer">

--- a/src/modules/client/components/planning/PlanningModalHeader.vue
+++ b/src/modules/client/components/planning/PlanningModalHeader.vue
@@ -4,7 +4,8 @@
       <img :src="avatar" class="avatar">
       <div class="person-name-text" v-if="options.length === 0">{{ formattedIdentity }}</div>
       <div v-else :class="{ 'col-md-6': $q.platform.is.desktop }" class="person-name-select">
-        <ni-select :value="value" :options="options" @input="input" no-error icon="swap_vert" :disable="disable" />
+        <ni-select no-border :value="value" :options="options" @input="input" no-error icon="swap_vert"
+          :disable="disable" />
       </div>
     </div>
     <div class="col-1 cursor-pointer modal-btn-close">


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client outil

- Périmetre roles : admin

- Cas d'usage : suppression de la bordure en trop sur les modales de `notes de suivi benef` et `creation d'evenement`. J'ai fais un tour des modales de la webapp et j'ai pas trouvé d'autre soucis d'affichage
