### PR TITLE
Com 2547

### DIFF
--- a/src/core/data/user.js
+++ b/src/core/data/user.js
@@ -32,5 +32,5 @@ export const userModel = {
       rib: { iban: '', bic: '' },
     },
   },
-  establishment: '',
+  establishment: { _id: '', siret: '' },
 };

--- a/src/modules/client/components/auxiliary/ProfileInfo.vue
+++ b/src/modules/client/components/auxiliary/ProfileInfo.vue
@@ -7,8 +7,8 @@
         @blur="updateUser('mentor')" />
       <ni-select v-model="userProfile.role.client._id" caption="Rôle" :options="auxiliaryRolesOptions"
         @focus="saveTmp('role.client._id')" @blur="updateUser('role.client._id')" />
-      <ni-select v-model="userProfile.establishment" caption="Établissement" :options="establishmentsOptions"
-        @focus="saveTmp('establishment')" @blur="updateUser('establishment')"
+      <ni-select v-model="userProfile.establishment._id" caption="Établissement" :options="establishmentsOptions"
+        @focus="saveTmp('establishment')" @blur="updateUser('establishment._id')"
         :error="$v.userProfile.establishment.$error" :error-message="REQUIRED_LABEL" option-disable="inactive" />
     </div>
     <div class="q-mb-xl">
@@ -380,7 +380,7 @@ export default {
             fullAddress: { required, frAddress },
           },
         },
-        establishment: { required },
+        establishment: { _id: { required } },
         administrative: {
           identityDocs: { required },
           emergencyContact: {
@@ -537,6 +537,7 @@ export default {
 
         const payload = set({}, path, value);
         if (path === 'role.client._id') payload.role = value;
+        if (path === 'establishment._id') payload.establishment = value;
         if (path.match(/birthCountry/i) && value !== 'FR') payload.identity.birthState = '99';
 
         await Users.updateById(this.userProfile._id, payload);


### PR DESCRIPTION
Fix d'un bug : quand je vais sur la page info d'une auxiliaire, le champ établissement ne s'affiche pas.

Le bug a été introduit sur la PR : https://github.com/sophiemoustard/compani-api/pull/1726/files.
Le champ establishment est populé mais en front on considérait toujours le champ comme un `objectId` et pas comme un objet ayant un champ `_id` et un nouveau champ (`siret`).
J'ai aussi vérifié que le champ n'était pas utilisé ailleurs que sur cette page.

- Périmetre interface : client > profileInfo

- Périmetre roles : auxiliaire / admin / coach
