### PR TITLE
Com 2643

### DIFF
--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -138,12 +138,13 @@ export default {
         { name: 'ni management questionnaire answers', params: { courseId: this.course._id, questionnaireId } }
       );
     },
-    formatTraineeAttendances (traineeAttendances) {
+    formatTraineeAttendances (attendancesGroupedByTrainee, traineeId) {
       return {
-        trainee: formatIdentity(traineeAttendances[0].trainee.identity, 'FL'),
-        attendancesCount: traineeAttendances.length,
-        duration: getTotalDuration(traineeAttendances.map(a => a.courseSlot)),
-        attendances: traineeAttendances
+        _id: traineeId,
+        trainee: formatIdentity(attendancesGroupedByTrainee[traineeId][0].trainee.identity, 'FL'),
+        attendancesCount: attendancesGroupedByTrainee[traineeId].length,
+        duration: getTotalDuration(attendancesGroupedByTrainee[traineeId].map(a => a.courseSlot)),
+        attendances: attendancesGroupedByTrainee[traineeId]
           .sort((a, b) => ascendingSort(a.courseSlot.startDate, b.courseSlot.startDate))
           .map(a => ({
             _id: a._id,
@@ -162,10 +163,7 @@ export default {
         };
         const unsubscribedAttendancesGroupedByTrainees = await Attendances.listUnsubscribed(query);
         this.unsubscribedAttendances = Object.keys(unsubscribedAttendancesGroupedByTrainees)
-          .map(traineeId => ({
-            _id: traineeId,
-            ...this.formatTraineeAttendances(unsubscribedAttendancesGroupedByTrainees[traineeId]),
-          }));
+          .map(traineeId => this.formatTraineeAttendances(unsubscribedAttendancesGroupedByTrainees, traineeId));
       } catch (e) {
         console.error(e);
         this.unsubscribedAttendances = [];

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -34,8 +34,8 @@
           <q-td colspan="100%">
             <div v-for="attendance in props.row.attendances" :key="attendance._id" :props="props"
               class="q-ma-sm expanding-table-expanded-row">
-              <div class="dates">{{ formatDate(attendance.slot.startDate) }}</div>
-              <div class="hours">{{ formatSlotHour(attendance.slot) }} ({{ attendance.duration }})</div>
+              <div class="dates">{{ attendance.date }}</div>
+              <div class="hours">{{ attendance.hours }}</div>
               <div class="misc">{{ attendance.misc }}</div>
               <div class="trainer">{{ attendance.trainer }}</div>
             </div>
@@ -59,9 +59,14 @@ import QuestionnaireAnswersCell from '@components/courses/QuestionnaireAnswersCe
 import BiColorButton from '@components/BiColorButton';
 import Banner from '@components/Banner';
 import { SURVEY, OPEN_QUESTION, QUESTION_ANSWER, E_LEARNING } from '@data/constants';
-import { upperCaseFirstLetter, formatIdentity, getTotalDuration, getSlotDuration } from '@helpers/utils';
-import { formatDate } from '@helpers/date';
-import moment from '@helpers/moment';
+import {
+  upperCaseFirstLetter,
+  formatIdentity,
+  getTotalDuration,
+  getSlotDuration,
+  formatSlotHour,
+} from '@helpers/utils';
+import { formatDate, ascendingSort } from '@helpers/date';
 import { downloadZip } from '@helpers/file';
 import { traineeFollowUpTableMixin } from '@mixins/traineeFollowUpTableMixin';
 import { courseMixin } from '@mixins/courseMixin';
@@ -90,15 +95,9 @@ export default {
       questionnaires: [],
       unsubscribedAttendances: [],
       columns: [
-        {
-          name: 'name',
-          label: 'Nom',
-          field: 'trainee',
-          format: value => formatIdentity(value.identity, 'FL'),
-          align: 'left',
-        },
+        { name: 'name', label: 'Nom', field: 'trainee', align: 'left' },
         { name: 'unexpectedAttendances', label: 'Emargements imprévus', field: 'attendancesCount', align: 'center' },
-        { name: 'duration', label: 'Durée', field: 'totalDuration', align: 'center' },
+        { name: 'duration', label: 'Durée', field: 'duration', align: 'center' },
         { name: 'expand', label: '', field: '' },
       ],
       pagination: { sortBy: 'name', ascending: true, page: 1, rowsPerPage: 15 },
@@ -124,6 +123,7 @@ export default {
   },
   methods: {
     get,
+    formatSlotHour,
     async refreshQuestionnaires () {
       try {
         this.questionnaires = await Courses.getCourseQuestionnaires(this.course._id);
@@ -138,9 +138,6 @@ export default {
         { name: 'ni management questionnaire answers', params: { courseId: this.course._id, questionnaireId } }
       );
     },
-    formatSlotHour (slot) {
-      return `${moment(slot.startDate).format('HH:mm')} - ${moment(slot.endDate).format('HH:mm')}`;
-    },
     async getUnsubscribedAttendances () {
       try {
         const query = {
@@ -148,23 +145,22 @@ export default {
           ...(this.isClientInterface && { company: this.loggedUser.company._id }),
         };
         const unsubscribedAttendancesGroupedByTrainees = await Attendances.listUnsubscribed(query);
-        const formattedUnsubscribedAttendances = Object.keys(unsubscribedAttendancesGroupedByTrainees)
+        this.unsubscribedAttendances = Object.keys(unsubscribedAttendancesGroupedByTrainees)
           .map(traineeId => ({
-            _id: unsubscribedAttendancesGroupedByTrainees[traineeId][0].trainee._id,
-            trainee: unsubscribedAttendancesGroupedByTrainees[traineeId][0].trainee,
-            attendances: unsubscribedAttendancesGroupedByTrainees[traineeId].map(a => ({
-              _id: a._id,
-              duration: getSlotDuration(a.courseSlot),
-              slot: { startDate: a.courseSlot.startDate, endDate: a.courseSlot.endDate },
-              trainer: formatIdentity(get(a, 'trainer.identity'), 'FL'),
-              misc: a.misc,
-            })),
+            _id: traineeId,
+            trainee: formatIdentity(unsubscribedAttendancesGroupedByTrainees[traineeId][0].trainee.identity, 'FL'),
+            attendancesCount: unsubscribedAttendancesGroupedByTrainees[traineeId].length,
+            duration: getTotalDuration(unsubscribedAttendancesGroupedByTrainees[traineeId].map(a => a.courseSlot)),
+            attendances: unsubscribedAttendancesGroupedByTrainees[traineeId]
+              .sort((a, b) => ascendingSort(a.courseSlot.startDate, b.courseSlot.startDate))
+              .map(a => ({
+                _id: a._id,
+                date: formatDate(a.courseSlot.startDate),
+                hours: `${formatSlotHour(a.courseSlot)} (${getSlotDuration(a.courseSlot)})`,
+                trainer: formatIdentity(get(a, 'trainer.identity'), 'FL'),
+                misc: a.misc,
+              })),
           }));
-        this.unsubscribedAttendances = formattedUnsubscribedAttendances.map(attendance => ({
-          ...attendance,
-          attendancesCount: attendance.attendances.length,
-          totalDuration: getTotalDuration(attendance.attendances.map(a => a.slot)),
-        }));
       } catch (e) {
         console.error(e);
         this.unsubscribedAttendances = [];

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -63,8 +63,8 @@ import {
   upperCaseFirstLetter,
   formatIdentity,
   getTotalDuration,
-  getSlotDuration,
-  formatSlotHour,
+  getDuration,
+  formatIntervalHourly,
 } from '@helpers/utils';
 import { formatDate, ascendingSort } from '@helpers/date';
 import { downloadZip } from '@helpers/file';
@@ -123,7 +123,7 @@ export default {
   },
   methods: {
     get,
-    formatSlotHour,
+    formatIntervalHourly,
     async refreshQuestionnaires () {
       try {
         this.questionnaires = await Courses.getCourseQuestionnaires(this.course._id);
@@ -156,7 +156,7 @@ export default {
               .map(a => ({
                 _id: a._id,
                 date: formatDate(a.courseSlot.startDate),
-                hours: `${formatSlotHour(a.courseSlot)} (${getSlotDuration(a.courseSlot)})`,
+                hours: `${formatIntervalHourly(a.courseSlot)} (${getDuration(a.courseSlot)})`,
                 trainer: formatIdentity(get(a, 'trainer.identity'), 'FL'),
                 misc: a.misc,
               })),

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -59,7 +59,7 @@ import QuestionnaireAnswersCell from '@components/courses/QuestionnaireAnswersCe
 import BiColorButton from '@components/BiColorButton';
 import Banner from '@components/Banner';
 import { SURVEY, OPEN_QUESTION, QUESTION_ANSWER, E_LEARNING } from '@data/constants';
-import { upperCaseFirstLetter, formatDuration, formatIdentity } from '@helpers/utils';
+import { upperCaseFirstLetter, formatIdentity, getTotalDuration, getSlotDuration } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 import moment from '@helpers/moment';
 import { downloadZip } from '@helpers/file';
@@ -138,19 +138,6 @@ export default {
         { name: 'ni management questionnaire answers', params: { courseId: this.course._id, questionnaireId } }
       );
     },
-    getTotalDuration (slots) {
-      const total = slots.reduce(
-        (acc, slot) => acc.add(moment.duration(moment(slot.endDate).diff(slot.startDate))),
-        moment.duration()
-      );
-
-      return formatDuration(total);
-    },
-    getSlotDuration (slot) {
-      const duration = moment.duration(moment(slot.endDate).diff(slot.startDate));
-
-      return formatDuration(duration);
-    },
     formatSlotHour (slot) {
       return `${moment(slot.startDate).format('HH:mm')} - ${moment(slot.endDate).format('HH:mm')}`;
     },
@@ -167,7 +154,7 @@ export default {
             trainee: unsubscribedAttendancesGroupedByTrainees[traineeId][0].trainee,
             attendances: unsubscribedAttendancesGroupedByTrainees[traineeId].map(a => ({
               _id: a._id,
-              duration: this.getSlotDuration(a.courseSlot),
+              duration: getSlotDuration(a.courseSlot),
               slot: { startDate: a.courseSlot.startDate, endDate: a.courseSlot.endDate },
               trainer: formatIdentity(get(a, 'trainer.identity'), 'FL'),
               misc: a.misc,
@@ -176,7 +163,7 @@ export default {
         this.unsubscribedAttendances = formattedUnsubscribedAttendances.map(attendance => ({
           ...attendance,
           attendancesCount: attendance.attendances.length,
-          totalDuration: this.getTotalDuration(attendance.attendances.map(a => a.slot)),
+          totalDuration: getTotalDuration(attendance.attendances.map(a => a.slot)),
         }));
       } catch (e) {
         console.error(e);

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -138,6 +138,22 @@ export default {
         { name: 'ni management questionnaire answers', params: { courseId: this.course._id, questionnaireId } }
       );
     },
+    formatTraineeAttendances (traineeAttendances) {
+      return {
+        trainee: formatIdentity(traineeAttendances[0].trainee.identity, 'FL'),
+        attendancesCount: traineeAttendances.length,
+        duration: getTotalDuration(traineeAttendances.map(a => a.courseSlot)),
+        attendances: traineeAttendances
+          .sort((a, b) => ascendingSort(a.courseSlot.startDate, b.courseSlot.startDate))
+          .map(a => ({
+            _id: a._id,
+            date: formatDate(a.courseSlot.startDate),
+            hours: `${formatIntervalHourly(a.courseSlot)} (${getDuration(a.courseSlot)})`,
+            trainer: formatIdentity(get(a, 'trainer.identity'), 'FL'),
+            misc: a.misc,
+          })),
+      };
+    },
     async getUnsubscribedAttendances () {
       try {
         const query = {
@@ -148,18 +164,7 @@ export default {
         this.unsubscribedAttendances = Object.keys(unsubscribedAttendancesGroupedByTrainees)
           .map(traineeId => ({
             _id: traineeId,
-            trainee: formatIdentity(unsubscribedAttendancesGroupedByTrainees[traineeId][0].trainee.identity, 'FL'),
-            attendancesCount: unsubscribedAttendancesGroupedByTrainees[traineeId].length,
-            duration: getTotalDuration(unsubscribedAttendancesGroupedByTrainees[traineeId].map(a => a.courseSlot)),
-            attendances: unsubscribedAttendancesGroupedByTrainees[traineeId]
-              .sort((a, b) => ascendingSort(a.courseSlot.startDate, b.courseSlot.startDate))
-              .map(a => ({
-                _id: a._id,
-                date: formatDate(a.courseSlot.startDate),
-                hours: `${formatIntervalHourly(a.courseSlot)} (${getDuration(a.courseSlot)})`,
-                trainer: formatIdentity(get(a, 'trainer.identity'), 'FL'),
-                misc: a.misc,
-              })),
+            ...this.formatTraineeAttendances(unsubscribedAttendancesGroupedByTrainees[traineeId]),
           }));
       } catch (e) {
         console.error(e);

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -72,7 +72,7 @@ import SlotEditionModal from '@components/courses/SlotEditionModal';
 import SlotCreationModal from '@components/courses/SlotCreationModal';
 import { NotifyNegative, NotifyWarning, NotifyPositive } from '@components/popup/notify';
 import { E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
-import { formatQuantity, formatDuration } from '@helpers/utils';
+import { formatQuantity, formatDuration, formatSlotHour } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 import { frAddress, minDate, maxDate, urlAddress } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
@@ -191,6 +191,7 @@ export default {
     else this.groupByCourses();
   },
   methods: {
+    formatSlotHour,
     courseSlotValidation (slot) {
       return {
         step: { required },
@@ -221,9 +222,6 @@ export default {
       const duration = moment.duration(moment(slot.endDate).diff(slot.startDate));
 
       return formatDuration(duration);
-    },
-    formatSlotHour (slot) {
-      return `${moment(slot.startDate).format('HH:mm')} - ${moment(slot.endDate).format('HH:mm')}`;
     },
     getSlotAddress (slot) {
       return get(slot, 'address.fullAddress') || 'Adresse non renseignée';

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -19,7 +19,7 @@
           <div :class="['slots-cells-content', { 'cursor-pointer': canEdit && !course.archivedAt }]"
             v-for="slot in value" :key="slot._id" @click="openEditionModal(slot)">
               <q-item class="text-weight-bold">{{ getStepTitle(slot) }}</q-item>
-              <q-item>{{ formatSlotHour(slot) }} ({{ getSlotDuration(slot) }})</q-item>
+              <q-item>{{ formatIntervalHourly(slot) }} ({{ getDuration(slot) }})</q-item>
               <q-item v-if="slot.step.type === ON_SITE">{{ getSlotAddress(slot) }}</q-item>
               <q-item v-else>
                 <a class="ellipsis" :href="slot.meetingLink" target="_blank" @click="$event.stopPropagation()">
@@ -72,7 +72,7 @@ import SlotEditionModal from '@components/courses/SlotEditionModal';
 import SlotCreationModal from '@components/courses/SlotCreationModal';
 import { NotifyNegative, NotifyWarning, NotifyPositive } from '@components/popup/notify';
 import { E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
-import { formatQuantity, formatDuration, formatSlotHour } from '@helpers/utils';
+import { formatQuantity, formatDuration, formatIntervalHourly, getDuration } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 import { frAddress, minDate, maxDate, urlAddress } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
@@ -191,7 +191,8 @@ export default {
     else this.groupByCourses();
   },
   methods: {
-    formatSlotHour,
+    getDuration,
+    formatIntervalHourly,
     courseSlotValidation (slot) {
       return {
         step: { required },
@@ -217,11 +218,6 @@ export default {
     groupByCourses () {
       this.courseSlots = groupBy(this.course.slots.filter(slot => !!slot.startDate), s => formatDate(s.startDate));
       this.courseSlotsToPlan = this.course.slotsToPlan || [];
-    },
-    getSlotDuration (slot) {
-      const duration = moment.duration(moment(slot.endDate).diff(slot.startDate));
-
-      return formatDuration(duration);
     },
     getSlotAddress (slot) {
       return get(slot, 'address.fullAddress') || 'Adresse non renseignée';

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -73,7 +73,7 @@
       </q-card>
     </div>
     <div v-if="unsubscribedAttendances.length" class="q-mb-xl">
-      <p class="text-weight-bold">Formations suivies</p>
+      <p class="text-weight-bold q-mb-sm">Emargements non prévus</p>
       <div class="text-italic q-ma-xs">
         {{ formatIdentity(userProfile.identity, 'FL') }} a émargé dans certaines formations sans inscription.
       </div>

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -85,9 +85,8 @@
               class="q-ma-sm expanding-table-expanded-row">
               <div class="dates">{{ attendance.date }}</div>
               <div class="hours">{{ attendance.hours }}</div>
-              <div class="trainer">{{ attendance.trainer }}</div>
-              <div class="step">{{ attendance.step }}</div>
               <div class="misc">{{ attendance.misc }}</div>
+              <div class="trainer">{{ attendance.trainer }}</div>
             </div>
           </q-td>
         </template>
@@ -284,7 +283,6 @@ export default {
                 hours: `${formatSlotHour(a.courseSlot)} (${getSlotDuration(a.courseSlot)})`,
                 trainer: formatIdentity(get(a, 'course.trainer.identity'), 'FL'),
                 misc: a.course.misc,
-                step: a.step.name,
               })),
           }));
       } catch (e) {
@@ -336,10 +334,7 @@ export default {
   width: 15%
 
 .trainer
-  width: 20%
-
-.step
-  width: 30%
+  width: 50%
 
 .misc
   width: 15%

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -103,7 +103,7 @@ import uniqBy from 'lodash/uniqBy';
 import Courses from '@api/Courses';
 import Attendances from '@api/Attendances';
 import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING } from '@data/constants';
-import { sortStrings, formatIdentity, getTotalDuration, getSlotDuration, formatSlotHour } from '@helpers/utils';
+import { sortStrings, formatIdentity, getTotalDuration, getDuration, formatIntervalHourly } from '@helpers/utils';
 import { isBetween, formatDate, ascendingSort } from '@helpers/date';
 import LineChart from '@components/charts/LineChart';
 import Progress from '@components/CourseProgress';
@@ -280,7 +280,7 @@ export default {
               .map(a => ({
                 _id: a._id,
                 date: formatDate(a.courseSlot.startDate),
-                hours: `${formatSlotHour(a.courseSlot)} (${getSlotDuration(a.courseSlot)})`,
+                hours: `${formatIntervalHourly(a.courseSlot)} (${getDuration(a.courseSlot)})`,
                 trainer: formatIdentity(get(a, 'course.trainer.identity'), 'FL'),
                 misc: a.course.misc,
               })),

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -74,7 +74,7 @@
     </div>
     <div v-if="unsubscribedAttendances.length" class="q-mb-xl">
       <p class="text-weight-bold q-mb-sm">Emargements non prévus</p>
-      <div class="text-italic q-ma-xs">
+      <div class="text-italic q-my-xs">
         {{ formatIdentity(userProfile.identity, 'FL') }} a émargé dans certaines formations sans inscription.
       </div>
       <ni-expanding-table :data="unsubscribedAttendances" :columns="attendanceColumns" :pagination="pagination"
@@ -265,12 +265,13 @@ export default {
 
       return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
     },
-    formatProgramAttendances (programAttendances) {
+    formatProgramAttendances (attendancesGroupedByProgram, programId) {
       return {
-        program: programAttendances[0].program.name,
-        attendancesCount: programAttendances.length,
-        duration: getTotalDuration(programAttendances.map(a => a.courseSlot)),
-        attendances: programAttendances
+        _id: programId,
+        program: attendancesGroupedByProgram[programId][0].program.name,
+        attendancesCount: attendancesGroupedByProgram[programId].length,
+        duration: getTotalDuration(attendancesGroupedByProgram[programId].map(a => a.courseSlot)),
+        attendances: attendancesGroupedByProgram[programId]
           .sort((a, b) => ascendingSort(a.courseSlot.startDate, b.courseSlot.startDate))
           .map(a => ({
             _id: a._id,
@@ -286,7 +287,7 @@ export default {
         const query = { trainee: this.userProfile._id };
         const unsubscribedAttendancesGroupedByPrograms = await Attendances.listUnsubscribed(query);
         this.unsubscribedAttendances = Object.keys(unsubscribedAttendancesGroupedByPrograms)
-          .map(programId => ({ _id: programId, ...this.formatProgramAttendances[programId] }));
+          .map(programId => this.formatProgramAttendances(unsubscribedAttendancesGroupedByPrograms, programId));
       } catch (e) {
         console.error(e);
         this.unsubscribedAttendances = [];

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -29,7 +29,7 @@
     <div class="q-mb-xl">
       <p class="text-weight-bold">Formations suivies</p>
       <q-card>
-        <ni-expanding-table :data="courses" :columns="columns" :loading="loading" v-model:pagination="pagination">
+        <ni-expanding-table :data="courses" :columns="courseColumns" :loading="loading" v-model:pagination="pagination">
           <template #row="{ props }">
             <q-td v-for="col in props.cols" :key="col.name" :props="props">
               <template v-if="col.name === 'attendances' && has(col, 'value.attendanceDuration')">
@@ -72,6 +72,27 @@
         </ni-expanding-table>
       </q-card>
     </div>
+    <div v-if="unsubscribedAttendances.length" class="q-mb-xl">
+      <p class="text-weight-bold">Formations suivies</p>
+      <div class="text-italic q-ma-xs">
+        {{ formatIdentity(userProfile.identity, 'FL') }} a émargé dans certaines formations sans inscription.
+      </div>
+      <ni-expanding-table :data="unsubscribedAttendances" :columns="attendanceColumns" :pagination="pagination"
+        :hide-bottom="false" :loading="loading">
+        <template #expanding-row="{ props }">
+          <q-td colspan="100%">
+            <div v-for="attendance in props.row.attendances" :key="attendance._id" :props="props"
+              class="q-ma-sm expanding-table-expanded-row">
+              <div class="dates">{{ attendance.date }}</div>
+              <div class="hours">{{ attendance.hours }}</div>
+              <div class="trainer">{{ attendance.trainer }}</div>
+              <div class="step">{{ attendance.step }}</div>
+              <div class="misc">{{ attendance.misc }}</div>
+            </div>
+          </q-td>
+        </template>
+      </ni-expanding-table>
+    </div>
   </div>
 </template>
 
@@ -81,9 +102,10 @@ import get from 'lodash/get';
 import has from 'lodash/has';
 import uniqBy from 'lodash/uniqBy';
 import Courses from '@api/Courses';
+import Attendances from '@api/Attendances';
 import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING } from '@data/constants';
-import { sortStrings } from '@helpers/utils';
-import { isBetween } from '@helpers/date';
+import { sortStrings, formatIdentity, getTotalDuration, getSlotDuration, formatSlotHour } from '@helpers/utils';
+import { isBetween, formatDate, ascendingSort } from '@helpers/date';
 import LineChart from '@components/charts/LineChart';
 import Progress from '@components/CourseProgress';
 import { NotifyNegative, NotifyPositive } from '@components/popup/notify';
@@ -107,7 +129,7 @@ export default {
       courses: [],
       loading: false,
       pagination: { sortBy: 'name', descending: false, page: 1, rowsPerPage: 15 },
-      columns: [
+      courseColumns: [
         {
           name: 'name',
           label: 'Nom',
@@ -138,7 +160,14 @@ export default {
         },
         { name: 'expand', label: '', field: '_id' },
       ],
+      attendanceColumns: [
+        { name: 'name', label: 'Nom', field: 'program', align: 'left' },
+        { name: 'unexpectedAttendances', label: 'Emargements imprévus', field: 'attendancesCount', align: 'center' },
+        { name: 'duration', label: 'Durée', field: 'duration', align: 'center' },
+        { name: 'expand', label: '', field: '' },
+      ],
       E_LEARNING,
+      unsubscribedAttendances: [],
     };
   },
   computed: {
@@ -173,22 +202,14 @@ export default {
         ? 'activités eLearning réalisées'
         : 'activité eLearning réalisée';
     },
-
   },
   async created () {
-    try {
-      this.loading = true;
-      this.courses = await Courses.listUserCourse({ traineeId: this.userProfile._id });
-      await this.computeChartsData();
-    } catch (e) {
-      NotifyNegative('Erreur lors de la récupération des formations');
-      console.error(e);
-      this.courses = [];
-    } finally {
-      this.loading = false;
-    }
+    await this.getUserCourses();
+    this.computeChartsData();
+    this.getUnsubscribedAttendances();
   },
   methods: {
+    formatIdentity,
     goToCourseProfile (props) {
       if (!this.isVendorInterface && props.row.subProgram.isStrictlyELearning) {
         return this.$router.push({ name: 'ni elearning courses info', params: { courseId: props.row._id } });
@@ -207,8 +228,21 @@ export default {
         params: { courseId: props.row._id, defaultTab: 'traineeFollowUp' },
       });
     },
+    async getUserCourses () {
+      try {
+        this.loading = true;
+        this.courses = await Courses.listUserCourse({ traineeId: this.userProfile._id });
+      } catch (e) {
+        NotifyNegative('Erreur lors de la récupération des formations');
+        console.error(e);
+        this.courses = [];
+      } finally {
+        this.loading = false;
+      }
+    },
     async computeChartsData () {
       try {
+        this.loading = true;
         const chartStartDate = new Date(new Date().getFullYear(), new Date().getMonth() - 6, 1);
         const chartEndDate = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
         const sixMonthsHistories = this.eLearningActivitiesCompleted
@@ -219,6 +253,8 @@ export default {
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors de la récupération des données.');
+      } finally {
+        this.loading = false;
       }
     },
     formatDuration (duration) {
@@ -230,6 +266,33 @@ export default {
     },
     get,
     has,
+    async getUnsubscribedAttendances () {
+      try {
+        const query = { trainee: this.userProfile._id };
+        const unsubscribedAttendancesGroupedByPrograms = await Attendances.listUnsubscribed(query);
+        this.unsubscribedAttendances = Object.keys(unsubscribedAttendancesGroupedByPrograms)
+          .map(programId => ({
+            _id: programId,
+            program: unsubscribedAttendancesGroupedByPrograms[programId][0].program.name,
+            attendancesCount: unsubscribedAttendancesGroupedByPrograms[programId].length,
+            duration: getTotalDuration(unsubscribedAttendancesGroupedByPrograms[programId].map(a => a.courseSlot)),
+            attendances: unsubscribedAttendancesGroupedByPrograms[programId]
+              .sort((a, b) => ascendingSort(a.courseSlot.startDate, b.courseSlot.startDate))
+              .map(a => ({
+                _id: a._id,
+                date: formatDate(a.courseSlot.startDate),
+                hours: `${formatSlotHour(a.courseSlot)} (${getSlotDuration(a.courseSlot)})`,
+                trainer: formatIdentity(get(a, 'course.trainer.identity'), 'FL'),
+                misc: a.course.misc,
+                step: a.step.name,
+              })),
+          }));
+      } catch (e) {
+        console.error(e);
+        this.unsubscribedAttendances = [];
+        NotifyNegative('Erreur lors de la récupération des émargements non prévus.');
+      }
+    },
   },
 };
 </script>
@@ -265,4 +328,19 @@ export default {
   flex-direction: row
   display: flex
   color: $primary
+
+.dates
+  width: 10%
+
+.hours
+  width: 15%
+
+.trainer
+  width: 20%
+
+.step
+  width: 30%
+
+.misc
+  width: 15%
 </style>

--- a/src/core/helpers/utils.js
+++ b/src/core/helpers/utils.js
@@ -122,14 +122,14 @@ export const getTotalDuration = (timePeriods) => {
   return formatDuration(total);
 };
 
-export const getSlotDuration = (timePeriod) => {
+export const getDuration = (timePeriod) => {
   const duration = moment.duration(moment(timePeriod.endDate).diff(timePeriod.startDate));
 
   return formatDuration(duration);
 };
 
-export const formatSlotHour = slot => `${moment(slot.startDate).format('HH:mm')} - `
-  + `${moment(slot.endDate).format('HH:mm')}`;
+export const formatIntervalHourly = timePeriod => `${moment(timePeriod.startDate).format('HH:mm')} - `
+  + `${moment(timePeriod.endDate).format('HH:mm')}`;
 
 export const formatPhone = phoneNumber => (phoneNumber
   ? phoneNumber.replace(/^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/, '$1 $2 $3 $4 $5')

--- a/src/core/helpers/utils.js
+++ b/src/core/helpers/utils.js
@@ -113,6 +113,21 @@ export const formatDuration = (duration) => {
   return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
 };
 
+export const getTotalDuration = (timePeriods) => {
+  const total = timePeriods.reduce(
+    (acc, tp) => acc.add(moment.duration(moment(tp.endDate).diff(tp.startDate))),
+    moment.duration()
+  );
+
+  return formatDuration(total);
+};
+
+export const getSlotDuration = (timePeriod) => {
+  const duration = moment.duration(moment(timePeriod.endDate).diff(timePeriod.startDate));
+
+  return formatDuration(duration);
+};
+
 export const formatPhone = phoneNumber => (phoneNumber
   ? phoneNumber.replace(/^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/, '$1 $2 $3 $4 $5')
   : '');

--- a/src/core/helpers/utils.js
+++ b/src/core/helpers/utils.js
@@ -128,6 +128,9 @@ export const getSlotDuration = (timePeriod) => {
   return formatDuration(duration);
 };
 
+export const formatSlotHour = slot => `${moment(slot.startDate).format('HH:mm')} - `
+  + `${moment(slot.endDate).format('HH:mm')}`;
+
 export const formatPhone = phoneNumber => (phoneNumber
   ? phoneNumber.replace(/^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/, '$1 $2 $3 $4 $5')
   : '');


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client ET vendeur, coach ET rof

- Cas d'usage : 
   - sur la page apprenants, on peut visualiser les emargements sans inscriptions
   - sur le profil d'une formation, refacto pour centraliser le formatage des infos dans une seule methode

- Comment tester ? :
    - emarger avec un.e stagiaire dans plusieurs programmes et dans differentes formations du meme programme
    - verifier les infos sur le profile de l'apprenant.e
    - verifier sur le profile d'une formation que les infos n'ont bougé suite a la refacto.

_Si tu as lu cette description, pense a réagir avec un :eye:_
