### PR TITLE
COM-2401 - Fix end hour bug for time stamped events

### DIFF
--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -83,15 +83,13 @@ export default {
     update (date, key) {
       const hoursFields = ['hours', 'minutes', 'seconds', 'milliseconds'];
       const dateObject = pick(moment(this.value[key]).toObject(), hoursFields);
-      const dates = {
-        ...this.value,
-        [key]: moment(date).set({ ...dateObject }).toISOString(),
-      };
+      const dates = { ...this.value, [key]: moment(date).set({ ...dateObject }).toISOString() };
       if (key === 'startDate' && this.disableEndDate) {
         const endDateObject = pick(moment(this.value.endDate).toObject(), hoursFields);
         dates.endDate = moment(date).set({ ...endDateObject }).toISOString();
       }
       if (key === 'endDate') dates.endDate = moment(dates.endDate).endOf('d').toISOString();
+
       this.$emit('input', dates);
     },
     updateHours (value, key) {
@@ -104,6 +102,7 @@ export default {
           dates.endDate = moment.min(moment(dates.startDate).add(2, 'H'), max).toISOString();
         }
       }
+
       this.$emit('input', dates);
     },
   },


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : aux / coach / admin

- Cas d'usage : 
Pour reproduire le bug sur dev : 
- Ajouter un evenement et horodater l'heure de fin mais pas le début
- Essayer de modifier l'heure de début sur le planning -> l'heure de fin se modifie (on ajoute 2h à l'heure de début)
- Faire pareil sur ma PR -> l'heure de fin ne se modifie pas