### PR TITLE
COM-2431

### DIFF
--- a/src/modules/client/helpers/tags.js
+++ b/src/modules/client/helpers/tags.js
@@ -32,6 +32,8 @@ export const getContractTags = (data) => {
     uploadDate: formatDate(Date.now()),
     initialContractStartDate: get(data, 'contract.startDate') ? formatDate(data.contract.startDate) : '',
     initialContractMonthlyHours: get(data, 'contract.versions[0]') ? getMonthlyHours(data.contract.versions[0]) : '',
+    companySIRET: get(data, 'user.establishment.siret') || '',
+    auxiliaryBirthCity: get(data, 'user.identity.birthCity') || '',
   };
 };
 

--- a/src/modules/client/pages/ni/config/TagConfig.vue
+++ b/src/modules/client/pages/ni/config/TagConfig.vue
@@ -44,6 +44,8 @@ export default {
         uploadDate: 'Date de mise en ligne du contrat',
         initialContractStartDate: 'Date d’effet du contrat initial',
         initialContractMonthlyHours: 'Volume d\'heures mensuel du contrat initial',
+        companySIRET: 'SIRET de l\'établissement',
+        auxiliaryBirthCity: 'Ville de naissance',
       },
       mandateTags: {
         customerTitle: 'Civilité',


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

-Périmetre interface : client

- Périmetre roles : Admin

- Cas d'usage : je peux utiliser le SIRET de l'établissement & ville de naissance dans les tags auxiliaire

- Pour tester la PR:
    - modifier le template d'un contrat ou d'un avenant en ajoutant les tags {companySIRET} et {auxiliaryBirthCity}
    - generer un contrat ou un avenant --> les infos correspondant aux tags sont bien présentes
