### PR TITLE
COM-2365 add textarea type to enlarge note area

### DIFF
--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -62,7 +62,7 @@
           <ni-search-address :value="newEvent.address" :error-message="addressError" @blur="validations.address.$touch"
             :error="validations.address.$error" in-modal @input="updateEvent('address', $event)" />
         </template>
-        <ni-input in-modal :value="newEvent.misc" caption="Notes" @blur="validations.misc.$touch"
+        <ni-input in-modal type="textarea" :value="newEvent.misc" caption="Notes" @blur="validations.misc.$touch"
           :error="validations.misc.$error" :required-field="newEvent.type === ABSENCE && newEvent.absence === OTHER"
           @input="updateEvent('misc', $event)" />
       </div>

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -68,8 +68,8 @@
             :disable="!selectedAuxiliary._id || historiesLoading" in-modal :extensions="extensions" drive-storage
             @delete="deleteDocument(editedEvent.attachment.driveId)" />
         </template>
-        <ni-input in-modal v-if="!editedEvent.shouldUpdateRepetition" :value="editedEvent.misc" caption="Notes"
-          :disable="!canUpdateIntervention || historiesLoading" @blur="validations.misc.$touch"
+        <ni-input in-modal v-if="!editedEvent.shouldUpdateRepetition" type="textarea" :value="editedEvent.misc"
+          caption="Notes" :disable="!canUpdateIntervention || historiesLoading" @blur="validations.misc.$touch"
           :error="validations.misc.$error" :required-field="isMiscRequired" @input="updateEvent('misc', $event)" />
         <div v-if="canCancel" class="row q-mb-md light-checkbox">
           <q-checkbox :value="editedEvent.isCancelled" label="Annuler l'évènement" dense :disable="historiesLoading"


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : Auxiliaire / coach / admin

- Cas d'usage : sur les modales de création et d'édition d'un événement, le champ "note" s'étend sur plusieurs lignes 

A vérifier sur les deux modales: 
- pour une heure interne: 
    - ajouter l'adresse (ou la modifier si on est sur la modale d'édition)
    - sortir du champ
    - éditer le champ notes --> verifier qu'aucun appel a l'api du gouvernement ne part
    - sortir du champ --> verifier que les modifications du champ note sont bien enregistrées 
    - supprimer l'adresse --> verifier que les modifications du champ note sont encore enregistrées 
    - ajouter l'adresse 
    - modifier d'autres champs de la modale --> verifier que les appels a l'api du gouvernement ne partent que lorsque l'on modifie l'adresse (une fois qu'on est sorti du champ adresse aucun ne doit partir)
- lorsque je cree ou édite un evenement, si je modifie plusieurs champs (par ex l'adresse puis la note) et clique sur le bouton `Creer/ Editer l'événement`, le loader apparait directement apres le click (on ne peut pas creer plusieurs fois l'événement)