### PR TITLE
Com 2710

### DIFF
--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -249,6 +249,7 @@
       :weekly-hours-error-message="weeklyHoursErrorMessage(v$.editedSubscription)" :loading="loading"
       :weekly-count-error-message="weeklyCountErrorMessage(v$.editedSubscription)" @hide="resetEditionSubscriptionData"
       :evenings-error-message="eveningsErrorMessage(v$.editedSubscription)" :validations="v$.editedSubscription"
+      :saturdays-error-message="saturdaysErrorMessage(v$.editedSubscription)"
       :sundays-error-message="sundaysErrorMessage(v$.editedSubscription)" />
 
     <subscription-history-modal v-model="subscriptionHistoryModal" :subscription="selectedSubscription"
@@ -794,7 +795,16 @@ export default {
     },
     openSubscriptionEditionModal (id) {
       const selectedSubscription = this.subscriptions.find(sub => sub._id === id);
-      const { _id, service, unitTTCRate, weeklyHours, weeklyCount, evenings, sundays } = selectedSubscription;
+      const {
+        _id,
+        service,
+        unitTTCRate,
+        weeklyHours,
+        weeklyCount,
+        evenings,
+        saturdays,
+        sundays,
+      } = selectedSubscription;
 
       this.editedSubscription = {
         _id,
@@ -803,6 +813,7 @@ export default {
         weeklyHours: weeklyHours || 0,
         weeklyCount: weeklyCount || 0,
         evenings: evenings || 0,
+        saturdays: saturdays || 0,
         sundays: sundays || 0,
         billingItems: service.billingItems,
       };
@@ -814,9 +825,10 @@ export default {
       this.v$.editedSubscription.$reset();
     },
     formatEditedSubscription () {
+      const hourlySubscriptionFields = ['saturdays', 'sundays', 'evenings', 'weeklyHours'];
       return {
         ...pickBy(pick(this.editedSubscription, ['unitTTCRate', 'weeklyCount'])),
-        ...(this.isHourlySubscription && pickBy(pick(this.editedSubscription, ['sundays', 'evenings', 'weeklyHours']))),
+        ...(this.isHourlySubscription && pickBy(pick(this.editedSubscription, hourlySubscriptionFields))),
       };
     },
     async updateSubscription () {

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -241,7 +241,8 @@
       :weekly-count-error-message="weeklyCountErrorMessage(v$.newSubscription)" @submit="createSubscription"
       :evenings-error-message="eveningsErrorMessage(v$.newSubscription)" @hide="resetCreationSubscriptionData"
       :sundays-error-message="sundaysErrorMessage(v$.newSubscription)" :validations="v$.newSubscription"
-      :unit-ttc-rate-error-message="unitTTCRateErrorMessage(v$.newSubscription)" :service-options="serviceOptions" />
+      :unit-ttc-rate-error-message="unitTTCRateErrorMessage(v$.newSubscription)" :service-options="serviceOptions"
+      :saturdays-error-message="saturdaysErrorMessage(v$.newSubscription)" />
 
     <subscription-edition-modal v-model="openEditedSubscriptionModal" v-model:edited-subscription="editedSubscription"
       @submit="updateSubscription" :unit-ttc-rate-error-message="unitTTCRateErrorMessage(v$.editedSubscription)"
@@ -382,7 +383,15 @@ export default {
         { name: 'signed', label: 'Signé', align: 'center', field: row => row.drive && row.drive.driveId },
       ],
       quotesLoading: false,
-      newSubscription: { service: '', unitTTCRate: 0, weeklyHours: 0, weeklyCount: 0, sundays: 0, evenings: 0 },
+      newSubscription: {
+        service: '',
+        unitTTCRate: 0,
+        weeklyHours: 0,
+        weeklyCount: 0,
+        saturdays: 0,
+        sundays: 0,
+        evenings: 0,
+      },
       editedSubscription: {},
       mandatesColumns: [
         { name: 'rum', label: 'RUM', align: 'left', field: 'rum' },
@@ -516,6 +525,7 @@ export default {
           minValue: minValue(0),
           integer: integerNumber,
         },
+        saturdays: { minValue: minValue(0) },
         sundays: { minValue: minValue(0) },
         evenings: { minValue: minValue(0) },
       };
@@ -648,6 +658,9 @@ export default {
     eveningsErrorMessage (validations) {
       return this.numberErrorMessage(validations.evenings);
     },
+    saturdaysErrorMessage (validations) {
+      return this.numberErrorMessage(validations.saturdays);
+    },
     sundaysErrorMessage (validations) {
       return this.numberErrorMessage(validations.sundays);
     },
@@ -739,11 +752,12 @@ export default {
     },
     // Subscriptions
     formatCreatedSubscription () {
+      const hourlySubscriptionFields = ['saturdays', 'sundays', 'evenings', 'weeklyHours'];
       return {
         service: this.newSubscription.service,
         versions: [{
           ...pickBy(pick(this.newSubscription, ['unitTTCRate', 'weeklyCount'])),
-          ...(this.isHourlySubscription && pickBy(pick(this.newSubscription, ['sundays', 'evenings', 'weeklyHours']))),
+          ...(this.isHourlySubscription && pickBy(pick(this.newSubscription, hourlySubscriptionFields))),
         }],
       };
     },
@@ -754,6 +768,7 @@ export default {
         unitTTCRate: 0,
         weeklyHours: 0,
         weeklyCount: 0,
+        saturdays: 0,
         sundays: 0,
         evenings: 0,
       };

--- a/src/modules/client/components/customers/infos/SubscriptionCreationModal.vue
+++ b/src/modules/client/components/customers/infos/SubscriptionCreationModal.vue
@@ -20,6 +20,9 @@
         :error="validations.weeklyHours.$error" caption="Volume horaire hebdomadaire estimatif (h)"
         @blur="validations.weeklyHours.$touch" @update:model-value="update($event, 'weeklyHours')"
         :error-message="weeklyHoursErrorMessage" />
+      <ni-input in-modal :model-value="newSubscription.saturdays" caption="Dont samedi (h)" type="number"
+        @update:model-value="update($event, 'saturdays')" :error-message="saturdaysErrorMessage"
+        :error="validations.saturdays.$error" @blur="validations.saturdays.$touch" />
       <ni-input in-modal :model-value="newSubscription.sundays" caption="Dont dimanche (h)" type="number"
         @update:model-value="update($event, 'sundays')" :error-message="sundaysErrorMessage"
         :error="validations.sundays.$error" @blur="validations.sundays.$touch" />
@@ -53,6 +56,7 @@ export default {
     weeklyHoursErrorMessage: { type: String, default: REQUIRED_LABEL },
     weeklyCountErrorMessage: { type: String, default: REQUIRED_LABEL },
     eveningsErrorMessage: { type: String, default: REQUIRED_LABEL },
+    saturdaysErrorMessage: { type: String, default: REQUIRED_LABEL },
     sundaysErrorMessage: { type: String, default: REQUIRED_LABEL },
   },
   components: {

--- a/src/modules/client/components/customers/infos/SubscriptionEditionModal.vue
+++ b/src/modules/client/components/customers/infos/SubscriptionEditionModal.vue
@@ -15,6 +15,9 @@
       <ni-input in-modal :model-value="editedSubscription.weeklyHours" :error="validations.weeklyHours.$error"
         caption="Volume horaire hebdomadaire estimatif (h)" @blur="validations.weeklyHours.$touch" type="number"
         required-field @update:model-value="update($event, 'weeklyHours')" :error-message="weeklyHoursErrorMessage" />
+      <ni-input in-modal :model-value="editedSubscription.saturdays" :error-message="saturdaysErrorMessage"
+        caption="Dont samedi (h)" type="number" @update:model-value="update($event, 'saturdays')"
+        :error="validations.saturdays.$error" @blur="validations.saturdays.$touch" />
       <ni-input in-modal :model-value="editedSubscription.sundays" :error-message="sundaysErrorMessage"
         caption="Dont dimanche (h)" type="number" @update:model-value="update($event, 'sundays')"
         :error="validations.sundays.$error" @blur="validations.sundays.$touch" />
@@ -46,6 +49,7 @@ export default {
     weeklyHoursErrorMessage: { type: String, default: REQUIRED_LABEL },
     weeklyCountErrorMessage: { type: String, default: REQUIRED_LABEL },
     eveningsErrorMessage: { type: String, default: REQUIRED_LABEL },
+    saturdaysErrorMessage: { type: String, default: REQUIRED_LABEL },
     sundaysErrorMessage: { type: String, default: REQUIRED_LABEL },
   },
   components: {


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- ~~[ ] J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client / admin - coach

- Cas d'usage :
Lorsque j'ajoute une souscription, je peux ajouter une majoration sur le samedi (je peux aussi éditer ce champ)

- Comment tester ? :
Dans l'onglet info de la fiche bénéficiaire, ajouter / Editer une souscription avec une majoration le samedi

_Si tu as lu cette description, pense a réagir avec un :eye:_
