### PR TITLE
Com 2613

### DIFF
--- a/src/core/api/Attendances.js
+++ b/src/core/api/Attendances.js
@@ -5,6 +5,13 @@ export default {
     const attendanceSheets = await alenviAxios.get(`${process.env.API_HOSTNAME}/attendances`, { params });
     return attendanceSheets.data.data.attendances;
   },
+  async listUnsubscribed (params) {
+    const unsubscribedAttendances = await alenviAxios.get(
+      `${process.env.API_HOSTNAME}/attendances/unsubscribed`,
+      { params }
+    );
+    return unsubscribedAttendances.data.data.unsubscribedAttendances;
+  },
   async create (payload) {
     await alenviAxios.post(`${process.env.API_HOSTNAME}/attendances`, payload);
   },

--- a/src/core/components/courses/CourseCell.vue
+++ b/src/core/components/courses/CourseCell.vue
@@ -48,7 +48,7 @@
 <script>
 import get from 'lodash/get';
 import { FORTHCOMING, COMPLETED, IN_PROGRESS, INTRA } from '@data/constants';
-import { formatQuantity } from '@helpers/utils';
+import { formatQuantity, formatDuration } from '@helpers/utils';
 import moment from '@helpers/moment';
 import { courseMixin } from '@mixins/courseMixin';
 
@@ -89,10 +89,7 @@ export default {
         );
       }
 
-      const paddedMinutes = this.padMinutes(slotsDuration.minutes());
-      const hours = slotsDuration.days() * 24 + slotsDuration.hours();
-
-      return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
+      return formatDuration(slotsDuration);
     },
     courseSlotsCount () {
       return this.course.slots.length;

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -91,18 +91,8 @@ export default {
           format: value => formatIdentity(value.identity, 'FL'),
           align: 'left',
         },
-        {
-          name: 'unexpectedAttendances',
-          label: 'Emargements imprévus',
-          field: 'attendancesCount',
-          align: 'center',
-        },
-        {
-          name: 'duration',
-          label: 'Durée',
-          field: 'totalDuration',
-          align: 'center',
-        },
+        { name: 'unexpectedAttendances', label: 'Emargements imprévus', field: 'attendancesCount', align: 'center' },
+        { name: 'duration', label: 'Durée', field: 'totalDuration', align: 'center' },
         { name: 'expand', label: '', field: '' },
       ],
       pagination: { sortBy: 'name', ascending: true, page: 1, rowsPerPage: 15 },
@@ -161,12 +151,12 @@ export default {
           course: this.course._id,
           ...(this.isClientInterface && { company: this.loggedUser.company._id }),
         };
-        const unsubscribedList = await Attendances.listUnsubscribed(query);
-        const formattedUnsubscribedAttendances = Object.keys(unsubscribedList)
-          .map(ul => ({
-            _id: unsubscribedList[ul][0].trainee._id,
-            trainee: unsubscribedList[ul][0].trainee,
-            attendances: unsubscribedList[ul].map(a => ({
+        const unsubscribedAttendancesGroupedByTrainees = await Attendances.listUnsubscribed(query);
+        const formattedUnsubscribedAttendances = Object.keys(unsubscribedAttendancesGroupedByTrainees)
+          .map(traineeId => ({
+            _id: unsubscribedAttendancesGroupedByTrainees[traineeId][0].trainee._id,
+            trainee: unsubscribedAttendancesGroupedByTrainees[traineeId][0].trainee,
+            attendances: unsubscribedAttendancesGroupedByTrainees[traineeId].map(a => ({
               _id: a._id,
               duration: this.getSlotDuration(a.courseSlot),
               step: get(a, 'courseSlot.step.name'),

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -31,7 +31,8 @@
         </template>
         <template #expanding-row="{ props }">
           <q-td colspan="100%">
-            <div v-for="attendance in props.row.attendances" :key="attendance._id" :props="props" class="q-my-sm row">
+            <div v-for="attendance in props.row.attendances" :key="attendance._id" :props="props"
+              class="q-ma-sm expanding-table-expanded-row">
               <div class="dates text-italic">{{ formatDate(attendance.slot.startDate) }}</div>
               <div class="dates text-italic">{{ formatSlotHour(attendance.slot) }} ({{ attendance.duration }})</div>
               <div class="trainer text-italic">{{ attendance.trainer }}</div>

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -14,7 +14,7 @@
     <elearning-follow-up-table v-if="courseHasElearningStep" :learners="learners" :loading="loading" class="q-mb-xl"
       is-blended />
     <div v-if="unsubscribedAttendances.length">
-      <div class="text-italic">
+      <div class="text-italic q-ma-xs">
         Certains stagiaires inscrits à cette formation ont émargé dans d’autres formations du même programme
       </div>
       <ni-expanding-table :data="unsubscribedAttendances" :columns="columns" :pagination="pagination"
@@ -24,9 +24,7 @@
             <template v-if="col.name === 'expand'">
               <q-icon :name="props.expand ? 'expand_less' : 'expand_more'" />
             </template>
-            <template v-else>
-              {{ col.value }}
-            </template>
+            <template v-else>{{ col.value }}</template>
           </q-td>
         </template>
         <template #expanding-row="{ props }">
@@ -96,7 +94,6 @@ export default {
         { name: 'expand', label: '', field: '' },
       ],
       pagination: { sortBy: 'name', ascending: true, page: 1, rowsPerPage: 15 },
-      formatDate,
     };
   },
   async created () {
@@ -176,6 +173,7 @@ export default {
         NotifyNegative('Erreur lors de la récupération des émargements annexes.');
       }
     },
+    formatDate,
   },
 };
 </script>

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -19,14 +19,6 @@
       </div>
       <ni-expanding-table :data="unsubscribedAttendances" :columns="columns" :pagination="pagination"
         :hide-bottom="false" :loading="loading">
-        <template #row="{ props }">
-          <q-td v-for="col in props.cols" :key="col.name" :props="props">
-            <template v-if="col.name === 'expand'">
-              <q-icon :name="props.expand ? 'expand_less' : 'expand_more'" />
-            </template>
-            <template v-else>{{ col.value }}</template>
-          </q-td>
-        </template>
         <template #expanding-row="{ props }">
           <q-td colspan="100%">
             <div v-for="attendance in props.row.attendances" :key="attendance._id" :props="props"

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -72,7 +72,7 @@ import SlotEditionModal from '@components/courses/SlotEditionModal';
 import SlotCreationModal from '@components/courses/SlotCreationModal';
 import { NotifyNegative, NotifyWarning, NotifyPositive } from '@components/popup/notify';
 import { E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
-import { formatQuantity } from '@helpers/utils';
+import { formatQuantity, formatDuration } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 import { frAddress, minDate, maxDate, urlAddress } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
@@ -142,10 +142,7 @@ export default {
         moment.duration()
       );
 
-      const paddedMinutes = this.padMinutes(total.minutes());
-      const hours = total.days() * 24 + total.hours();
-
-      return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
+      return formatDuration(total);
     },
     formatSlotTitle () {
       const slotsToPlanLength = this.courseSlotsToPlan.length;
@@ -223,9 +220,7 @@ export default {
     getSlotDuration (slot) {
       const duration = moment.duration(moment(slot.endDate).diff(slot.startDate));
 
-      const paddedMinutes = this.padMinutes(duration.minutes());
-
-      return paddedMinutes ? `${duration.hours()}h${paddedMinutes}` : `${duration.hours()}h`;
+      return formatDuration(duration);
     },
     formatSlotHour (slot) {
       return `${moment(slot.startDate).format('HH:mm')} - ${moment(slot.endDate).format('HH:mm')}`;

--- a/src/core/components/courses/TraineeTable.vue
+++ b/src/core/components/courses/TraineeTable.vue
@@ -106,7 +106,7 @@ export default {
 
         if (course.value.type === INTRA) query = { company: get(course.value, 'company._id') };
         if (course.value.type === INTER_B2B) {
-          query = isClientInterface.value ? { company: get(loggedUser, 'company._id') } : { hasCompany: true };
+          query = isClientInterface ? { company: get(loggedUser.value, 'company._id') } : { hasCompany: true };
         }
 
         potentialTrainees.value = Object.freeze(await Users.learnerList(query));

--- a/src/core/components/table/ExpandingTable.vue
+++ b/src/core/components/table/ExpandingTable.vue
@@ -10,7 +10,14 @@
       </template>
       <template #body="props">
         <q-tr :props="props" @click="props.expand = !props.expand" class="cursor-pointer">
-          <slot name="row" :props="props" />
+          <slot name="row" :props="props">
+            <q-td v-for="col in props.cols" :key="col.name" :props="props">
+              <template v-if="col.name === 'expand'">
+                <q-icon :name="props.expand ? 'expand_less' : 'expand_more'" />
+              </template>
+              <template v-else>{{ col.value }}</template>
+            </q-td>
+          </slot>
         </q-tr>
         <q-tr v-show="props.expand" :props="props">
           <slot name="expanding-row" :props="props" />

--- a/src/core/composables/learners.js
+++ b/src/core/composables/learners.js
@@ -167,7 +167,7 @@ export const useLearners = (company, isClientInterface, refresh) => {
   };
 
   const updateSearch = (value) => {
-    this.searchStr = value;
+    searchStr.value = value;
   };
 
   return {

--- a/src/core/helpers/utils.js
+++ b/src/core/helpers/utils.js
@@ -104,6 +104,15 @@ export const formatHours = (value, digits = 2) => {
 
 export const formatHoursWithMinutes = date => `${moment(date).hours()}h${moment(date).format('mm')}`;
 
+export const formatDuration = (duration) => {
+  const paddedMinutes = duration.minutes() > 0 && duration.minutes() < 10
+    ? duration.minutes().toString().padStart(2, 0)
+    : duration.minutes();
+  const hours = (duration.days() * 24) + duration.hours();
+
+  return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
+};
+
 export const formatPhone = phoneNumber => (phoneNumber
   ? phoneNumber.replace(/^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/, '$1 $2 $3 $4 $5')
   : '');

--- a/src/core/mixins/courseMixin.js
+++ b/src/core/mixins/courseMixin.js
@@ -56,9 +56,6 @@ export const courseMixin = {
     happened (sameDaySlots) {
       return moment().isSameOrAfter(sameDaySlots[sameDaySlots.length - 1].endDate);
     },
-    padMinutes (minutes) {
-      return minutes > 0 && minutes < 10 ? minutes.toString().padStart(2, 0) : minutes;
-    },
     saveTmp (path) {
       this.tmpInput = this.getValue(path);
     },

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -511,9 +511,9 @@ export default {
             fullAddress: { required, frAddress },
           },
           secondaryAddress: {
-            zipCode: { required: requiredIf(!!get(this.customer, 'contact.secondaryAddress.fullAddress')) },
-            street: { required: requiredIf(!!get(this.customer, 'contact.secondaryAddress.fullAddress')) },
-            city: { required: requiredIf(!!get(this.customer, 'contact.secondaryAddress.fullAddress')) },
+            zipCode: { required: requiredIf(item => item && !!item.fullAddress) },
+            street: { required: requiredIf(item => item && !!item.fullAddress) },
+            city: { required: requiredIf(item => item && !!item.fullAddress) },
             fullAddress: { frAddress },
           },
         },

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -511,9 +511,9 @@ export default {
             fullAddress: { required, frAddress },
           },
           secondaryAddress: {
-            zipCode: { required: requiredIf(item => item && !!item.fullAddress) },
-            street: { required: requiredIf(item => item && !!item.fullAddress) },
-            city: { required: requiredIf(item => item && !!item.fullAddress) },
+            zipCode: { required: requiredIf(!!get(this.customer, 'contact.secondaryAddress.fullAddress')) },
+            street: { required: requiredIf(!!get(this.customer, 'contact.secondaryAddress.fullAddress')) },
+            city: { required: requiredIf(!!get(this.customer, 'contact.secondaryAddress.fullAddress')) },
             fullAddress: { frAddress },
           },
         },

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -81,7 +81,7 @@ export default {
       newCourse: {
         program: { required },
         subProgram: { required },
-        company: { required: requiredIf(item => item.type === INTRA) },
+        company: { required: requiredIf(this.newCourse.type === INTRA) },
         type: { required },
         salesRepresentative: { required },
       },

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -81,7 +81,7 @@ export default {
       newCourse: {
         program: { required },
         subProgram: { required },
-        company: { required: requiredIf(this.newCourse.type === INTRA) },
+        company: { required: requiredIf(item => item.type === INTRA) },
         type: { required },
         salesRepresentative: { required },
       },


### PR DESCRIPTION
- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- [x] J'ai verifié la fonctionnalite sur mobile

- Périmetre interface : vendeur/client

- Périmetre roles : rof/coach/client-admin/vendor-admin

- Cas d'usage : dans le suivi d'une formation, j'affiche les émargements non prévus dans d'autres formations
TESTS : 
FORMATION INTER_B2B
- prendre 2 apprenant (un alenvi, un d'une autre structure) et les émarger dans une autre formation ayant le même sous-programme
- je vois ces émargements côté vendeur
- côté client je ne vois que les émargements de l'apprenant alenvi

FORMATION INTRA
- émarger un des apprenant dans une autre formation ayant le même sous-programme
- je vois ces émargements côté vendeur et côté client

en tant que formateur de la formation je vois ces émargements non prévus


Boyscout : 
mutualisation de la méthode de calcul de durée
fix bug validation sur la création de formation inter
fix bug barre de recherche répertoire apprenant
fix bug error 403 sur la récupération des apprenants