### PR TITLE
COM-2710 - Add saturday to subscription history and data export

### DIFF
--- a/src/modules/client/mixins/subscriptionMixin.js
+++ b/src/modules/client/mixins/subscriptionMixin.js
@@ -76,8 +76,14 @@ export const subscriptionMixin = {
           field: row => (row.evenings ? `${row.evenings}h` : ''),
         },
         {
+          name: 'saturdays',
+          label: 'dont samedis',
+          align: 'center',
+          field: row => (row.saturdays ? `${row.saturdays}h` : ''),
+        },
+        {
           name: 'sundays',
-          label: 'dont dimanche',
+          label: 'dont dimanches',
           align: 'center',
           field: row => (row.sundays ? `${row.sundays}h` : ''),
         },

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -346,6 +346,7 @@ export default {
         startDate: lastVersion.startDate,
         ...(lastVersion.weeklyHours && { weeklyHours: lastVersion.weeklyHours }),
         ...(lastVersion.evenings && { evenings: lastVersion.evenings }),
+        ...(lastVersion.saturdays && { saturdays: lastVersion.saturdays }),
         ...(lastVersion.sundays && { sundays: lastVersion.sundays }),
       };
     },


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- ~~[ ] J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client / admin -coach

- Cas d'usage :
Lorsque j'ajoute/édite une souscription avec une majoration le samedi -> je retrouve l'info dans l'historique
J'ai aussi l'info dans l'export des données de souscriptions

- Comment tester ? :
Dans profil benef onglet infos -> ajoute/édite une souscription avec une majoration le samedi -> clique sur le bouton historique
Télécharge  l'export des données de souscriptions

_Si tu as lu cette description, pense a réagir avec un :eye:_
