### PR TITLE
COM-2370 - Prevent creation, edition and deletion of payment for archived customers

### DIFF
--- a/src/modules/client/components/customers/billing/ProfileBilling.vue
+++ b/src/modules/client/components/customers/billing/ProfileBilling.vue
@@ -403,11 +403,11 @@ export default {
         const payload = omit(this.editedPayment, ['_id', 'thirdPartyPayer']);
         await Payments.update(this.editedPayment._id, payload);
         this.paymentEditionModal = false;
-        NotifyPositive('Règlement créé');
+        NotifyPositive('Règlement modifié.');
         await this.refresh();
       } catch (e) {
         console.error(e);
-        NotifyNegative('Erreur lors de la création du règlement.');
+        NotifyNegative('Erreur lors de l\'édition du règlement.');
       } finally {
         this.paymentEditionLoading = false;
       }


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : 
Je ne peux pas créer, éditer et supprimer un paiement d'un bénéficiare archivé

Comment tester : 
- Ajouter un bénéficiaire + un tpp
- Lui facturer un évenement
- Lui ajouter un réglement et un paiement
- Ajouter à son tpp un réglement et un paiement
- L'archiver

Vérifier sur l'onglet facturation du profil et sur les balances clients
