### PR TITLE
COM-2515 remove duplicate in select options

### DIFF
--- a/src/core/components/courses/AttendanceSheetAdditionModal.vue
+++ b/src/core/components/courses/AttendanceSheetAdditionModal.vue
@@ -51,7 +51,7 @@ export default {
       return formatAndSortIdentityOptions(this.course.trainees);
     },
     dateOptions () {
-      const dateOptionsSet = new Set([...this.course.slots.map(date => moment(date.startDate).startOf('d').toDate())]);
+      const dateOptionsSet = new Set(this.course.slots.map(date => moment(date.startDate).startOf('d').toISOString()));
 
       return [...dateOptionsSet].map(date => ({ value: new Date(date), label: formatDate(date) }));
     },


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur

- Périmetre roles : rof

- Cas d'usage :  Correction de bug. Dans la modale d'ajout d'une feuille d’émargement, il n'y a plus de doublon de date dans le select
