### PR TITLE
COM-2670 - Fix date-input bug

### DIFF
--- a/src/modules/client/components/contracts/VersionCreationModal.vue
+++ b/src/modules/client/components/contracts/VersionCreationModal.vue
@@ -5,7 +5,7 @@
     </template>
     <ni-input in-modal caption="Volume horaire hebdomadaire" :model-value="newVersion.weeklyHours" type="number"
       :error="validations.weeklyHours.$error" :error-message="weeklyHoursError" @blur="validations.weeklyHours.$touch"
-       @update:model-value="update($event, 'weeklyHours')" suffix="h" required-field />
+      @update:model-value="update($event, 'weeklyHours')" suffix="h" required-field />
     <ni-input in-modal caption="Taux horaire" :error="validations.grossHourlyRate.$error" type="number" suffix="€"
       :model-value="newVersion.grossHourlyRate" required-field @update:model-value="update($event, 'grossHourlyRate')"
       @blur="validations.grossHourlyRate.$touch" :error-message="grossHourlyRateError" />

--- a/src/modules/client/components/contracts/VersionEditionModal.vue
+++ b/src/modules/client/components/contracts/VersionEditionModal.vue
@@ -9,7 +9,7 @@
     <ni-date-input :model-value="editedVersion.startDate" :min="minStartDate" :error="validations.startDate.$error"
       @update:model-value="update($event, 'startDate')" required-field @blur="validations.startDate.$touch"
       :error-message="startDateError" :class="[!validations.startDate.minDate && $q.platform.is.mobile && 'q-mb-sm']"
-       in-modal caption="Date d'effet" />
+      in-modal caption="Date d'effet" />
     <div class="margin-input last">
       <q-checkbox dense :model-value="editedVersion.shouldBeSigned" label="Signature en ligne"
         @update:model-value="update($event, 'shouldBeSigned')" />

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -12,7 +12,8 @@
         <ni-select caption="Civilité" :error="v$.customer.identity.title.$error" v-model="customer.identity.title"
           :options="civilityOptions" @focus="saveTmp('identity.title')" @blur="updateCustomer('identity.title')" />
         <ni-date-input v-model="customer.identity.birthDate" @focus="saveTmp('identity.birthDate')"
-          caption="Date de naissance" @blur="updateCustomer('identity.birthDate')" content-class="col-xs-12 col-md-6" />
+          caption="Date de naissance" @update:model-value="updateCustomer('identity.birthDate')"
+          content-class="col-xs-12 col-md-6" />
       </div>
     </div>
     <div class="q-mb-xl">
@@ -138,7 +139,7 @@
                     :disable="docLoading || !getDriveId(props.row)" />
                 </template>
                 <template v-else-if="col.name === 'signedAt'">
-                  <ni-date-input @blur="updateSignedAt(props.row)" in-modal
+                  <ni-date-input in-modal @update:model-value="updateSignedAt(props.row)"
                     v-model="customer.payment.mandates[getRowIndex(customer.payment.mandates, props.row)].signedAt"
                     @focus="saveTmpSignedAt(getRowIndex(customer.payment.mandates, props.row))" />
                 </template>


### PR DESCRIPTION
Bug : 
ETQ admin / coach, je ne pouvais plus modifier la date d'anniversaire ni la date de signature de mandat d'un bénéficiaire, via l'outil de selection de date (on pouvait toujours remplir le champ au clavier).

D'où venait le bug : 
La fonction `focus` enregistre la valeur du champ dans un `tmpInput`.
Cette fonction est malheureusement appelée quand on clique sur une date.
La fonction `update` du champ est appelée au `blur` et elle vérifie que tmpInput est différent de la valeur qu'on lui donne.
Cependant vu que `update` est appelée après `focus`, tmpInput était toujours égal à la valeur du champ et donc rien ne se passait.

Correction : 
J'ai passé l'update du champ sur `update:model-value` plutôt que `blur` car `update:model-value` est appelée avant focus.

Le ticket ne parle que du champ date sur les mandats mais le bug était aussi présent sur la date d'anniversaire. Je suis repassé sur tous les champs date utilisant un focus et seul ces deux champs était impacté par le bug.
Un autre champ date utilise un focus sur ProfileInfo auxiliary et c'est comme ça que j'ai trouvé la solution car ce champ fonctionnait bien.