### PR TITLE
COM-2405 fix deletion button disabled on contract page

### DIFF
--- a/src/core/helpers/date.js
+++ b/src/core/helpers/date.js
@@ -45,6 +45,8 @@ export const descendingSort = (a, b) => {
   return 0;
 };
 
+export const descendingSortArray = (array, key) => [...array].sort((a, b) => descendingSort(a[key], b[key]));
+
 export const formatDate = (value) => {
   if (!value) return '';
 

--- a/src/modules/client/components/contracts/ContractsCell.vue
+++ b/src/modules/client/components/contracts/ContractsCell.vue
@@ -85,7 +85,7 @@ import ResponsiveTable from '@components/table/ResponsiveTable';
 import { COACH, CUSTOMER, AUXILIARY, DOC_EXTENSIONS } from '@data/constants';
 import { downloadDriveDocx, downloadFile } from '@helpers/file';
 import { formatIdentity } from '@helpers/utils';
-import { formatDate, descendingSort } from '@helpers/date';
+import { formatDate, descendingSortArray } from '@helpers/date';
 import moment from '@helpers/moment';
 import { getContractTags } from 'src/modules/client/helpers/tags';
 import { tableMixin } from 'src/modules/client/mixins/tableMixin';
@@ -133,8 +133,7 @@ export default {
   },
   computed: {
     sortedContracts () {
-      const contracts = [...this.contracts];
-      return contracts.sort((a, b) => descendingSort(a.startDate, b.startDate));
+      return descendingSortArray(this.contracts, 'startDate');
     },
   },
   methods: {

--- a/src/modules/client/components/contracts/ContractsCell.vue
+++ b/src/modules/client/components/contracts/ContractsCell.vue
@@ -133,7 +133,7 @@ export default {
   },
   computed: {
     sortedContracts () {
-      const { contracts } = this;
+      const contracts = [...this.contracts];
       return contracts.sort((a, b) => descendingSort(a.startDate, b.startDate));
     },
   },


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : coach/admin

- Cas d'usage : Sur la page d'un auxiliaire, si celui-ci a des evenements apres la date de debut de son contrat, je ne peux pas supprimer le contrat, sinon je peux le supprimer. 
