### PR TITLE
COM-2432 fix displayed service name in subscription creation modal

### DIFF
--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -451,7 +451,7 @@ export default {
       const availableServices = this.services.filter(service => !subscribedServices.includes(service._id));
 
       return availableServices.map(service => ({
-        label: getLastVersion(service.versions).name,
+        label: getLastVersion(service.versions, 'createdAt').name,
         value: { _id: service._id, nature: service.nature },
       }));
     },

--- a/src/modules/client/components/table/ToBillRow.vue
+++ b/src/modules/client/components/table/ToBillRow.vue
@@ -28,7 +28,7 @@
       <template v-else-if="col.name === 'endDate'">{{ formatDate(bill.endDate) }}</template>
       <template v-else-if="col.name === 'service'">
         <template v-if="!bill.subscription">{{ bill.billingItem.name }}</template>
-        <template v-else>{{ getLastVersion(bill.subscription.service.versions).name }}</template>
+        <template v-else>{{ getLastVersion(bill.subscription.service.versions, 'createdAt').name }}</template>
       </template>
       <template v-else-if="col.name === 'hours'">
         <template v-if="!bill.subscription">{{ bill.eventsList.length }}</template>


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : coach

- Cas d'usage : sur la page profile d'un beneficiaire, sur la modale de creation d'une souscription, les noms des services sont bien les derniers noms donnés aux services. 
Sur la page a facturer, ca ne devrait rien changer mais verifier egalement que c'est bien le dernier nom du service qui s'affiche. 
