### PR TITLE
COM-2463-fix edition

### DIFF
--- a/src/modules/client/components/config/ThirdPartyPayerCreationModal.vue
+++ b/src/modules/client/components/config/ThirdPartyPayerCreationModal.vue
@@ -8,7 +8,7 @@
       <ni-search-address :value="newThirdPartyPayer.address" error-message="Adresse invalide" in-modal
         @blur="validations.address.$touch" :error="validations.address.$error" @input="update($event, 'address')" />
       <ni-input in-modal caption="Email" :value="newThirdPartyPayer.email" error-message="Email non valide"
-        :error="!validations.email.email" @input="update($event.trim(), 'email')" />
+        :error="validations.email.$error" @input="update($event.trim(), 'email')" @blur="validations.email.$touch" />
       <ni-input in-modal caption="Prix unitaire TTC par défaut" suffix="€" type="number"
         :value="newThirdPartyPayer.unitTTCRate" :error="validations.unitTTCRate.$error"
         :error-message="nbrError('unitTTCRate', validations)" @input="update($event, 'unitTTCRate')" />

--- a/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
+++ b/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
@@ -8,7 +8,7 @@
       <ni-search-address in-modal :value="editedThirdPartyPayer.address" error-message="Adresse invalide"
         @blur="validations.address.$touch" :error="validations.address.$error" @input="update($event, 'address')" />
       <ni-input in-modal caption="Email" :value="editedThirdPartyPayer.email" error-message="Email invalide"
-        :error="!validations.email.email" @input="update($event.trim(), 'email')" />
+        :error="validations.email.$error" @input="update($event.trim(), 'email')" @blur="validations.email.$touch" />
       <ni-input in-modal caption="Prix unitaire TTC par défaut" suffix="€" type="number"
         :value="editedThirdPartyPayer.unitTTCRate" :error="validations.unitTTCRate.$error"
         :error-message="nbrError('unitTTCRate', validations)" @input="update($event, 'unitTTCRate')" />
@@ -20,7 +20,7 @@
       <div class="row q-mb-md light-checkbox">
         <q-checkbox :value="editedThirdPartyPayer.isApa" label="Financement APA" @input="update($event, 'isApa')"
           dense />
-      </div>
+    </div>
       <template slot="footer">
         <q-btn no-caps class="full-width modal-btn" label="Editer le tiers payeur" icon-right="check" color="primary"
           :loading="loading" @click="submit" />

--- a/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
+++ b/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
@@ -20,7 +20,7 @@
       <div class="row q-mb-md light-checkbox">
         <q-checkbox :value="editedThirdPartyPayer.isApa" label="Financement APA" @input="update($event, 'isApa')"
           dense />
-    </div>
+      </div>
       <template slot="footer">
         <q-btn no-caps class="full-width modal-btn" label="Editer le tiers payeur" icon-right="check" color="primary"
           :loading="loading" @click="submit" />

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -1128,10 +1128,10 @@ export default {
     openThirdPartyPayerEditionModal (tppId) {
       this.thirdPartyPayerEditionModal = true;
       const selectedTpp = this.thirdPartyPayers.find(tpp => tpp._id === tppId);
-      const { name, address, email: tppEmail, unitTTCRate, billingMode, isApa, teletransmissionId } = selectedTpp;
+      const { _id, name, address, email: tppEmail, unitTTCRate, billingMode, isApa, teletransmissionId } = selectedTpp;
 
       this.editedThirdPartyPayer = {
-        _id: selectedTpp._id,
+        _id,
         name: name || '',
         email: tppEmail || '',
         address: address || {},

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -350,8 +350,6 @@ export default {
       },
       surchargesColumns: [
         { name: 'name', label: 'Nom', align: 'left', field: 'name' },
-        { name: 'saturday', label: 'Samedi', align: 'center', field: row => roundFrenchPercentage(row.saturday, 0) },
-        { name: 'sunday', label: 'Dimanche', align: 'center', field: row => roundFrenchPercentage(row.sunday, 0) },
         {
           name: 'firstOfJanuary',
           label: '1er janvier',
@@ -376,6 +374,8 @@ export default {
           align: 'center',
           field: row => roundFrenchPercentage(row.publicHoliday, 0),
         },
+        { name: 'saturday', label: 'Samedi', align: 'center', field: row => roundFrenchPercentage(row.saturday, 0) },
+        { name: 'sunday', label: 'Dimanche', align: 'center', field: row => roundFrenchPercentage(row.sunday, 0) },
         { name: 'evening', label: 'Soirée', align: 'center', field: row => roundFrenchPercentage(row.evening, 0) },
         {
           name: 'eveningStartTime',

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -1127,13 +1127,18 @@ export default {
     // Third party payers
     openThirdPartyPayerEditionModal (tppId) {
       this.thirdPartyPayerEditionModal = true;
-      const currentThirdPartyPayer = this.thirdPartyPayers.find(tpp => tpp._id === tppId);
+      const selectedTpp = this.thirdPartyPayers.find(tpp => tpp._id === tppId);
+      const { name, address, email: tppEmail, unitTTCRate, billingMode, isApa, teletransmissionId } = selectedTpp;
+
       this.editedThirdPartyPayer = {
-        address: {},
-        ...pick(
-          currentThirdPartyPayer,
-          ['_id', 'name', 'address', 'email', 'unitTTCRate', 'billingMode', 'isApa', 'teletransmissionId']
-        ),
+        _id: selectedTpp._id,
+        name: name || '',
+        email: tppEmail || '',
+        address: address || {},
+        unitTTCRate: unitTTCRate || 0,
+        billingMode: billingMode || '',
+        isApa: isApa || false,
+        teletransmissionId: teletransmissionId || '',
       };
     },
     resetThirdPartyPayerCreation () {


### PR DESCRIPTION
- ~J'ai ajouté une variable d'environnement~ :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : Bug relevé par Manon : parfois si on modifie le champ teletransmissionId et qu'on blur, le champ change direct pour son ancienne valeur.

=> Le pb vient de l'utilisation de "set" sans initialiser les champs. Prenons un tpp avec aucun `teletransmissionId`.
   - Au moment, ou tu entre le premier caractere dans le champ `teletransmissionId`. 
      -  le `set(this.editedThirdPartyPayer, path, value);` fait son travail et crée le champ. On peut le verifier en affichant `editiedThirdPartyPayer` juste apres.
      - Mais vue ne met pas a jour tout de suite `editedThirdPartyPayer`. Il suffit de regarder avec le vueDevTool. C'est au blur que le champ est créé. => debut de l'incoherence.
   - Ensuite on a deux etats differents entre ce qui  est dans le champ de la modale et editedThirdPartyPayer du devTool.

  - Solution: initialiser les champs