### PR TITLE
COM-2642: change 'to come' mention style

### DIFF
--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -74,7 +74,7 @@
                       <span class="text-green-600">Présent(e)</span>
                     </div>
                     <div v-else-if="isBefore(new Date(), slot.endDate)" class="attendance">
-                      <span class="q-mx-sm">à venir</span>
+                      <span class="q-mx-sm text-italic text-copper-grey-800">à venir</span>
                     </div>
                     <div v-else class="attendance">
                       <q-icon size="12px" name="fas fa-times-circle" color="orange-700" />


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client/vendeur rof/admin/coach

- Cas d'usage : changement du style de la mention à venir pour les créneaux non passés dans le récap des émargements d'un apprenant

- Comment tester ? : regarder le tableau d'un stagiaire inscrit à une formation ayant des créneaux à venir

_Si tu as lu cette description, pense a réagir avec un :eye:_
