### PR TITLE
COM-2659 - fix Romain's reviews

### DIFF
--- a/src/modules/client/components/planning/EventHours.vue
+++ b/src/modules/client/components/planning/EventHours.vue
@@ -28,11 +28,11 @@ export default {
 .icon-container
   display: flex
   justify-content: left
-  color: $copper-500
   font-size: 10px
 .hour-content
   display: flex
   flex-direction: row
+  color: $copper-700
 .bold
   font-weight: bold
 </style>

--- a/src/modules/client/mixins/planningEventMixin.js
+++ b/src/modules/client/mixins/planningEventMixin.js
@@ -52,15 +52,11 @@ export const planningEventMixin = {
       return !customerAbsence ? '' : customerAbsence.label;
     },
     eventTitle (event) {
-      const customerIdentity = event.customer.identity;
-      const shortenCustomerFirstName = `${customerIdentity.firstname.substring(0, 3)}. `;
-      const formatCustomerIdentity = () => (
-        formatIdentity({ ...customerIdentity, firstname: shortenCustomerFirstName }, 'FL').replace(' ', '')
-      );
-
       if (!event.auxiliary && this.isCustomerPlanning) return 'À affecter';
 
-      return this.isCustomerPlanning ? formatIdentity(event.auxiliary.identity, 'Fl') : formatCustomerIdentity();
+      return this.isCustomerPlanning
+        ? formatIdentity(event.auxiliary.identity, 'Fl')
+        : formatIdentity(event.customer.identity, 'fL').replace(' ', '');
     },
     getDisplayedEvent (event, day, startDisplay, endDisplay) {
       const dayEvent = { ...event };


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Remarques de Romain:
     - La nouvelle couleur des horaires rend le contraste très faible sur les heures internes : peut-on passer les horaires copper/700 finalement ?
     - Par ailleurs, je me rends compte que le fait de mettre les 3 premières lettres du prénom font qu’on ne voit même plus les premières lettres du nom, pour un mobile avec écran étroit, comme c’est mon cas. Dans le design que proposait Félix, ça marchait, mais c’est parce qu’on avait réussi à gagner de l’espace horizontal. Du coup finalement, désolé, mais revenir sur R.Delenda (en revanche, continuer à retirer l’espace après le point, pour gagner de la place) 
 
- Comment tester ? :
- ETQ Coach/Auxiliaire, sur le planning auxiliaire:
     - le titre de la cellule est P.NOM
     - l'horaire et l'icones d'horodatage sont visibles pour les interventions
     - l'horaire est visible pour une heure interne

_Si tu as lu cette description, pense a réagir avec un :eye:_
