### PR TITLE
COM-2428 - Fix border for file uploader

### DIFF
--- a/src/core/components/form/FileUploader.vue
+++ b/src/core/components/form/FileUploader.vue
@@ -132,6 +132,10 @@ export default {
   /deep/ .q-field__control
     height: 40px
     min-height: 40px
+    border: 0
+
+  /deep/ .q-uploader__header
+    border-radius: 4px
 
   /deep/ .q-field__append
     display: none


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement : ~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : aux / coach / admin

- Cas d'usage : 
La bordure des file uploader s'affiche mal à certains endroits.
Exemple : modale de création d'une absence avec justificatif (arrêt maladie par exemple), la bordure est trop épaisse.