### PR TITLE
COM-2605 - half-daily absence edition

### DIFF
--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -266,8 +266,7 @@ export default {
       return this.isHourlyAbsence(this.editedEvent) || this.isHalfDailyAbsence(this.editedEvent);
     },
     isAbsenceStartHourDisabled () {
-      return !this.isIllnessOrWorkAccident(this.editedEvent) && !this.isHourlyAbsence(this.editedEvent) &&
-        !this.isHalfDailyAbsence(this.editedEvent);
+      return this.isDailyAbsence(this.editedEvent) && !this.isIllnessOrWorkAccident(this.editedEvent);
     },
   },
   methods: {

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -59,9 +59,9 @@
             :error="validations.absence.$error" required-field @blur="validations.absence.$touch"
             :disable="isHourlyAbsence(editedEvent) || historiesLoading" @update:model-value="updateAbsence($event)" />
           <ni-datetime-range caption="Dates et heures de l'évènement" :model-value="editedEvent.dates" required-field
-            :disable-end-date="isHourlyAbsence(editedEvent)" :disable-start-hour="!isIllnessOrWorkAccident(editedEvent)"
+            :disable-end-date="isAbsenceEndDateDisabled" :disable-start-hour="isAbsenceStartHourDisabled"
             @blur="validations.dates.$touch" :disable-end-hour="isDailyAbsence(editedEvent)" :disable="historiesLoading"
-              :error="validations.dates.$error" @update:model-value="updateEvent('dates', $event)" />
+            :error="validations.dates.$error" @update:model-value="updateEvent('dates', $event)" />
           <ni-file-uploader v-if="isIllnessOrWorkAccident(editedEvent)" caption="Justificatif d'absence" required-field
             path="attachment" :entity="editedEvent" name="file" :url="docsUploadUrl"
             @uploaded="documentUploaded" :additional-value="additionalValue" :error="validations.attachment.$error"
@@ -261,6 +261,13 @@ export default {
     },
     canUpdateAuxiliary () {
       return this.canUpdateIntervention && !this.isEventTimeStamped;
+    },
+    isAbsenceEndDateDisabled () {
+      return this.isHourlyAbsence(this.editedEvent) || this.isHalfDailyAbsence(this.editedEvent);
+    },
+    isAbsenceStartHourDisabled () {
+      return !this.isIllnessOrWorkAccident(this.editedEvent) && !this.isHourlyAbsence(this.editedEvent) &&
+        !this.isHalfDailyAbsence(this.editedEvent);
     },
   },
   methods: {

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -22,6 +22,7 @@ import {
   ABSENCE_NATURES,
   UNJUSTIFIED,
   DAILY,
+  HALF_DAILY,
   HOURLY,
   ILLNESS,
   WORK_ACCIDENT,
@@ -41,7 +42,6 @@ import { formatAndSortIdentityOptions } from '@helpers/utils';
 import moment from '@helpers/moment';
 import { isBefore } from '@helpers/date';
 import PlanningModalHeader from 'src/modules/client/components/planning/PlanningModalHeader';
-import { HALF_DAILY } from '../../../core/data/constants';
 
 export const planningModalMixin = {
   components: {


### PR DESCRIPTION
- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [ ] J'ai verifié la fonctionnalite sur mobile -np

- Périmetre interface :  client coach/admin/auxiliaire

- Périmetre roles : Je peux éditer des congés payées a la demi-journée

- Cas d'usage : 
   - editer une absence demi-journalière
   - exporter l'historique des absences et verifier que les absences demi-journalière sont bien prises en compte  
