### PR TITLE
COM-2583 - Fix reactivity warning

### DIFF
--- a/src/modules/client/pages/ni/auxiliaries/AuxiliaryProfile.vue
+++ b/src/modules/client/pages/ni/auxiliaries/AuxiliaryProfile.vue
@@ -8,16 +8,15 @@
 </template>
 
 <script>
-import { createMetaMixin } from 'quasar';
-import { mapState } from 'vuex';
+import { useMeta } from 'quasar';
+import { ref, computed, watch, onBeforeUnmount } from 'vue';
+import { useStore } from 'vuex';
 import get from 'lodash/get';
 import AuxiliaryProfileHeader from 'src/modules/client/components/auxiliary/AuxiliaryProfileHeader';
 import ProfileTabs from '@components/ProfileTabs';
 import ProfileInfo from 'src/modules/client/components/auxiliary/ProfileInfo';
 import ProfileContracts from 'src/modules/client/components/auxiliary/ProfileContracts';
 import ProfilePay from 'src/modules/client/components/auxiliary/ProfilePay';
-
-const metaInfo = { title: 'Fiche auxiliaire' };
 
 export default {
   name: 'AuxiliaryProfile',
@@ -29,47 +28,53 @@ export default {
     'auxiliary-profile-header': AuxiliaryProfileHeader,
     'profile-tabs': ProfileTabs,
   },
-  mixins: [createMetaMixin(metaInfo)],
-  data () {
-    return {
-      tabsContent: [
-        {
-          label: 'Infos personnelles',
-          name: 'info',
-          default: this.defaultTab === 'info',
-          component: ProfileInfo,
-          notification: 'profiles',
-        },
-        { label: 'Contrats', name: 'contracts', default: this.defaultTab === 'contracts', component: ProfileContracts },
-        { label: 'Paie', name: 'pays', default: this.defaultTab === 'pays', component: ProfilePay },
-      ],
-      auxiliaryName: '',
-    };
-  },
-  async created () {
-    await this.$store.dispatch('userProfile/fetchUserProfile', { userId: this.auxiliaryId });
-    this.refreshAuxiliaryName();
-  },
-  computed: {
-    ...mapState('userProfile', ['userProfile', 'notifications']),
-  },
-  watch: {
-    async userProfile () {
-      await this.$store.dispatch('userProfile/updateNotifications');
-    },
-    'userProfile.identity': function () {
-      this.refreshAuxiliaryName();
-    },
-  },
-  methods: {
-    refreshAuxiliaryName () {
-      this.auxiliaryName = get(this.userProfile, 'identity')
-        ? `${this.userProfile.identity.firstname} ${this.userProfile.identity.lastname}`
+  setup (props) {
+    const metaInfo = { title: 'Fiche auxiliaire' };
+    useMeta(metaInfo);
+
+    const tabsContent = [
+      {
+        label: 'Infos personnelles',
+        name: 'info',
+        default: props.defaultTab === 'info',
+        component: ProfileInfo,
+        notification: 'profiles',
+      },
+      { label: 'Contrats', name: 'contracts', default: props.defaultTab === 'contracts', component: ProfileContracts },
+      { label: 'Paie', name: 'pays', default: props.defaultTab === 'pays', component: ProfilePay },
+    ];
+    const auxiliaryName = ref('');
+
+    const $store = useStore();
+    const userProfile = computed(() => $store.state.userProfile.userProfile);
+    const notifications = computed(() => $store.state.userProfile.notifications);
+
+    watch(userProfile, async () => $store.dispatch('userProfile/updateNotifications'));
+    watch(userProfile, () => refreshAuxiliaryName());
+
+    const refreshAuxiliaryName = () => {
+      auxiliaryName.value = get(userProfile.value, 'identity')
+        ? `${userProfile.value.identity.firstname} ${userProfile.value.identity.lastname}`
         : '';
-    },
-  },
-  beforeUnmount () {
-    this.$store.dispatch('userProfile/resetUserProfile');
+    };
+
+    const created = async () => {
+      await $store.dispatch('userProfile/fetchUserProfile', { userId: props.auxiliaryId });
+      refreshAuxiliaryName();
+    };
+
+    onBeforeUnmount(() => { $store.dispatch('userProfile/resetUserProfile'); });
+
+    created();
+
+    return {
+      // Data
+      tabsContent,
+      auxiliaryName,
+      // Computed
+      userProfile,
+      notifications,
+    };
   },
 };
 </script>


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : Client

- Périmetre roles : Coach / Auxiliaire

- Cas d'usage : 
Quand j'arrive sur le fiche auxiliaire, je n'ai plus les messages d'alerte sur la reactivité des onglets. Je peux changer d'onglet sans souci

en creusant cette histoire de message d'alerte sur la reactivité des composant, je me suis dit qu'n fait, on pouvait créer un tabContent qui n'est pas reactif : passer en APi de composition et ne pas utiliser le ref. On a un objet JS classique et pas une donnée reactive
<img width="879" alt="image" src="https://user-images.githubusercontent.com/24521863/148384650-66742a1f-736c-45b2-b37f-a685041a2109.png">

