### PR TITLE
COM-2404: calculate netInclTaxes in backend

### DIFF
--- a/src/modules/client/pages/ni/billing/ManualBills.vue
+++ b/src/modules/client/pages/ni/billing/ManualBills.vue
@@ -175,7 +175,7 @@ export default {
     },
     formatCreationPayload () {
       return {
-        ...pick(this.newManualBill, ['customer', 'date', 'netInclTaxes']),
+        ...pick(this.newManualBill, ['customer', 'date']),
         billingItemList: this.newManualBill.billingItemList.map(bi => omit(bi, 'vat')),
       };
     },


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : client_admin

- Cas d'usage : 
lorsque je créé une facture manuelle pour un beneficiaire, je n'ai plus la ligne Tiers-payeur sur la facture avec un montant de -0,00

POUR TESTER : 
facture manuelle à un bénéficaire avec 2 articles de facturation : 
PU TTC: 1,43 Volume: 7
PU TTC: 2, Volume: 8
