### PR TITLE
Com 2657 2

### DIFF
--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -549,7 +549,9 @@ export const BILLING_ITEMS_TYPE_OPTIONS = [
 
 // CREDIT_NOTES
 export const EVENTS = 'events';
+export const BILLING_ITEMS = 'billing_items';
 export const CREDIT_NOTE_TYPE_OPTIONS = [
   { label: 'Souscription', value: SUBSCRIPTION },
   { label: 'Intervention', value: EVENTS },
+  { label: 'Article manuel', value: BILLING_ITEMS },
 ];

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -202,7 +202,6 @@ export default {
     },
     updateCreditNoteType (event) {
       this.$emit('update:credit-note-type', event);
-      this.tmpInput = '';
     },
     addBillingItem () {
       this.$emit('add-billing-item');

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -69,18 +69,20 @@
         <div class="row">
           <ni-select in-modal @update:model-value="updateBillingItem($event, index, 'billingItem')" required-field
             :caption="`Article ${index + 1}`" :model-value="item.billingItem" :options="billingItemsOptions"
-            class="flex-1" />
+            class="flex-1" @blur="validations.billingItemList.$touch" :error="getError('billingItem', index)" />
           <ni-button icon="close" size="12px" @click="removeBillingItem(index)"
             :disable="newCreditNote.billingItemList.length === 1" />
         </div>
         <div class="flex-row">
           <div class="q-mr-sm">
             <ni-input caption="PU TTC" @update:model-value="updateBillingItem($event, index, 'unitInclTaxes')"
-              :model-value="item.unitInclTaxes" required-field type="number" />
+              :model-value="item.unitInclTaxes" required-field type="number" :error="getError('unitInclTaxes', index)"
+              :error-message="getErrorMessage('unitInclTaxes', index)" @blur="validations.billingItemList.$touch" />
             </div>
           <div class="q-ml-sm">
             <ni-input caption="Quantité" :model-value="item.count" type="number" required-field
-              @update:model-value="updateBillingItem($event, index, 'count')" />
+              @update:model-value="updateBillingItem($event, index, 'count')" :error="getError('count', index)"
+            @blur="validations.billingItemList.$touch" :error-message="getErrorMessage('count', index)" />
           </div>
         </div>
       </div>
@@ -95,6 +97,7 @@
 </template>
 
 <script>
+import get from 'lodash/get';
 import BiColorButton from '@components/BiColorButton';
 import Button from '@components/Button';
 import DateInput from '@components/form/DateInput';
@@ -202,6 +205,19 @@ export default {
     },
     removeBillingItem (index) {
       this.$emit('remove-billing-item', index);
+    },
+    getError (path, index) {
+      const validation = this.validations.billingItemList.$each.$response.$errors[index];
+
+      return this.validations.billingItemList.$dirty && get(validation, `${path}.0.$response`) === false;
+    },
+    getErrorMessage (path, index) {
+      const validation = this.validations.billingItemList.$each.$response.$errors[index];
+      if (get(validation, `${path}.0.$validator`) === 'required') return REQUIRED_LABEL;
+      if (get(validation, `${path}.0.$validator`) === 'positiveNumber' ||
+        get(validation, `${path}.0.$validator`) === 'strictPositiveNumber') return 'Nombre non valide';
+
+      return '';
     },
   },
 };

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -88,6 +88,10 @@
       </div>
       <ni-bi-color-button label="Ajouter un article" icon="add" class="q-mb-md" @click="addBillingItem"
         label-color="primary" />
+      <div class="row q-mb-md">
+        <div class="col-6 total-text">Total HT : {{ formatPrice(totalExclTaxes) }}</div>
+        <div class="col-6 total-text">Total TTC : {{ formatPrice(totalInclTaxes) }}</div>
+      </div>
     </template>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Créer l'avoir" icon-right="add" color="primary"
@@ -157,12 +161,30 @@ export default {
       SUBSCRIPTION,
       EVENTS,
       inclTaxesError: 'Montant TTC non valide',
+      totalExclTaxes: 0,
+      totalInclTaxes: 0,
     };
   },
   computed: {
     newCreditNoteHasNoEvents () {
       return this.newCreditNote.customer && this.newCreditNote.startDate && this.newCreditNote.endDate &&
         !this.creditNoteEvents.length;
+    },
+  },
+  watch: {
+    'newCreditNote.billingItemList': {
+      deep: true,
+      handler () {
+        this.totalExclTaxes = this.newCreditNote.billingItemList
+          .reduce(
+            (acc, bi) => (bi.billingItem ? acc + this.getExclTaxes(bi.unitInclTaxes, bi.vat) * bi.count : acc),
+            0
+          );
+        this.totalInclTaxes = this.newCreditNote.billingItemList.reduce(
+          (acc, bi) => (bi.billingItem ? acc + bi.unitInclTaxes * bi.count : acc),
+          0
+        );
+      },
     },
   },
   methods: {
@@ -218,6 +240,9 @@ export default {
         get(validation, `${path}.0.$validator`) === 'strictPositiveNumber') return 'Nombre non valide';
 
       return '';
+    },
+    getExclTaxes (inclTaxes, vat) {
+      return inclTaxes / (1 + vat / 100);
     },
   },
 };

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -50,7 +50,7 @@
       </div>
     </template>
     <!-- Subscription -->
-    <template v-else>
+    <template v-else-if="creditNoteType === SUBSCRIPTION">
       <ni-select in-modal caption="Souscription concernée" :options="subscriptionsOptions" required-field
         :model-value="newCreditNote.subscription" :disable="!newCreditNote.customer"
         :error="validations.subscription.$error" @blur="validations.subscription.$touch"
@@ -121,15 +121,13 @@ export default {
       CREDIT_NOTE_TYPE_OPTIONS,
       SUBSCRIPTION,
       EVENTS,
+      inclTaxesError: 'Montant TTC non valide',
     };
   },
   computed: {
     newCreditNoteHasNoEvents () {
       return this.newCreditNote.customer && this.newCreditNote.startDate && this.newCreditNote.endDate &&
         !this.creditNoteEvents.length;
-    },
-    inclTaxesError () {
-      return 'Montant TTC non valide';
     },
   },
   methods: {

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -63,6 +63,33 @@
         :model-value="newCreditNote.inclTaxesTpp" required-field :error="validations.inclTaxesTpp.$error" type="number"
         @blur="validations.inclTaxesTpp.$touch" :error-message="inclTaxesError" caption="Montant TTC" suffix="€" />
     </template>
+    <!-- Billing items -->
+    <template v-else>
+      {{ newCreditNote.billingItemList }}
+      <!-- <div v-for="(item, index) of newCreditNote.billingItemList" :key="index">
+        <div class="row">
+          <ni-select in-modal @update:model-value="updateBillingItem($event, index, 'billingItem')" required-field
+            :caption="`Article ${index + 1}`" :model-value="item.billingItem" :options="billingItemsOptions"
+            @blur="validations.billingItemList.$touch" :error="getError('billingItem', index)" class="flex-1" />
+          <ni-button icon="close" size="12px" @click="removeBillingItem(index)"
+            :disable="newCreditNote.billingItemList.length === 1" />
+        </div>
+        <div class="flex-row">
+          <div class="q-mr-sm">
+            <ni-input caption="PU TTC" @update:model-value="updateBillingItem($event, index, 'unitInclTaxes')"
+              :error-message="getErrorMessage('unitInclTaxes', index)" :model-value="item.unitInclTaxes" required-field
+              :error="getError('unitInclTaxes', index)" type="number" @blur="validations.billingItemList.$touch" />
+            </div>
+          <div class="q-ml-sm">
+            <ni-input caption="Quantité" :model-value="item.count" type="number" required-field
+              @update:model-value="updateBillingItem($event, index, 'count')" :error="getError('count', index)"
+              @blur="validations.billingItemList.$touch" :error-message="getErrorMessage('count', index)" />
+          </div>
+        </div>
+      </div> -->
+      <ni-bi-color-button label="Ajouter un article" icon="add" class="q-mb-md" @click="addBillingItem"
+        label-color="primary" />
+    </template>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Créer l'avoir" icon-right="add" color="primary"
         :loading="loading" @click="submit" />
@@ -71,6 +98,7 @@
 </template>
 
 <script>
+import BiColorButton from '@components/BiColorButton';
 import DateInput from '@components/form/DateInput';
 import Input from '@components/form/Input';
 import Select from '@components/form/Select';
@@ -105,6 +133,7 @@ export default {
     'ni-input': Input,
     'ni-date-input': DateInput,
     'ni-btn-toggle': ButtonToggle,
+    'ni-bi-color-button': BiColorButton,
   },
   emits: [
     'hide',
@@ -115,6 +144,7 @@ export default {
     'update:new-credit-note',
     'reset-customer-data',
     'update:credit-note-type',
+    'add-billing-item',
   ],
   data () {
     return {
@@ -162,6 +192,9 @@ export default {
     updateCreditNoteType (event) {
       this.$emit('update:credit-note-type', event);
       this.tmpInput = '';
+    },
+    addBillingItem () {
+      this.$emit('add-billing-item');
     },
   },
 };

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -57,11 +57,12 @@
         @update:model-value="update($event, 'subscription')" />
       <ni-input in-modal v-if="!newCreditNote.thirdPartyPayer" caption="Montant TTC" suffix="€" type="number"
         :model-value="newCreditNote.inclTaxesCustomer" required-field :error="validations.inclTaxesCustomer.$error"
-        @blur="validations.inclTaxesCustomer.$touch" :error-message="inclTaxesError"
+        @blur="validations.inclTaxesCustomer.$touch" error-message="Montant TTC non valide"
         @update:model-value="update($event, 'inclTaxesCustomer')" />
       <ni-input in-modal v-if="newCreditNote.thirdPartyPayer" @update:model-value="update($event, 'inclTaxesTpp')"
         :model-value="newCreditNote.inclTaxesTpp" required-field :error="validations.inclTaxesTpp.$error" type="number"
-        @blur="validations.inclTaxesTpp.$touch" :error-message="inclTaxesError" caption="Montant TTC" suffix="€" />
+        @blur="validations.inclTaxesTpp.$touch" error-message="Montant TTC non valide" caption="Montant TTC"
+        suffix="€" />
     </template>
     <!-- Billing items -->
     <template v-else>
@@ -161,7 +162,6 @@ export default {
       SUBSCRIPTION,
       EVENTS,
       BILLING_ITEMS,
-      inclTaxesError: 'Montant TTC non valide',
       totalExclTaxes: 0,
       totalInclTaxes: 0,
     };

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -65,14 +65,13 @@
     </template>
     <!-- Billing items -->
     <template v-else>
-      {{ newCreditNote.billingItemList }}
       <div v-for="(item, index) of newCreditNote.billingItemList" :key="index">
         <div class="row">
           <ni-select in-modal @update:model-value="updateBillingItem($event, index, 'billingItem')" required-field
             :caption="`Article ${index + 1}`" :model-value="item.billingItem" :options="billingItemsOptions"
             class="flex-1" />
-          <!-- <ni-button icon="close" size="12px" @click="removeBillingItem(index)"
-            :disable="newCreditNote.billingItemList.length === 1" /> -->
+          <ni-button icon="close" size="12px" @click="removeBillingItem(index)"
+            :disable="newCreditNote.billingItemList.length === 1" />
         </div>
         <div class="flex-row">
           <div class="q-mr-sm">
@@ -97,6 +96,7 @@
 
 <script>
 import BiColorButton from '@components/BiColorButton';
+import Button from '@components/Button';
 import DateInput from '@components/form/DateInput';
 import Input from '@components/form/Input';
 import Select from '@components/form/Select';
@@ -132,6 +132,7 @@ export default {
     'ni-date-input': DateInput,
     'ni-btn-toggle': ButtonToggle,
     'ni-bi-color-button': BiColorButton,
+    'ni-button': Button,
   },
   emits: [
     'hide',
@@ -144,6 +145,7 @@ export default {
     'update:credit-note-type',
     'add-billing-item',
     'update-billing-item',
+    'remove-billing-item',
   ],
   data () {
     return {
@@ -195,8 +197,11 @@ export default {
     addBillingItem () {
       this.$emit('add-billing-item');
     },
-    async updateBillingItem (event, index, path) {
-      await this.$emit('update-billing-item', event, index, path);
+    updateBillingItem (event, index, path) {
+      this.$emit('update-billing-item', event, index, path);
+    },
+    removeBillingItem (index) {
+      this.$emit('remove-billing-item', index);
     },
   },
 };

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -66,27 +66,25 @@
     <!-- Billing items -->
     <template v-else>
       {{ newCreditNote.billingItemList }}
-      <!-- <div v-for="(item, index) of newCreditNote.billingItemList" :key="index">
+      <div v-for="(item, index) of newCreditNote.billingItemList" :key="index">
         <div class="row">
           <ni-select in-modal @update:model-value="updateBillingItem($event, index, 'billingItem')" required-field
             :caption="`Article ${index + 1}`" :model-value="item.billingItem" :options="billingItemsOptions"
-            @blur="validations.billingItemList.$touch" :error="getError('billingItem', index)" class="flex-1" />
-          <ni-button icon="close" size="12px" @click="removeBillingItem(index)"
-            :disable="newCreditNote.billingItemList.length === 1" />
+            class="flex-1" />
+          <!-- <ni-button icon="close" size="12px" @click="removeBillingItem(index)"
+            :disable="newCreditNote.billingItemList.length === 1" /> -->
         </div>
         <div class="flex-row">
           <div class="q-mr-sm">
             <ni-input caption="PU TTC" @update:model-value="updateBillingItem($event, index, 'unitInclTaxes')"
-              :error-message="getErrorMessage('unitInclTaxes', index)" :model-value="item.unitInclTaxes" required-field
-              :error="getError('unitInclTaxes', index)" type="number" @blur="validations.billingItemList.$touch" />
+              :model-value="item.unitInclTaxes" required-field type="number" />
             </div>
           <div class="q-ml-sm">
             <ni-input caption="Quantité" :model-value="item.count" type="number" required-field
-              @update:model-value="updateBillingItem($event, index, 'count')" :error="getError('count', index)"
-              @blur="validations.billingItemList.$touch" :error-message="getErrorMessage('count', index)" />
+              @update:model-value="updateBillingItem($event, index, 'count')" />
           </div>
         </div>
-      </div> -->
+      </div>
       <ni-bi-color-button label="Ajouter un article" icon="add" class="q-mb-md" @click="addBillingItem"
         label-color="primary" />
     </template>
@@ -145,6 +143,7 @@ export default {
     'reset-customer-data',
     'update:credit-note-type',
     'add-billing-item',
+    'update-billing-item',
   ],
   data () {
     return {
@@ -195,6 +194,9 @@ export default {
     },
     addBillingItem () {
       this.$emit('add-billing-item');
+    },
+    async updateBillingItem (event, index, path) {
+      await this.$emit('update-billing-item', event, index, path);
     },
   },
 };

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -96,6 +96,7 @@ export default {
     startDateErrorMessage: { type: String, default: REQUIRED_LABEL },
     endDateErrorMessage: { type: String, default: REQUIRED_LABEL },
     minAndMaxDates: { type: Object, default: () => ({}) },
+    billingItemsOptions: { type: Array, default: () => ([]) },
   },
   components: {
     'ni-option-group': OptionGroup,

--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -70,20 +70,23 @@
         <div class="row">
           <ni-select in-modal @update:model-value="updateBillingItem($event, index, 'billingItem')" required-field
             :caption="`Article ${index + 1}`" :model-value="item.billingItem" :options="billingItemsOptions"
-            class="flex-1" @blur="validations.billingItemList.$touch" :error="getError('billingItem', index)" />
+            class="flex-1" @blur="validations.billingItemList.$touch"
+            :error="getBillingItemError('billingItem', index)" />
           <ni-button icon="close" size="12px" @click="removeBillingItem(index)"
             :disable="newCreditNote.billingItemList.length === 1" />
         </div>
         <div class="flex-row">
           <div class="q-mr-sm">
             <ni-input caption="PU TTC" @update:model-value="updateBillingItem($event, index, 'unitInclTaxes')"
-              :model-value="item.unitInclTaxes" required-field type="number" :error="getError('unitInclTaxes', index)"
-              :error-message="getErrorMessage('unitInclTaxes', index)" @blur="validations.billingItemList.$touch" />
+              :model-value="item.unitInclTaxes" required-field type="number"
+              :error-message="getBillingItemErrorMessage('unitInclTaxes', index)"
+              :error="getBillingItemError('unitInclTaxes', index)" @blur="validations.billingItemList.$touch" />
             </div>
           <div class="q-ml-sm">
             <ni-input caption="Quantité" :model-value="item.count" type="number" required-field
-              @update:model-value="updateBillingItem($event, index, 'count')" :error="getError('count', index)"
-            @blur="validations.billingItemList.$touch" :error-message="getErrorMessage('count', index)" />
+              @update:model-value="updateBillingItem($event, index, 'count')"
+              @blur="validations.billingItemList.$touch" :error-message="getBillingItemErrorMessage('count', index)"
+              :error="getBillingItemError('count', index)" />
           </div>
         </div>
       </div>
@@ -212,12 +215,12 @@ export default {
     removeBillingItem (index) {
       this.$emit('remove-billing-item', index);
     },
-    getError (path, index) {
+    getBillingItemError (path, index) {
       const validation = this.validations.billingItemList.$each.$response.$errors[index];
 
       return this.validations.billingItemList.$dirty && get(validation, `${path}.0.$response`) === false;
     },
-    getErrorMessage (path, index) {
+    getBillingItemErrorMessage (path, index) {
       const validation = this.validations.billingItemList.$each.$response.$errors[index];
       if (get(validation, `${path}.0.$validator`) === 'required') return REQUIRED_LABEL;
       if (get(validation, `${path}.0.$validator`) === 'positiveNumber' ||

--- a/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
+++ b/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
@@ -119,14 +119,6 @@ export default {
     getExclTaxes (inclTaxes, vat) {
       return inclTaxes / (1 + vat / 100);
     },
-    nbrError (path, index) {
-      const validation = this.validations.billingItemList.$each.$response.$errors[index];
-      if (get(validation, `${path}.required.$response`) === false) return REQUIRED_LABEL;
-      if (get(validation, `${path}.positiveNumber.$response`) === false ||
-        get(validation, `${path}.strictPositiveNumber.$response`) === false) return 'Nombre non valide';
-
-      return '';
-    },
     hide () {
       this.totalExclTaxes = 0;
       this.selectedBillingItem = null;

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -107,6 +107,7 @@ export default {
         inclTaxesTpp: 0,
         subscription: '',
         misc: '',
+        billingItemList: [],
       },
       editedCreditNote: {},
       creditNotes: [],
@@ -266,6 +267,7 @@ export default {
         exclTaxesTpp: 0,
         inclTaxesTpp: 0,
         misc: '',
+        billingItemList: [],
       };
 
       this.v$.newCreditNote.startDate.$reset();
@@ -441,6 +443,8 @@ export default {
         inclTaxesTpp: 0,
         subscription: '',
         thirdPartyPayer: '',
+        misc: '',
+        billingItemList: [],
       };
       this.creditNoteEvents = [];
       this.creditNoteType = SUBSCRIPTION;

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -582,6 +582,9 @@ export default {
     async createNewCreditNote () {
       try {
         if (this.creditNoteType !== BILLING_ITEMS) this.newCreditNote.billingItemList = [];
+        const hasDuplicateBillingItems = this.newCreditNote.billingItemList.map(bi => bi.billingItem).length
+          === [...new Set(this.newCreditNote.billingItemList.map(bi => bi.billingItem))].length;
+        if (hasDuplicateBillingItems) return NotifyWarning('Vous ne pouvez pas ajouter plusieurs fois le même article');
 
         this.v$.newCreditNote.$touch();
         if (this.v$.newCreditNote.$error) return NotifyWarning('Champ(s) invalide(s)');

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -178,6 +178,20 @@ export default {
       this.newCreditNote.exclTaxesTpp = prices.exclTaxesTpp;
       this.newCreditNote.inclTaxesTpp = prices.inclTaxesTpp;
     },
+    'newCreditNote.billingItemList': {
+      deep: true,
+      handler () {
+        this.newCreditNote.exclTaxesCustomer = this.newCreditNote.billingItemList
+          .reduce(
+            (acc, bi) => (bi.billingItem ? acc + this.getExclTaxes(bi.unitInclTaxes, bi.vat) * bi.count : acc),
+            0
+          );
+        this.newCreditNote.inclTaxesCustomer = this.newCreditNote.billingItemList.reduce(
+          (acc, bi) => (bi.billingItem ? acc + bi.unitInclTaxes * bi.count : acc),
+          0
+        );
+      },
+    },
     'editedCreditNote.events': function (previousValue, currentValue) {
       if (!isEqual(previousValue, currentValue) && this.creditNoteType === EVENTS) {
         const prices = this.computePrices(this.editedCreditNote.events);
@@ -547,7 +561,7 @@ export default {
       try {
         this.v$.newCreditNote.$touch();
 
-        if (this.v$.newCreditNote.$error || this.noEventSelectedForNewCreditNote) {
+        if (this.v$.newCreditNote.$error) {
           return NotifyWarning('Champ(s) invalide(s)');
         }
         this.loading = true;
@@ -576,6 +590,9 @@ export default {
         set(this.newCreditNote.billingItemList[index], 'vat', billingItem?.vat || 0);
         set(this.newCreditNote.billingItemList[index], 'unitInclTaxes', billingItem?.defaultUnitAmount || 0);
       }
+    },
+    getExclTaxes (inclTaxes, vat) {
+      return inclTaxes / (1 + vat / 100);
     },
     // Edition
     async openCreditNoteEditionModal (creditNote) {

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -48,7 +48,7 @@
 
 <script>
 import { useMeta } from 'quasar';
-import { required, requiredIf } from '@vuelidate/validators';
+import { required, requiredIf, helpers } from '@vuelidate/validators';
 import useVuelidate from '@vuelidate/core';
 import cloneDeep from 'lodash/cloneDeep';
 import pickBy from 'lodash/pickBy';
@@ -65,9 +65,9 @@ import TitleHeader from '@components/TitleHeader';
 import Button from '@components/Button';
 import SimpleTable from '@components/table/SimpleTable';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
-import { COMPANI, REQUIRED_LABEL, SUBSCRIPTION, EVENTS, MANUAL } from '@data/constants';
+import { COMPANI, REQUIRED_LABEL, SUBSCRIPTION, EVENTS, MANUAL, BILLING_ITEMS } from '@data/constants';
 import { formatPrice, getLastVersion, formatIdentity, formatAndSortOptions } from '@helpers/utils';
-import { strictPositiveNumber, minDate, maxDate } from '@helpers/vuelidateCustomVal';
+import { strictPositiveNumber, minDate, maxDate, positiveNumber } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
 import { getStartOfDay, getEndOfDay, formatDate } from '@helpers/date';
 import CreditNoteEditionModal from 'src/modules/client/components/customers/billing/CreditNoteEditionModal';
@@ -112,7 +112,7 @@ export default {
         inclTaxesTpp: 0,
         subscription: '',
         misc: '',
-        billingItemList: [],
+        billingItemList: [{ billingItem: '', unitInclTaxes: 0, count: 1 }],
       },
       editedCreditNote: {},
       creditNotes: [],
@@ -199,6 +199,14 @@ export default {
       customer: { required },
       events: { required: requiredIf(this.creditNoteType === EVENTS) },
       subscription: { required: requiredIf(this.creditNoteType === SUBSCRIPTION) },
+      billingItemList: {
+        required: requiredIf(this.creditNoteType === BILLING_ITEMS),
+        $each: helpers.forEach({
+          billingItem: { required },
+          unitInclTaxes: { positiveNumber, required },
+          count: { strictPositiveNumber, required },
+        }),
+      },
       inclTaxesTpp: {},
       inclTaxesCustomer: {},
     };
@@ -272,7 +280,7 @@ export default {
         exclTaxesTpp: 0,
         inclTaxesTpp: 0,
         misc: '',
-        billingItemList: [],
+        billingItemList: [{ billingItem: '', unitInclTaxes: 0, count: 1 }],
       };
 
       this.v$.newCreditNote.startDate.$reset();
@@ -454,7 +462,7 @@ export default {
         subscription: '',
         thirdPartyPayer: '',
         misc: '',
-        billingItemList: [],
+        billingItemList: [{ billingItem: '', unitInclTaxes: 0, count: 1 }],
       };
       this.creditNoteEvents = [];
       this.creditNoteType = SUBSCRIPTION;

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -32,7 +32,8 @@
       :customers-options="customersOptions" @hide="resetCreationCreditNoteData" v-model:new-credit-note="newCreditNote"
       :end-date-error-message="setEndDateErrorMessage(this.v$.newCreditNote, this.newCreditNote.events)"
       @reset-customer-data="resetCustomerData" :billing-items-options="billingItemsOptions"
-      @add-billing-item="addBillingItem" @update-billing-item="updateBillingItem" />
+      @add-billing-item="addBillingItem" @update-billing-item="updateBillingItem"
+      @remove-billing-item="removeBillingItem" />
 
     <!-- Credit note edition modal -->
     <credit-note-edition-modal v-if="Object.keys(editedCreditNote).length > 0" @submit="updateCreditNote"
@@ -556,6 +557,9 @@ export default {
     },
     addBillingItem () {
       this.newCreditNote.billingItemList.push({ billingItem: '', unitInclTaxes: 0, count: 1 });
+    },
+    removeBillingItem (index) {
+      this.newCreditNote.billingItemList.splice(index, 1);
     },
     updateBillingItem (event, index, path) {
       set(this.newCreditNote.billingItemList[index], path, event);

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -32,7 +32,7 @@
       :customers-options="customersOptions" @hide="resetCreationCreditNoteData" v-model:new-credit-note="newCreditNote"
       :end-date-error-message="setEndDateErrorMessage(this.v$.newCreditNote, this.newCreditNote.events)"
       @reset-customer-data="resetCustomerData" :billing-items-options="billingItemsOptions"
-      @add-billing-item="addBillingItem" />
+      @add-billing-item="addBillingItem" @update-billing-item="updateBillingItem" />
 
     <!-- Credit note edition modal -->
     <credit-note-edition-modal v-if="Object.keys(editedCreditNote).length > 0" @submit="updateCreditNote"
@@ -96,6 +96,7 @@ export default {
       creditNoteType: SUBSCRIPTION,
       customersOptions: [],
       creditNoteEvents: [],
+      billingItems: [],
       billingItemsOptions: [],
       newCreditNote: {
         customer: '',
@@ -282,6 +283,7 @@ export default {
     // Refresh data
     async refreshBillingItemsOptions () {
       const billingItems = Object.freeze(await BillingItems.list({ type: MANUAL }));
+      this.billingItems = billingItems;
       this.billingItemsOptions = formatAndSortOptions(billingItems, 'name');
     },
     async refreshCustomersOptions () {
@@ -554,6 +556,14 @@ export default {
     },
     addBillingItem () {
       this.newCreditNote.billingItemList.push({ billingItem: '', unitInclTaxes: 0, count: 1 });
+    },
+    updateBillingItem (event, index, path) {
+      set(this.newCreditNote.billingItemList[index], path, event);
+      if (path === 'billingItem') {
+        const billingItem = this.billingItems.find(bi => bi._id === event);
+        set(this.newCreditNote.billingItemList[index], 'vat', billingItem?.vat || 0);
+        set(this.newCreditNote.billingItemList[index], 'unitInclTaxes', billingItem?.defaultUnitAmount || 0);
+      }
     },
     // Edition
     async openCreditNoteEditionModal (creditNote) {

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -582,8 +582,8 @@ export default {
     async createNewCreditNote () {
       try {
         if (this.creditNoteType !== BILLING_ITEMS) this.newCreditNote.billingItemList = [];
-        const hasDuplicateBillingItems = this.newCreditNote.billingItemList.map(bi => bi.billingItem).length
-          === [...new Set(this.newCreditNote.billingItemList.map(bi => bi.billingItem))].length;
+        const billingItems = this.newCreditNote.billingItemList.map(bi => bi.billingItem);
+        const hasDuplicateBillingItems = billingItems.length !== [...new Set(billingItems)].length;
         if (hasDuplicateBillingItems) return NotifyWarning('Vous ne pouvez pas ajouter plusieurs fois le même article');
 
         this.v$.newCreditNote.$touch();

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -297,6 +297,7 @@ export default {
       this.creditNoteEvents = [];
       this.newCreditNote = {
         ...this.newCreditNote,
+        thirdPartyPayer: '',
         events: [],
         subscription: null,
         startDate: '',
@@ -305,7 +306,6 @@ export default {
         inclTaxesCustomer: 0,
         exclTaxesTpp: 0,
         inclTaxesTpp: 0,
-        misc: '',
         billingItemList: [{ billingItem: '', unitInclTaxes: 0, count: 1 }],
       };
 

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -31,7 +31,8 @@
       :credit-note-events="creditNoteEvents" :start-date-error-message="setStartDateErrorMessage(this.v$.newCreditNote)"
       :customers-options="customersOptions" @hide="resetCreationCreditNoteData" v-model:new-credit-note="newCreditNote"
       :end-date-error-message="setEndDateErrorMessage(this.v$.newCreditNote, this.newCreditNote.events)"
-      @reset-customer-data="resetCustomerData" :billing-items-options="billingItemsOptions" />
+      @reset-customer-data="resetCustomerData" :billing-items-options="billingItemsOptions"
+      @add-billing-item="addBillingItem" />
 
     <!-- Credit note edition modal -->
     <credit-note-edition-modal v-if="Object.keys(editedCreditNote).length > 0" @submit="updateCreditNote"
@@ -550,6 +551,9 @@ export default {
       } finally {
         this.loading = false;
       }
+    },
+    addBillingItem () {
+      this.newCreditNote.billingItemList.push({ billingItem: '', unitInclTaxes: 0, count: 1 });
     },
     // Edition
     async openCreditNoteEditionModal (creditNote) {


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client

- Cas d'usage : Je peux créer un avoir sur les articles manuels

- Comment tester ? :
Créer un avoir avoir lié à des articles de facturations.
La création d'avoir étant complexe, je vous conseille de créer un avoir sur les souscriptions et un avoir lié à des évènements.
Essayer sur un bénéficiaire avec et sans tpp, avec plusieurs souscriptions, essayer avec plusieurs articles  de facturations, changer les prix / quantité des articles.

⚠️ Le filtre sur les options de articles de facturations n'est pas possible à faire facilement (limitation de quasar). Vu avec Romain : on bloque l'ajout de doublon en front et en back

_Si tu as lu cette description, pense a réagir avec un :eye:_
