### PR TITLE
COM-2371 - boyscoot replace createlist by list

### DIFF
--- a/src/core/api/Payments.js
+++ b/src/core/api/Payments.js
@@ -7,9 +7,9 @@ export default {
     const payment = await alenviAxios.post(`${process.env.API_HOSTNAME}/payments`, data);
     return payment.data.data.payment;
   },
-  async createList (data) {
+  async list (data) {
     const file = await alenviAxios({
-      url: `${process.env.API_HOSTNAME}/payments/createlist`,
+      url: `${process.env.API_HOSTNAME}/payments/list`,
       method: 'POST',
       responseType: 'blob',
       data,

--- a/src/modules/client/pages/ni/billing/ClientsBalances.vue
+++ b/src/modules/client/pages/ni/billing/ClientsBalances.vue
@@ -196,7 +196,7 @@ export default {
           date: new Date(),
           rum: getLastVersion(row.customer.payment.mandates, 'createdAt').rum,
         }));
-        await Payments.createList(payload);
+        await Payments.list(payload);
         NotifyPositive('Règlement(s) créé(s)');
         await this.refresh();
       } catch (e) {


### PR DESCRIPTION
Boyscoot: remplacer createlist par list dans la route `POST /payments/createlist`

- Tester la route en créant des prélèvements sur la page Balance client 


