### PR TITLE
COM-2615: display presence progress

### DIFF
--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -127,12 +127,7 @@ export default {
           format: value => ((value === BLENDED) ? 'Mixte' : 'ELearning'),
           sort: sortStrings,
         },
-        {
-          name: 'attendances',
-          label: 'Emargements',
-          field: row => get(row, 'progress.presence'),
-          align: 'center',
-        },
+        { name: 'attendances', label: 'Emargements', field: row => get(row, 'progress.presence'), align: 'center' },
         {
           name: 'eLearning',
           label: 'eLearning',
@@ -227,7 +222,7 @@ export default {
       }
     },
     formatDuration (duration) {
-      const durationInHours = duration / 60;
+      const durationInHours = duration.minutes / 60;
       const hours = Math.trunc(durationInHours);
       const paddedMinutes = (durationInHours - hours) * 60;
 

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -32,7 +32,13 @@
         <ni-expanding-table :data="courses" :columns="columns" :loading="loading" v-model:pagination="pagination">
           <template #row="{ props }">
             <q-td v-for="col in props.cols" :key="col.name" :props="props">
-              <template v-if="col.name === 'progress'">
+              <template v-if="col.name === 'attendances' && has(col, 'value.attendanceDuration')">
+                <div>
+                  {{ formatDuration(get(col, 'value.attendanceDuration')) }}
+                  / {{ formatDuration(get(col, 'value.maxDuration')) }}
+                  </div>
+              </template>
+              <template v-else-if="col.name === 'eLearning' && col.value >= 0">
                 <ni-progress class="q-ml-lg" :value="col.value" />
               </template>
               <template v-else-if="col.name === 'expand'">
@@ -47,13 +53,18 @@
           <template #expanding-row="{ props }">
             <q-td colspan="100%">
               <div v-for="(step, stepIndex) in props.row.subProgram.steps" :key="step._id" :props="props"
-                class="q-ma-sm expanding-table-expanded-row">
+                class="q-ma-sm row">
                 <div>
                   <q-icon :name="getStepTypeIcon(step.type)" />
                   {{ stepIndex + 1 }} - {{ step.name }}
                 </div>
-                <div class="expanding-table-progress-container">
-                  <ni-progress class="expanding-table-sub-progress" :value="getStepProgress(step)" />
+                <div class="step-progress">
+                  <div v-if="has(step, 'progress.presence')">
+                    {{ formatDuration(get(step, 'progress.presence.attendanceDuration')) }}
+                    / {{ formatDuration(get(step, 'progress.presence.maxDuration')) }}
+                  </div>
+                  <ni-progress v-if="has(step, 'progress.eLearning')" class="expanding-table-sub-progress"
+                    :value="step.progress.eLearning" />
                 </div>
               </div>
             </q-td>
@@ -117,11 +128,15 @@ export default {
           sort: sortStrings,
         },
         {
-          name: 'progress',
-          label: 'Progression',
-          field: row => (get(row, 'format') === BLENDED
-            ? get(row, 'progress.blended')
-            : get(row, 'progress.eLearning')),
+          name: 'attendances',
+          label: 'Emargements',
+          field: row => get(row, 'progress.presence'),
+          align: 'center',
+        },
+        {
+          name: 'eLearning',
+          label: 'eLearning',
+          field: row => get(row, 'progress.eLearning'),
           align: 'center',
           sortable: true,
           style: 'min-width: 150px; width: 20%',
@@ -211,10 +226,15 @@ export default {
         NotifyNegative('Erreur lors de la récupération des données.');
       }
     },
-    getStepProgress (step) {
-      if (has(step, 'progress.live')) return step.progress.live;
-      return step.progress.eLearning;
+    formatDuration (duration) {
+      const durationInHours = duration / 60;
+      const hours = Math.trunc(durationInHours);
+      const paddedMinutes = (durationInHours - hours) * 60;
+
+      return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
     },
+    get,
+    has,
   },
 };
 </script>
@@ -242,4 +262,12 @@ export default {
 
 .learners-data
   flex: 1
+.step-progress
+  align-items: center
+  justify-content: space-between
+  width: 20%
+  margin: 0px 24px
+  flex-direction: row
+  display: flex
+  color: $primary
 </style>


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client admin_vendeur/admin_client/coach/rof

- Cas d'usage : je peux visualiser les présences dans les formations suivies sur le profil d'un apprenant

- Comment tester ? : se mettre sur le profil d'un apprenant et en comparant avec ce qu'on a sur l'appli mobile et les émargements sur les formations s'assurer pour chaque formation: 
- que la progression elearning totale est la bonne
- que la présence totale est la bonne
- que la progression elearning de chaque étape est la bonne
- que la présence pour chaque étape est la bonne
- ⚠️ : 
  - si absence à tous les créneaux => 0h /xh
  - si elearning pas fait 0%
  - si pas de créneaux (progression totale) => vide
  - si pas de elearning (progression totale) => vide
  - si pas de créneaux dans l'étape => 0h/0h

_Si tu as lu cette description, pense a réagir avec un :eye:_
