### PR TITLE
COM-2642: add to come mention for slot to come

### DIFF
--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -73,6 +73,9 @@
                       <q-icon size="12px" name="check_circle" color="green-600" />
                       <span class="text-green-600">Présent(e)</span>
                     </div>
+                    <div v-else-if="isBefore(new Date(), slot.endDate)" class="attendance">
+                      <span class="q-mx-sm">à venir</span>
+                    </div>
                     <div v-else class="attendance">
                       <q-icon size="12px" name="fas fa-times-circle" color="orange-700" />
                       <span class="text-orange-700">Absent(e)</span>
@@ -124,6 +127,7 @@ import {
   getTotalDuration,
   getDuration,
   formatIntervalHourly,
+  isBefore,
 } from '@helpers/date';
 import LineChart from '@components/charts/LineChart';
 import Progress from '@components/CourseProgress';
@@ -317,6 +321,7 @@ export default {
     formatDate,
     formatIntervalHourly,
     getDuration,
+    isBefore,
   },
 };
 </script>


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles :  vendeur/client   client_admin/coach/vendor_admin/rof

- Cas d'usage : quand le créneau d'une étape n'est pas encore passé au lieu d'être noté "absent", on a la mention "à venir"

- Comment tester ? : regarder la fiche apprenant d'un stagiaire inscrit à une formation dont certains créneaux ne sont pas passés => ils doivent être marqué "à venir"

_Si tu as lu cette description, pense a réagir avec un :eye:_
