### PR TITLE
Com 2709

### DIFF
--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -262,6 +262,7 @@ export const EVENT_TRANSPORT_OPTIONS = [
 ];
 
 export const REQUIRED_LABEL = 'Champ requis';
+export const INVALID_NUMBER = 'Nombre invalide';
 
 // BILLING
 

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -483,11 +483,10 @@ export default {
     },
     isHourlySubscription () {
       const selectedService = this.openNewSubscriptionModal
-        ? this.newSubscription.service
-        : this.editedSubscription.service;
-      const service = this.serviceOptions.find(s => s.value === selectedService);
+        ? this.serviceOptions.find(s => s.value === this.newSubscription.service)
+        : this.editedSubscription;
 
-      return get(service, 'nature') === HOURLY;
+      return get(selectedService, 'nature') === HOURLY;
     },
   },
   validations () {
@@ -701,13 +700,11 @@ export default {
     },
     // Subscriptions
     formatCreatedSubscription () {
-      const isHourlyService = this.services.find(s => s._id === this.newSubscription.service).nature === HOURLY;
-
       return {
         service: this.newSubscription.service,
         versions: [{
           ...pick(this.newSubscription, ['unitTTCRate', 'weeklyCount']),
-          ...(isHourlyService && pick(this.newSubscription, ['sundays', 'evenings', 'weeklyHours'])),
+          ...(this.isHourlySubscription && pick(this.newSubscription, ['sundays', 'evenings', 'weeklyHours'])),
         }],
       };
     },
@@ -761,11 +758,9 @@ export default {
       this.v$.editedSubscription.$reset();
     },
     formatEditedSubscription () {
-      const isHourlyService = this.editedSubscription.nature === HOURLY;
-
       return {
         ...pick(this.editedSubscription, ['unitTTCRate', 'weeklyCount']),
-        ...(isHourlyService && pick(this.editedSubscription, ['sundays', 'evenings', 'weeklyHours'])),
+        ...(this.isHourlySubscription && pick(this.editedSubscription, ['sundays', 'evenings', 'weeklyHours'])),
       };
     },
     async updateSubscription () {

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -302,6 +302,7 @@ import {
   HOURLY,
   MONTHLY,
   REQUIRED_LABEL,
+  INVALID_NUMBER,
   CIVILITY_OPTIONS,
   DOC_EXTENSIONS,
   ONCE,
@@ -615,31 +616,31 @@ export default {
         },
       };
     },
-    numberErrorMessage (field, minValueErreurMessage) {
+    numberErrorMessage (field) {
       if (get(field, 'required.$response') === false) return REQUIRED_LABEL;
-      if (get(field, 'minValue.$response') === false) return minValueErreurMessage;
+      if (get(field, 'minValue.$response') === false) return INVALID_NUMBER;
       return '';
     },
     weeklyHoursErrorMessage (validations) {
-      return this.numberErrorMessage(validations.weeklyHours, 'Volume horaire hebdomadaire invalide');
+      return this.numberErrorMessage(validations.weeklyHours);
     },
     weeklyCountErrorMessage (validations) {
-      return this.numberErrorMessage(validations.weeklyCount, 'Nombre d\'interventions hebdomadaire invalide');
+      return this.numberErrorMessage(validations.weeklyCount);
     },
     eveningsErrorMessage (validations) {
-      return this.numberErrorMessage(validations.evenings, 'Nombre de soirées invalide');
+      return this.numberErrorMessage(validations.evenings);
     },
     sundaysErrorMessage (validations) {
-      return this.numberErrorMessage(validations.sundays, 'Nombre de dimanches invalide');
+      return this.numberErrorMessage(validations.sundays);
     },
     careHoursErrorMessage (validations) {
-      return this.numberErrorMessage(validations.unitTTCRate, 'Nombre d\'heures invalide');
+      return this.numberErrorMessage(validations.unitTTCRate);
     },
     amountTTCErrorMessage (validations) {
-      return this.numberErrorMessage(validations.amountTTC, 'Montant forfaitaire TTC invalide');
+      return this.numberErrorMessage(validations.amountTTC);
     },
     unitTTCRateErrorMessage (validations) {
-      return this.numberErrorMessage(validations.unitTTCRate, 'Prix unitaire TTC invalide');
+      return this.numberErrorMessage(validations.unitTTCRate);
     },
     customerParticipationRateErrorMessage (validations) {
       if (get(validations, 'customerParticipationRate.required.$response') === false) return REQUIRED_LABEL;

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -306,7 +306,7 @@ import { formatDate, isSameOrBefore } from '@helpers/date';
 import { getLastVersion } from '@helpers/utils';
 import { frPhoneNumber, iban, bic, frAddress, minDate } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
-import { getSubscriptionQuoteTags, getQuoteTags, getMandateTags } from 'src/modules/client/helpers/tags';
+import { getTagsToGenerateQuote, getTagsToDownloadQuote, getMandateTags } from 'src/modules/client/helpers/tags';
 import { userMixin } from '@mixins/userMixin';
 import { validationMixin } from '@mixins/validationMixin';
 import HelperEditionModal from 'src/modules/client/components/customers/infos/HelperEditionModal';
@@ -856,7 +856,7 @@ export default {
           estimatedWeeklyRate: this.computeWeeklyRate(subscription),
         }));
 
-        const data = getQuoteTags(this.customer, this.company, { ...quote, subscriptions });
+        const data = getTagsToDownloadQuote(this.customer, this.company, { ...quote, subscriptions });
         const params = { driveId: quoteDriveId };
         await downloadDriveDocx(params, data, 'devis.docx');
         NotifyPositive('Devis téléchargé.');
@@ -867,7 +867,7 @@ export default {
     },
     async generateQuote () {
       try {
-        const payload = { subscriptions: this.subscriptions.map(getSubscriptionQuoteTags) };
+        const payload = { subscriptions: this.subscriptions.map(getTagsToGenerateQuote) };
         await Customers.addQuote(this.customer._id, payload);
 
         await this.refreshQuotes();

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -483,7 +483,11 @@ export default {
       return !!get(this.editedFunding, 'thirdPartyPayer.teletransmissionId');
     },
     isHourlySubscription () {
-      const service = this.serviceOptions.find(s => s.value === this.newSubscription.service);
+      const selectedService = this.openNewSubscriptionModal
+        ? this.newSubscription.service
+        : this.editedSubscription.service;
+      const service = this.serviceOptions.find(s => s.value === selectedService);
+
       return get(service, 'nature') === HOURLY;
     },
   },
@@ -533,7 +537,8 @@ export default {
       },
       editedSubscription: {
         unitTTCRate: { required },
-        estimatedWeeklyVolume: { required },
+        weeklyHours: { required: requiredIf(this.isHourlySubscription) },
+        weeklyCount: { required: requiredIf(!this.isHourlySubscription) },
       },
       newFunding: {
         thirdPartyPayer: { required },
@@ -734,12 +739,13 @@ export default {
     },
     openSubscriptionEditionModal (id) {
       const selectedSubscription = this.subscriptions.find(sub => sub._id === id);
-      const { _id, service, unitTTCRate, estimatedWeeklyVolume, evenings, sundays } = selectedSubscription;
+      const { _id, service, unitTTCRate, weeklyHours, weeklyCount, evenings, sundays } = selectedSubscription;
       this.editedSubscription = {
         _id,
         nature: service.nature,
         unitTTCRate: unitTTCRate || 0,
-        estimatedWeeklyVolume: estimatedWeeklyVolume || 0,
+        weeklyHours: weeklyHours || 0,
+        weeklyCount: weeklyCount || 0,
         evenings: evenings || 0,
         sundays: sundays || 0,
       };

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -376,11 +376,7 @@ export default {
         { name: 'signed', label: 'Signé', align: 'center', field: row => row.drive && row.drive.driveId },
       ],
       quotesLoading: false,
-      newSubscription: {
-        service: '',
-        unitTTCRate: 0,
-        estimatedWeeklyVolume: '',
-      },
+      newSubscription: { service: '', unitTTCRate: 0, weeklyHours: 0, weeklyCount: 0 },
       editedSubscription: {},
       mandatesColumns: [
         { name: 'rum', label: 'RUM', align: 'left', field: 'rum' },
@@ -392,11 +388,7 @@ export default {
       mandatesLoading: false,
       fundingsVisibleColumns: ['thirdPartyPayer', 'folderNumber', 'nature', 'startDate', 'endDate', 'actions'],
       fundingHistoryModal: false,
-      paginationFundingHistory: {
-        rowsPerPage: 0,
-        sortBy: 'createdAt',
-        descending: true,
-      },
+      paginationFundingHistory: { rowsPerPage: 0, sortBy: 'createdAt', descending: true },
       ttpList: [],
       newFunding: {
         thirdPartyPayer: '',
@@ -418,11 +410,7 @@ export default {
       fundingDetailsModal: false,
       selectedFunding: {},
       editedFunding: {},
-      pagination: {
-        sortBy: 'createdAt',
-        ascending: true,
-        rowsPerPage: 0,
-      },
+      pagination: { sortBy: 'createdAt', ascending: true, rowsPerPage: 0 },
       extensions: DOC_EXTENSIONS,
       firstStep: true,
       docLoading: false,
@@ -494,6 +482,10 @@ export default {
     needFundingPlanIdForEditedFunding () {
       return !!get(this.editedFunding, 'thirdPartyPayer.teletransmissionId');
     },
+    isHourlySubscription () {
+      const service = this.serviceOptions.find(s => s.value === this.newSubscription.service);
+      return get(service, 'nature') === HOURLY;
+    },
   },
   validations () {
     return {
@@ -536,7 +528,8 @@ export default {
       newSubscription: {
         service: { required },
         unitTTCRate: { required },
-        estimatedWeeklyVolume: { required },
+        weeklyHours: { required: requiredIf(this.isHourlySubscription) },
+        weeklyCount: { required: requiredIf(!this.isHourlySubscription) },
       },
       editedSubscription: {
         unitTTCRate: { required },
@@ -704,20 +697,20 @@ export default {
     },
     // Subscriptions
     formatCreatedSubscription () {
-      const { service, unitTTCRate, estimatedWeeklyVolume, sundays, evenings } = this.newSubscription;
-      const formattedService = { service, versions: [{ unitTTCRate, estimatedWeeklyVolume }] };
-
-      if (sundays) formattedService.versions[0].sundays = sundays;
-      if (evenings) formattedService.versions[0].evenings = evenings;
-
-      return formattedService;
+      return {
+        service: this.newSubscription.service,
+        versions: [{
+          ...pick(this.newSubscription, ['unitTTCRate', 'weeklyHours', 'sundays', 'evenings', 'weeklyCount']),
+        }],
+      };
     },
     resetCreationSubscriptionData () {
       this.v$.newSubscription.$reset();
       this.newSubscription = {
         service: '',
         unitTTCRate: 0,
-        estimatedWeeklyVolume: '',
+        weeklyHours: 0,
+        weeklyCount: 0,
       };
     },
     async createSubscription () {

--- a/src/modules/client/components/customers/infos/SubscriptionCreationModal.vue
+++ b/src/modules/client/components/customers/infos/SubscriptionCreationModal.vue
@@ -17,7 +17,7 @@
     </template>
     <template v-else>
       <ni-input in-modal :model-value="newSubscription.weeklyHours" type="number" required-field
-        :error="validations.weeklyHours.$error" caption="Volume horaire hebdomadaire estimatif"
+        :error="validations.weeklyHours.$error" caption="Volume horaire hebdomadaire estimatif (h)"
         @blur="validations.weeklyHours.$touch" @update:model-value="update($event, 'weeklyHours')"
         :error-message="weeklyHoursErrorMessage" />
       <ni-input in-modal :model-value="newSubscription.sundays" caption="Dont dimanche (h)" type="number"
@@ -49,7 +49,7 @@ export default {
     serviceOptions: { type: Array, default: () => [] },
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
-    unitTtcRateErrorMessage: { type: String, default: 'poiuy' },
+    unitTtcRateErrorMessage: { type: String, default: REQUIRED_LABEL },
     weeklyHoursErrorMessage: { type: String, default: REQUIRED_LABEL },
     weeklyCountErrorMessage: { type: String, default: REQUIRED_LABEL },
     eveningsErrorMessage: { type: String, default: REQUIRED_LABEL },

--- a/src/modules/client/components/customers/infos/SubscriptionCreationModal.vue
+++ b/src/modules/client/components/customers/infos/SubscriptionCreationModal.vue
@@ -9,13 +9,20 @@
     <ni-input in-modal :model-value="newSubscription.unitTTCRate" :error="validations.unitTTCRate.$error" required-field
       caption="Prix unitaire TTC" @blur="validations.unitTTCRate.$touch" type="number"
       @update:model-value="update($event, 'unitTTCRate')" />
-    <ni-input in-modal :model-value="newSubscription.estimatedWeeklyVolume" type="number" required-field
-      :error="validations.estimatedWeeklyVolume.$error" caption="Volume hebdomadaire estimatif"
-      @blur="validations.estimatedWeeklyVolume.$touch" @update:model-value="update($event, 'estimatedWeeklyVolume')" />
-    <ni-input in-modal v-if="serviceNature !== FIXED" :model-value="newSubscription.sundays"
-      caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')" />
-    <ni-input in-modal v-if="serviceNature !== FIXED" :model-value="newSubscription.evenings"
-      caption="Dont soirée (h)" last type="number" @update:model-value="update($event, 'evenings')" />
+    <template v-if="serviceNature === FIXED">
+      <ni-input in-modal :model-value="newSubscription.weeklyCount" type="number" required-field
+        :error="validations.weeklyCount.$error" caption="Volume hebdomadaire estimatif"
+        @blur="validations.weeklyCount.$touch" @update:model-value="update($event, 'weeklyCount')" />
+    </template>
+    <template v-else>
+      <ni-input in-modal :model-value="newSubscription.weeklyHours" type="number" required-field
+        :error="validations.weeklyHours.$error" caption="Volume hebdomadaire estimatif"
+        @blur="validations.weeklyHours.$touch" @update:model-value="update($event, 'weeklyHours')" />
+      <ni-input in-modal :model-value="newSubscription.sundays"
+        caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')" />
+      <ni-input in-modal :model-value="newSubscription.evenings"
+        caption="Dont soirée (h)" last type="number" @update:model-value="update($event, 'evenings')" />
+    </template>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Ajouter une souscription" icon-right="add" color="primary"
         :loading="loading" @click="submit" />

--- a/src/modules/client/components/customers/infos/SubscriptionCreationModal.vue
+++ b/src/modules/client/components/customers/infos/SubscriptionCreationModal.vue
@@ -8,20 +8,24 @@
       :error="validations.service.$error" />
     <ni-input in-modal :model-value="newSubscription.unitTTCRate" :error="validations.unitTTCRate.$error" required-field
       caption="Prix unitaire TTC" @blur="validations.unitTTCRate.$touch" type="number"
-      @update:model-value="update($event, 'unitTTCRate')" />
+      @update:model-value="update($event, 'unitTTCRate')" :error-message="unitTtcRateErrorMessage" />
     <template v-if="serviceNature === FIXED">
       <ni-input in-modal :model-value="newSubscription.weeklyCount" type="number" required-field
-        :error="validations.weeklyCount.$error" caption="Volume hebdomadaire estimatif"
-        @blur="validations.weeklyCount.$touch" @update:model-value="update($event, 'weeklyCount')" />
+        :error="validations.weeklyCount.$error" caption="Nombre d'interventions hebdomadaire estimatif"
+        @blur="validations.weeklyCount.$touch" @update:model-value="update($event, 'weeklyCount')"
+        :error-message="weeklyCountErrorMessage" />
     </template>
     <template v-else>
       <ni-input in-modal :model-value="newSubscription.weeklyHours" type="number" required-field
-        :error="validations.weeklyHours.$error" caption="Volume hebdomadaire estimatif"
-        @blur="validations.weeklyHours.$touch" @update:model-value="update($event, 'weeklyHours')" />
-      <ni-input in-modal :model-value="newSubscription.sundays"
-        caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')" />
-      <ni-input in-modal :model-value="newSubscription.evenings"
-        caption="Dont soirée (h)" last type="number" @update:model-value="update($event, 'evenings')" />
+        :error="validations.weeklyHours.$error" caption="Volume horaire hebdomadaire estimatif"
+        @blur="validations.weeklyHours.$touch" @update:model-value="update($event, 'weeklyHours')"
+        :error-message="weeklyHoursErrorMessage" />
+      <ni-input in-modal :model-value="newSubscription.sundays" caption="Dont dimanche (h)" type="number"
+        @update:model-value="update($event, 'sundays')" :error-message="sundaysErrorMessage"
+        :error="validations.sundays.$error" @blur="validations.sundays.$touch" />
+      <ni-input in-modal :model-value="newSubscription.evenings" caption="Dont soirée (h)" last type="number"
+        @update:model-value="update($event, 'evenings')" :error-message="eveningsErrorMessage"
+        :error="validations.evenings.$error" @blur="validations.evenings.$touch" />
     </template>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Ajouter une souscription" icon-right="add" color="primary"
@@ -35,7 +39,7 @@ import get from 'lodash/get';
 import Modal from '@components/modal/Modal';
 import Input from '@components/form/Input';
 import Select from '@components/form/Select';
-import { FIXED } from '@data/constants';
+import { FIXED, REQUIRED_LABEL } from '@data/constants';
 
 export default {
   name: 'SubscriptionCreationModal',
@@ -45,6 +49,11 @@ export default {
     serviceOptions: { type: Array, default: () => [] },
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
+    unitTtcRateErrorMessage: { type: String, default: 'poiuy' },
+    weeklyHoursErrorMessage: { type: String, default: REQUIRED_LABEL },
+    weeklyCountErrorMessage: { type: String, default: REQUIRED_LABEL },
+    eveningsErrorMessage: { type: String, default: REQUIRED_LABEL },
+    sundaysErrorMessage: { type: String, default: REQUIRED_LABEL },
   },
   components: {
     'ni-input': Input,

--- a/src/modules/client/components/customers/infos/SubscriptionEditionModal.vue
+++ b/src/modules/client/components/customers/infos/SubscriptionEditionModal.vue
@@ -6,14 +6,20 @@
     <ni-input in-modal :model-value="editedSubscription.unitTTCRate" :error="validations.unitTTCRate.$error"
       caption="Prix unitaire TTC" @blur="validations.unitTTCRate.$touch" type="number" required-field
       @update:model-value="update($event, 'unitTTCRate')" />
-    <ni-input in-modal :model-value="editedSubscription.estimatedWeeklyVolume"
-      :error="validations.estimatedWeeklyVolume.$error" caption="Volume hebdomadaire estimatif"
-      @blur="validations.estimatedWeeklyVolume.$touch" type="number" required-field
-      @update:model-value="update($event, 'estimatedWeeklyVolume')" />
-    <ni-input in-modal v-if="editedSubscription.nature !== FIXED" :model-value="editedSubscription.sundays"
-      caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')" />
-    <ni-input in-modal v-if="editedSubscription.nature !== FIXED" :model-value="editedSubscription.evenings"
-      caption="Dont soirée (h)" last type="number" @update:model-value="update($event, 'evenings')" />
+    <template v-if="editedSubscription.nature === FIXED">
+      <ni-input in-modal :model-value="editedSubscription.weeklyCount" :error="validations.weeklyCount.$error"
+        caption="Volume hebdomadaire estimatif" @blur="validations.weeklyCount.$touch" type="number" required-field
+        @update:model-value="update($event, 'weeklyCount')" />
+    </template>
+    <template v-else>
+      <ni-input in-modal :model-value="editedSubscription.weeklyHours" :error="validations.weeklyHours.$error"
+        caption="Volume hebdomadaire estimatif" @blur="validations.weeklyHours.$touch" type="number" required-field
+        @update:model-value="update($event, 'weeklyHours')" />
+      <ni-input in-modal :model-value="editedSubscription.sundays"
+        caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')" />
+      <ni-input in-modal :model-value="editedSubscription.evenings"
+        caption="Dont soirée (h)" last type="number" @update:model-value="update($event, 'evenings')" />
+    </template>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Editer la souscription" icon-right="check" color="primary"
         :loading="loading" @click="submit" />

--- a/src/modules/client/components/customers/infos/SubscriptionEditionModal.vue
+++ b/src/modules/client/components/customers/infos/SubscriptionEditionModal.vue
@@ -5,20 +5,22 @@
     </template>
     <ni-input in-modal :model-value="editedSubscription.unitTTCRate" :error="validations.unitTTCRate.$error"
       caption="Prix unitaire TTC" @blur="validations.unitTTCRate.$touch" type="number" required-field
-      @update:model-value="update($event, 'unitTTCRate')" />
+      @update:model-value="update($event, 'unitTTCRate')" :error-message="unitTtcRateErrorMessage" />
     <template v-if="editedSubscription.nature === FIXED">
       <ni-input in-modal :model-value="editedSubscription.weeklyCount" :error="validations.weeklyCount.$error"
-        caption="Volume hebdomadaire estimatif" @blur="validations.weeklyCount.$touch" type="number" required-field
-        @update:model-value="update($event, 'weeklyCount')" />
+        caption="Nombre d'interventions hebdomadaire estimatif" @blur="validations.weeklyCount.$touch" type="number"
+        @update:model-value="update($event, 'weeklyCount')" required-field :error-message="weeklyCountErrorMessage" />
     </template>
     <template v-else>
       <ni-input in-modal :model-value="editedSubscription.weeklyHours" :error="validations.weeklyHours.$error"
-        caption="Volume hebdomadaire estimatif" @blur="validations.weeklyHours.$touch" type="number" required-field
-        @update:model-value="update($event, 'weeklyHours')" />
-      <ni-input in-modal :model-value="editedSubscription.sundays"
-        caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')" />
-      <ni-input in-modal :model-value="editedSubscription.evenings"
-        caption="Dont soirée (h)" last type="number" @update:model-value="update($event, 'evenings')" />
+        caption="Volume horaire hebdomadaire estimatif" @blur="validations.weeklyHours.$touch" type="number"
+        required-field @update:model-value="update($event, 'weeklyHours')" :error-message="weeklyHoursErrorMessage" />
+      <ni-input in-modal :model-value="editedSubscription.sundays" :error-message="sundaysErrorMessage"
+        caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')"
+        :error="validations.sundays.$error" @blur="validations.sundays.$touch" />
+      <ni-input in-modal :model-value="editedSubscription.evenings" :error-message="eveningsErrorMessage"
+        caption="Dont soirée (h)" last type="number" @update:model-value="update($event, 'evenings')"
+        :error="validations.evenings.$error" @blur="validations.evenings.$touch" />
     </template>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Editer la souscription" icon-right="check" color="primary"
@@ -30,7 +32,7 @@
 <script>
 import Modal from '@components/modal/Modal';
 import Input from '@components/form/Input';
-import { FIXED } from '@data/constants';
+import { FIXED, REQUIRED_LABEL } from '@data/constants';
 
 export default {
   name: 'SubscriptionEditionModal',
@@ -40,6 +42,11 @@ export default {
     serviceOptions: { type: Array, default: () => [] },
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
+    unitTtcRateErrorMessage: { type: String, default: REQUIRED_LABEL },
+    weeklyHoursErrorMessage: { type: String, default: REQUIRED_LABEL },
+    weeklyCountErrorMessage: { type: String, default: REQUIRED_LABEL },
+    eveningsErrorMessage: { type: String, default: REQUIRED_LABEL },
+    sundaysErrorMessage: { type: String, default: REQUIRED_LABEL },
   },
   components: {
     'ni-input': Input,

--- a/src/modules/client/components/customers/infos/SubscriptionEditionModal.vue
+++ b/src/modules/client/components/customers/infos/SubscriptionEditionModal.vue
@@ -13,7 +13,7 @@
     </template>
     <template v-else>
       <ni-input in-modal :model-value="editedSubscription.weeklyHours" :error="validations.weeklyHours.$error"
-        caption="Volume horaire hebdomadaire estimatif" @blur="validations.weeklyHours.$touch" type="number"
+        caption="Volume horaire hebdomadaire estimatif (h)" @blur="validations.weeklyHours.$touch" type="number"
         required-field @update:model-value="update($event, 'weeklyHours')" :error-message="weeklyHoursErrorMessage" />
       <ni-input in-modal :model-value="editedSubscription.sundays" :error-message="sundaysErrorMessage"
         caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')"

--- a/src/modules/client/components/planning/EventHours.vue
+++ b/src/modules/client/components/planning/EventHours.vue
@@ -1,12 +1,12 @@
 <template>
   <div :class="['icon-container', $q.screen.width < 767 ? 'flex-column' : 'flex-row']">
     <div class="hour-content">
-      <p class="q-pr-xs q-mb-none" data-cy="event-start-hour">{{ startHour }}</p>
+      <div class="q-pr-xs" data-cy="event-start-hour">{{ startHour }}</div>
       <q-icon v-if="event.startDateTimeStamp" class="bold" name="check" />
     </div>
-    <p v-if="!($q.screen.width < 767)" class="q-pr-xs q-pl-xs"> - </p>
+    <div v-if="!($q.screen.width < 767)" class="q-pr-xs q-pl-xs"> - </div>
     <div class="hour-content">
-      <p class="q-pr-xs q-mb-none" data-cy="event-end-hour">{{ endHour }}</p>
+      <div class="q-pr-xs" data-cy="event-end-hour">{{ endHour }}</div>
       <q-icon v-if="event.endDateTimeStamp" class="bold" name="check" />
     </div>
   </div>

--- a/src/modules/client/helpers/tags.js
+++ b/src/modules/client/helpers/tags.js
@@ -67,7 +67,7 @@ export const getMandateTags = (customer, company, mandate) => ({
   rum: mandate.rum,
 });
 
-export const getSubscriptionQuoteTags = data => ({
+export const getTagsToGenerateQuote = data => ({
   service: {
     name: get(data, 'service.name'),
     nature: get(data, 'service.nature'),
@@ -79,19 +79,20 @@ export const getSubscriptionQuoteTags = data => ({
     },
   },
   unitTTCRate: data.unitTTCRate,
-  estimatedWeeklyVolume: data.estimatedWeeklyVolume,
+  weeklyCount: data.weeklyCount,
+  weeklyHours: data.weeklyHours,
   ...data.sundays && { sundays: data.sundays },
   ...data.evenings && { evenings: data.evenings },
 });
 
-export const getQuoteTags = (customer, company, quote) => ({
+export const getTagsToDownloadQuote = (customer, company, quote) => ({
   ...getCustomerDocumentTags({ customer, company }),
   quoteNumber: quote.quoteNumber,
   subscriptions: quote.subscriptions.map(subscription => ({
     serviceName: subscription.service.name,
     sundays: subscription.sundays ? subscription.sundays : '',
     evenings: subscription.evenings ? subscription.evenings : '',
-    weeklyVolume: subscription.estimatedWeeklyVolume,
+    weeklyVolume: subscription.weeklyHours || subscription.weeklyCount,
     serviceNature: subscription.service.nature
       ? NATURE_OPTIONS.find(nat => nat.value === subscription.service.nature).label
       : '',

--- a/src/modules/client/mixins/subscriptionMixin.js
+++ b/src/modules/client/mixins/subscriptionMixin.js
@@ -34,12 +34,10 @@ export const subscriptionMixin = {
           field: row => row.unitTTCRate && `${this.formatNumber(row.unitTTCRate)}€`,
         },
         {
-          name: 'estimatedWeeklyVolume',
+          name: 'weeklyVolume',
           label: 'Volume hebdomadaire estimatif',
           align: 'center',
-          field: row => (get(row, 'service.nature') === HOURLY
-            ? row.estimatedWeeklyVolume && `${row.estimatedWeeklyVolume}h`
-            : row.estimatedWeeklyVolume),
+          field: row => (row.weeklyHours ? `${row.weeklyHours}h` : row.weeklyCount),
         },
         {
           name: 'weeklyRate',
@@ -69,12 +67,10 @@ export const subscriptionMixin = {
           field: row => `${this.formatNumber(row.unitTTCRate)}€`,
         },
         {
-          name: 'estimatedWeeklyVolume',
+          name: 'weeklyVolume',
           label: 'Volume hebdomadaire estimatif',
           align: 'center',
-          field: row => (get(this.selectedSubscription, 'service.nature') === HOURLY
-            ? `${row.estimatedWeeklyVolume}h`
-            : row.estimatedWeeklyVolume),
+          field: row => (row.weeklyHours ? `${row.weeklyHours}h` : row.weeklyCount),
         },
         {
           name: 'evenings',

--- a/src/modules/client/mixins/subscriptionMixin.js
+++ b/src/modules/client/mixins/subscriptionMixin.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import has from 'lodash/has';
 import capitalize from 'lodash/capitalize';
 import { MONTHLY, FIXED, ONCE, HOURLY, NATURE_OPTIONS, WEEKS_PER_MONTH } from '@data/constants';
 import { getLastVersion } from '@helpers/utils';
@@ -117,13 +118,13 @@ export const subscriptionMixin = {
     },
     isCompleteFunding (funding) {
       if (!funding || funding === {}) return false;
-      if (!(funding.frequency && funding.nature && funding.customerParticipationRate)) return false;
+      if (!(funding.frequency && funding.nature && has(funding, 'customerParticipationRate'))) return false;
       if (funding.nature === FIXED && !funding.amountTTC) return false;
       if (funding.nature === HOURLY && (!funding.unitTTCRate || !funding.careHours)) return false;
       return true;
     },
     getMatchingFunding (subscription) {
-      return this.fundings.find(fd => fd.subscription === subscription._id &&
+      return this.fundings.find(fd => fd.subscription._id === subscription._id &&
         (fd.endDate ? moment().isBetween(fd.startDate, fd.endDate) : moment().isSameOrAfter(fd.startDate)));
     },
     showHistory (id) {

--- a/src/modules/client/mixins/subscriptionMixin.js
+++ b/src/modules/client/mixins/subscriptionMixin.js
@@ -11,12 +11,7 @@ export const subscriptionMixin = {
       selectedSubscription: {},
       subscriptionHistoryModal: false,
       subscriptionsColumns: [
-        {
-          name: 'service',
-          label: 'Service',
-          align: 'left',
-          field: row => get(row, 'service.name'),
-        },
+        { name: 'service', label: 'Service', align: 'left', field: row => get(row, 'service.name') },
         {
           name: 'nature',
           label: 'Nature',
@@ -45,12 +40,7 @@ export const subscriptionMixin = {
           align: 'center',
           field: row => `${this.formatNumber(this.computeWeeklyRate(row, this.getMatchingFunding(row)))}€`,
         },
-        {
-          name: 'actions',
-          label: '',
-          align: 'left',
-          field: '_id',
-        },
+        { name: 'actions', label: '', align: 'left', field: '_id' },
       ],
       subscriptionHistoryColumns: [
         {
@@ -85,11 +75,7 @@ export const subscriptionMixin = {
           field: row => (row.sundays ? `${row.sundays}h` : ''),
         },
       ],
-      paginationHistory: {
-        rowsPerPage: 0,
-        sortBy: 'createdAt',
-        descending: true,
-      },
+      paginationHistory: { rowsPerPage: 0, sortBy: 'createdAt', descending: true },
       subscriptionsLoading: false,
     };
   },
@@ -151,12 +137,8 @@ export const subscriptionMixin = {
     refreshSubscriptions (customer) {
       try {
         this.subscriptionsLoading = true;
-        const { subscriptions } = customer;
-        this.subscriptions = subscriptions
-          ? subscriptions.map(sub => ({
-            ...getLastVersion(sub.versions, 'createdAt'),
-            ...sub,
-          }))
+        this.subscriptions = customer.subscriptions
+          ? customer.subscriptions.map(sub => ({ ...getLastVersion(sub.versions, 'createdAt'), ...sub }))
           : [];
       } catch (e) {
         console.error(e);

--- a/src/modules/client/mixins/subscriptionMixin.js
+++ b/src/modules/client/mixins/subscriptionMixin.js
@@ -98,8 +98,11 @@ export const subscriptionMixin = {
       return parseFloat(Math.round(number * 100) / 100).toFixed(2);
     },
     computeWeeklyRate (subscription, funding) {
-      let weeklyRate = subscription.unitTTCRate * subscription.estimatedWeeklyVolume;
-      if (get(subscription, 'service.surcharge', null)) {
+      let weeklyRate = subscription.weeklyHours
+        ? subscription.unitTTCRate * subscription.weeklyHours
+        : subscription.unitTTCRate * subscription.weeklyCount;
+
+      if (get(subscription, 'service.surcharge')) {
         if (subscription.sundays && subscription.service.surcharge.sunday) {
           weeklyRate += subscription.sundays * subscription.unitTTCRate * subscription.service.surcharge.sunday / 100;
         }
@@ -115,7 +118,7 @@ export const subscriptionMixin = {
           } else {
             const refundedHours = Math.min(
               funding.frequency === MONTHLY ? funding.careHours / WEEKS_PER_MONTH : funding.careHours,
-              subscription.estimatedWeeklyVolume
+              subscription.weeklyHours
             );
             fundingReduction = refundedHours * funding.unitTTCRate;
           }

--- a/test/cypress/integration/customer/subscription.spec.js
+++ b/test/cypress/integration/customer/subscription.spec.js
@@ -23,7 +23,7 @@ describe('customers subscription tests', () => {
     cy.dataCy('col-service').should('contain', 'Service 1');
     cy.dataCy('col-nature').should('contain', 'Horaire');
     cy.dataCy('col-unitTTCRate').should('contain', '12.00€');
-    cy.dataCy('col-estimatedWeeklyVolume').should('contain', '12h');
+    cy.dataCy('col-weeklyVolume').should('contain', '12h');
     cy.dataCy('col-weeklyRate').should('contain', '144.00€');
   });
 
@@ -51,13 +51,13 @@ describe('customers subscription tests', () => {
 
       cy.dataCy('col-createdAt').eq(0).should('contain', '01/01/2020');
       cy.dataCy('col-unitTTCRate').eq(0).should('contain', '12.00€');
-      cy.dataCy('col-estimatedWeeklyVolume').eq(0).should('contain', '12h');
+      cy.dataCy('col-weeklyVolume').eq(0).should('contain', '12h');
       cy.dataCy('col-evenings').eq(0).should('contain', '2');
       cy.dataCy('col-sundays').eq(0).should('contain', '1');
 
       cy.dataCy('col-createdAt').eq(1).should('contain', '01/06/2019');
       cy.dataCy('col-unitTTCRate').eq(1).should('contain', '10.00€');
-      cy.dataCy('col-estimatedWeeklyVolume').eq(1).should('contain', '8h');
+      cy.dataCy('col-weeklyVolume').eq(1).should('contain', '8h');
       cy.dataCy('col-evenings').eq(1).should('contain', '');
       cy.dataCy('col-sundays').eq(1).should('contain', '2');
     });


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach/aidant

- Cas d'usage : refacto estimatedWeeklyVolume en weeklyHours et weeklyCount
- Le test end2end de la page souscription aidant devrait fonctionner

- Comment tester ? : 

_ETQ coach_ 
- je peux creer, modifier, supprimer une souscription; 
- je peux créer un devis
- sur l'export des souscriptions j'ai bien les bonnes infos pour des services horaires ou forfaitaire
- Je peux facturer un beneficiaire avec une souscription forfaitaire/horaire et avec/sans tiers payeurs

_ETQ aidant_ 
- je peux voir mes souscriptions, le details de celles-ci et des financements dans les modales
- je peux valider les souscriptions. 

_Si tu as lu cette description, pense a réagir avec un :eye:_
