### PR TITLE
COM-2612 move completion certificates

### DIFF
--- a/src/core/components/courses/ProfileAdmin.vue
+++ b/src/core/components/courses/ProfileAdmin.vue
@@ -17,17 +17,9 @@
           pour assurer le suivi de la formation : {{ followUpMissingInfo.join(', ') }}.
         </template>
       </ni-banner>
-      <ni-banner v-if="!get(this.course, 'subProgram.program.learningGoals')">
-        <template #message>
-          Merci de renseigner les objectifs pédagogiques du programme pour pouvoir télécharger
-          les attestations de fin de formation.
-        </template>
-      </ni-banner>
       <ni-course-info-link :disable-link="disableDocDownload" @download="downloadConvocation" />
       <ni-bi-color-button icon="file_download" label="Feuilles d'émargement"
         :disable="disableDocDownload" @click="downloadAttendanceSheet" size="16px" />
-      <ni-bi-color-button icon="file_download" label="Attestations de fin de formation"
-        :disable="disableDownloadCompletionCertificates" @click="downloadCompletionCertificates" size="16px" />
     </div>
     <div class="q-mb-xl">
       <p class="text-weight-bold">Envoi de SMS</p>
@@ -100,7 +92,7 @@ import {
   formatAndSortIdentityOptions,
 } from '@helpers/utils';
 import { formatDate, descendingSort, ascendingSort } from '@helpers/date';
-import { downloadFile, downloadZip } from '@helpers/file';
+import { downloadFile } from '@helpers/file';
 import moment from '@helpers/moment';
 import { courseMixin } from '@mixins/courseMixin';
 
@@ -173,9 +165,6 @@ export default {
   },
   computed: {
     ...mapState('course', ['course']),
-    disableDownloadCompletionCertificates () {
-      return this.disableDocDownload || !get(this.course, 'subProgram.program.learningGoals');
-    },
     isFinished () {
       const slots = this.course.slots.filter(slot => moment().isBefore(slot.startDate));
       return !slots.length && !this.course.slotsToPlan.length;
@@ -349,20 +338,6 @@ export default {
           return NotifyNegative(message);
         }
         NotifyNegative('Erreur lors du téléchargement de la feuille d\'émargement.');
-      } finally {
-        this.pdfLoading = false;
-      }
-    },
-    async downloadCompletionCertificates () {
-      if (this.disableDownloadCompletionCertificates) return;
-
-      try {
-        this.pdfLoading = true;
-        const pdf = await Courses.downloadCompletionCertificates(this.course._id);
-        downloadZip(pdf, 'attestations.zip');
-      } catch (e) {
-        console.error(e);
-        NotifyNegative('Erreur lors du téléchargement des attestations.');
       } finally {
         this.pdfLoading = false;
       }


### PR DESCRIPTION
- Sur drive, j'ai créé un modele de certificat de fin de formation pour dev specifiquement

- Sur heroku, j'ai modifié le lien vers le certificat pour pointer vers mon modele nouvellement créé
  - [x] J'ai précisé sur le slite de MES et MEP qu'il faut modifier le certificat de fin de formation

- [ ] ~J'ai verifié la fonctionnalite sur mobile~

- Périmetre interface : client / vendeur

- Périmetre roles :   rof / coach

- Cas d'usage : 
   - Je peux telecharger les attestations de fin de formation non plus dans l'onglet "Admin" mais dans "Suivi des stagiaires"
      - Si les infos necessaires ne sont pas remplies (un stagiaire, un créneau, un.e formateur.ice avec tel) le bouton est grisé.
      - Si les objectifs peda du programme ne sont pas remplis, le bouton est grisé et une banniere m'informe
   - Lorsque je genere une attestation, la durée de presence du/de la stagiaire est inscrite automatiquement

- Comment tester: 
   - dans les .env coté API, modifier GOOGLE_DRIVE_TRAINING_CERTIFICATE_TEMPLATE_ID pour pointer vers ce fichier test  https://docs.google.com/document/d/1I5BbWGzyvXoV-G35lU2whVfiLX5lL1AL/edit
   - formation sans formateur.ice => bouton indisponible
   - formation sans objectif peda => bouton indisponible + banniere
   - formation valide avec plusieurs stagiaire et des participations differentes => attestations dispos + verifier les durées totales de presence des different.es stagiaires.