### PR TITLE
COM-2566 - add month - 2 in select

### DIFF
--- a/src/modules/client/mixins/payMixin.js
+++ b/src/modules/client/mixins/payMixin.js
@@ -210,6 +210,7 @@ export const payMixin = {
       periodOptions: [
         { label: 'Mois en cours', value: 0 },
         { label: 'Mois précédent', value: 1 },
+        { label: 'Mois M - 2', value: 2 },
       ],
       dates: {
         startDate: moment().startOf('M').toISOString(),
@@ -320,7 +321,7 @@ export const payMixin = {
         ]);
       }
 
-      return downloadCsv(csvData, `Paie_${moment().format('MM_YYYY')}.csv`);
+      return downloadCsv(csvData, `Paie_${moment(this.dates.startDate).format('MM_YYYY')}.csv`);
     },
     async exportTxt (type) {
       try {


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Client

- Périmetre roles : admin

- Cas d'usage : sur la page paie mensuelle, je peux valider la paie du mois M-2 dans el selecteur
