### PR TITLE
COM-2492 - remove customer absences from weekly hours count

### DIFF
--- a/src/modules/client/components/planning/ChipCustomerIndicator.vue
+++ b/src/modules/client/components/planning/ChipCustomerIndicator.vue
@@ -17,7 +17,7 @@
 import get from 'lodash/get';
 import { formatIdentity } from '@helpers/utils';
 import { ascendingSort } from '@helpers/date';
-import { DEFAULT_AVATAR } from '@data/constants';
+import { DEFAULT_AVATAR, INTERVENTION } from '@data/constants';
 import moment from '@helpers/moment';
 
 export default {
@@ -34,7 +34,7 @@ export default {
       let weeklyHours = 0;
       this.events.forEach((event) => {
         if (event.auxiliary && !auxiliaries.includes(event.auxiliary._id)) auxiliaries.push(event.auxiliary._id);
-        weeklyHours += moment(event.endDate).diff(event.startDate, 'h', true);
+        if (event.type === INTERVENTION) weeklyHours += moment(event.endDate).diff(event.startDate, 'h', true);
       });
       return { auxiliariesNumber: auxiliaries.length, weeklyHours: Math.round(weeklyHours) };
     },


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : coach/admin/auxiliaire

- Cas d'usage : les interventions d'une répétition ne sont pas créés si le bénéficiaire a une absence. Les absences ne sont pas prises en compte dans le compte des heures de la semaine réalisées chez le beneficiaire.
