### PR TITLE
Com 2709 fix

### DIFF
--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -521,16 +521,18 @@ export default {
         unitTTCRate: { required, minValue: value => value > 0 },
         weeklyHours: {
           required: requiredIf(this.isHourlySubscription),
-          checkValue: value => (!(value && !this.isHourlySubscription) && value && value > 0) ||
-            (!value && !this.isHourlySubscription),
+          checkValue: (value) => {
+            const isForbidden = !this.isHourlySubscription;
+            return (!isForbidden && value && value > 0) || (!value && isForbidden);
+          },
         },
         weeklyCount: {
           required: requiredIf(!this.isHourlySubscription),
           integer: integerNumber,
-          checkValue: value => (
-            (!(value && this.isHourlySubscription && !this.serviceHasBillingItems) && value && value > 0) ||
-              (!value && this.isHourlySubscription && !this.serviceHasBillingItems)
-          ),
+          checkValue: (value) => {
+            const isForbidden = this.isHourlySubscription && !this.serviceHasBillingItems;
+            return (!isForbidden && value && value > 0) || (!value && isForbidden);
+          },
         },
         saturdays: { minValue: minValue(0) },
         sundays: { minValue: minValue(0) },

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -514,6 +514,7 @@ export default {
       const selectedService = this.openNewSubscriptionModal
         ? this.serviceOptions.find(s => s.value === this.newSubscription.service)
         : this.editedSubscription;
+
       return !!get(selectedService, 'billingItems.length') || false;
     },
     getSubscriptionValidation () {
@@ -527,7 +528,7 @@ export default {
           },
         },
         weeklyCount: {
-          required: requiredIf(!this.isHourlySubscription),
+          required: requiredIf(!this.isHourlySubscription || this.serviceHasBillingItems),
           integer: integerNumber,
           checkValue: (value) => {
             const isForbidden = this.isHourlySubscription && !this.serviceHasBillingItems;

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -752,6 +752,9 @@ export default {
       this.v$.customer.$touch();
     },
     // Subscriptions
+    isDefinedOrZero (value) {
+      return !!value || value === 0;
+    },
     formatCreatedSubscription () {
       const hourlySubscriptionFields = ['saturdays', 'sundays', 'evenings', 'weeklyHours'];
       return {

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -526,6 +526,7 @@ export default {
         },
         weeklyCount: {
           required: requiredIf(!this.isHourlySubscription),
+          integer: integerNumber,
           checkValue: value => (
             (!(value && this.isHourlySubscription && !this.serviceHasBillingItems) && value && value > 0) ||
               (!value && this.isHourlySubscription && !this.serviceHasBillingItems)

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -520,20 +520,11 @@ export default {
     getSubscriptionValidation () {
       return {
         unitTTCRate: { required, minValue: value => value > 0 },
-        weeklyHours: {
-          required: requiredIf(this.isHourlySubscription),
-          checkValue: (value) => {
-            const isForbidden = !this.isHourlySubscription;
-            return (!isForbidden && value && value > 0) || (!value && isForbidden);
-          },
-        },
+        weeklyHours: { ...(this.isHourlySubscription && { required, minValue: value => value > 0 }) },
         weeklyCount: {
-          required: requiredIf(!this.isHourlySubscription || this.serviceHasBillingItems),
+          ...((!this.isHourlySubscription || this.serviceHasBillingItems) &&
+            { required, minValue: value => value > 0 }),
           integer: integerNumber,
-          checkValue: (value) => {
-            const isForbidden = this.isHourlySubscription && !this.serviceHasBillingItems;
-            return (!isForbidden && value && value > 0) || (!value && isForbidden);
-          },
         },
         saturdays: { minValue: minValue(0) },
         sundays: { minValue: minValue(0) },
@@ -655,9 +646,7 @@ export default {
     numberErrorMessage (field) {
       if (get(field, 'required.$response') === false) return REQUIRED_LABEL;
 
-      const isInvalidNumber = !get(field, 'minValue.$response') ||
-        !get(field, 'integer.$response') ||
-        !get(field, 'checkValue.$response');
+      const isInvalidNumber = !get(field, 'minValue.$response') || !get(field, 'integer.$response');
       if (isInvalidNumber) return INVALID_NUMBER;
 
       return '';

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -654,9 +654,12 @@ export default {
     },
     numberErrorMessage (field) {
       if (get(field, 'required.$response') === false) return REQUIRED_LABEL;
-      if (get(field, 'minValue.$response') === false || get(field, 'integer.$response') === false) {
-        return INVALID_NUMBER;
-      }
+
+      const isInvalidNumber = !get(field, 'minValue.$response') ||
+        !get(field, 'integer.$response') ||
+        !get(field, 'checkValue.$response');
+      if (isInvalidNumber) return INVALID_NUMBER;
+
       return '';
     },
     weeklyHoursErrorMessage (validations) {


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : COACH

- Cas d'usage : Les validations fonctionnent pour tous les cas de tests ci-dessous.

- Comment tester ? : 
Je ne peux pas creer/editer de souscription:
     - liee a un service forfaitaire si : 
         - `Prix unitaire TTC` est nul
         -  `Nombre d'interventions hebdomadaire estimatif` est nul 
     - liee a un service horaire sans article de facturation si:
         -  `Prix unitaire TTC` est nul
         - `Volume horaire hebdomadaire estimatif ` est nul 
     - liee a un service horaire avec article de facturation si:
         - `Prix unitaire TTC` est nul
         - `Volume horaire hebdomadaire estimatif ` est nul 
         - `Nombre d'interventions hebdomadaire estimatif` est nul

Je peux creer/ editer des souscriptions.

_Si tu as lu cette description, pense a réagir avec un :eye:_
