### PR TITLE
Com 2552 fix

### DIFF
--- a/src/core/components/form/DateRange.vue
+++ b/src/core/components/form/DateRange.vue
@@ -70,7 +70,7 @@ export default {
   methods: {
     update (value, key) {
       this.$v.value.$touch();
-      if (key === 'endDate') value = moment(value).endOf('d').toISOString();
+      if (key === 'endDate') value = moment(value).endOf('d').milliseconds(0).toISOString();
 
       this.$emit('input', { ...this.value, [key]: value });
     },

--- a/src/core/components/form/DateRange.vue
+++ b/src/core/components/form/DateRange.vue
@@ -70,7 +70,7 @@ export default {
   methods: {
     update (value, key) {
       this.$v.value.$touch();
-      if (key === 'endDate') value = moment(value).endOf('d').milliseconds(0).toISOString();
+      if (key === 'endDate') value = moment(value).endOf('d').toISOString();
 
       this.$emit('input', { ...this.value, [key]: value });
     },

--- a/src/core/helpers/date.js
+++ b/src/core/helpers/date.js
@@ -31,7 +31,7 @@ export const isBetween = (date, min, max) => new Date(date) < new Date(max) && n
 
 export const getStartOfDay = date => new Date(date.getFullYear(), date.getMonth(), date.getDate());
 
-export const getEndOfDay = date => new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59);
+export const getEndOfDay = date => new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
 
 export const ascendingSort = (a, b) => {
   if (moment(a).isAfter(b)) return 1;


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface : client

- Périmetre roles : auxiliaire/ coach/ admin

- Cas d'usage : Je peux mettre a jour une absence bénéficiaire jusqu'à la date d'arrêt du beneficiaire.
 ( rappel: le bug était 'lorsque je mets a jour une absence jusqu'a la date d'arrêt du beneficiaire, une erreur arrive --> Impossible: la personne est arrêtée sur cette période`)

- Cette modification peut impacter: 
   - la creation d'une absence beneficiaire --> verifier qu'on ne peut pas creer d'absence apres la date d'arrêt d'un evenement 
   - l'archivage d'un beneficiaire --> verifier qu'on peut archiver un beneficiaire apres sa date d'arrêt
   - la creation d'evbenements --> verifier qu'on peut créer un évènement avant ou le jour de la date d'arrêt mais pas apres
   - la creation d'une répétition --> vérifier que lors d'une création d'une répétition elle s'arrête bien a la date d'arrêt du beneficiaire