### PR TITLE
Com 2705

### DIFF
--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -52,36 +52,38 @@
           </template>
           <template #expanding-row="{ props }">
             <q-td colspan="100%">
-              <div v-for="(step, stepIndex) in props.row.subProgram.steps" :key="step._id" :props="props">
-                <div class="q-ma-sm row">
+              <div v-if="getStepsByType(props.row.subProgram.steps, [ON_SITE, REMOTE]).length"
+                class="text-weight-bold q-mb-sm">
+                Présences
+              </div>
+              <div v-for="step in getStepsByType(props.row.subProgram.steps, [ON_SITE, REMOTE])" :key="step._id"
+                :props="props" class="q-mb-xs">
+                <div v-for="slot in step.slots" :key="slot._id" class="q-ml-md row">
                   <q-icon :name="getStepTypeIcon(step.type)" />
-                  {{ stepIndex + 1 }} - {{ step.name }}
-                  <div class="step-progress">
-                    <div v-if="has(step, 'progress.presence')">
-                      {{ formatDuration(get(step, 'progress.presence.attendanceDuration')) }}
-                      / {{ formatDuration(get(step, 'progress.presence.maxDuration')) }}
-                    </div>
-                    <ni-progress v-if="has(step, 'progress.eLearning')" class="expanding-table-sub-progress"
-                      :value="step.progress.eLearning" />
+                  <div class="col-6">{{ step.name }}</div>
+                  <div class="dates col-2">{{ formatDate(slot.startDate) }}</div>
+                  <div class="hours  col-2">{{ formatIntervalHourly(slot) }} ({{ getDuration(slot) }})</div>
+                  <div v-if="slot.attendances.length" class="attendance">
+                    <q-icon size="12px" name="check_circle" color="green-600" />
+                    <span class="text-green-600">Présent(e)</span>
+                  </div>
+                  <div v-else-if="isBefore(new Date(), slot.endDate)" class="attendance">
+                    <span class="q-mx-sm text-italic text-copper-grey-800">à venir</span>
+                  </div>
+                  <div v-else class="attendance">
+                    <q-icon size="12px" name="fas fa-times-circle" color="orange-700" />
+                    <span class="text-orange-700">Absent(e)</span>
                   </div>
                 </div>
-                <div v-if="step.slots.length">
-                  <div v-for="slot in step.slots" :key="slot._id" class="slot row">
-                    <div class="dates">{{ formatDate(slot.startDate) }}</div>
-                    <div class="hours">{{ formatIntervalHourly(slot) }} ({{ getDuration(slot) }})</div>
-                    <div v-if="slot.attendances.length" class="attendance">
-                      <q-icon size="12px" name="check_circle" color="green-600" />
-                      <span class="text-green-600">Présent(e)</span>
-                    </div>
-                    <div v-else-if="isBefore(new Date(), slot.endDate)" class="attendance">
-                      <span class="q-mx-sm text-italic text-copper-grey-800">à venir</span>
-                    </div>
-                    <div v-else class="attendance">
-                      <q-icon size="12px" name="fas fa-times-circle" color="orange-700" />
-                      <span class="text-orange-700">Absent(e)</span>
-                    </div>
-                  </div>
-                </div>
+              </div>
+              <div v-if="getStepsByType(props.row.subProgram.steps, [E_LEARNING])" class="text-weight-bold q-my-sm">
+                Complétion eLearning
+              </div>
+              <div v-for="step in getStepsByType(props.row.subProgram.steps, [E_LEARNING])" :key="step._id"
+                :props="props" class="q-mb-xs q-ml-md row">
+                <q-icon name="stay_current_portrait" />
+                <div class="col-9">{{ step.name }}</div>
+                <ni-progress class="expanding-table-sub-progress" :value="step.progress.eLearning" />
               </div>
             </q-td>
           </template>
@@ -118,7 +120,7 @@ import has from 'lodash/has';
 import uniqBy from 'lodash/uniqBy';
 import Courses from '@api/Courses';
 import Attendances from '@api/Attendances';
-import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING } from '@data/constants';
+import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
 import { sortStrings, formatIdentity } from '@helpers/utils';
 import {
   isBetween,
@@ -190,6 +192,8 @@ export default {
         { name: 'expand', label: '', field: '' },
       ],
       E_LEARNING,
+      ON_SITE,
+      REMOTE,
       unsubscribedAttendances: [],
     };
   },
@@ -318,6 +322,9 @@ export default {
         NotifyNegative('Erreur lors de la récupération des émargements non prévus.');
       }
     },
+    getStepsByType (steps, types) {
+      return steps.filter(step => types.includes(step.type));
+    },
     formatDate,
     formatIntervalHourly,
     getDuration,
@@ -371,12 +378,4 @@ export default {
 
 .misc
   width: 15%
-.attendance
-  @media screen and (min-width: 767px)
-    width: 15%
-
-.slot
-  margin: 0px 40px
-  @media screen and (max-width: 767px)
-    justify-content: space-between
 </style>

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -61,14 +61,14 @@
                   <div class="col-6">{{ step.name }}</div>
                   <div class="dates col-2">{{ formatDate(slot.startDate) }}</div>
                   <div class="hours col-2">{{ formatIntervalHourly(slot) }} ({{ getDuration(slot) }})</div>
-                  <div v-if="slot.attendances.length">
+                  <div v-if="slot.attendances.length" class="col-1">
                     <q-icon size="12px" name="check_circle" color="green-600" />
                     <span class="text-green-600">Présent(e)</span>
                   </div>
-                  <div v-else-if="isBefore(new Date(), slot.endDate)">
+                  <div v-else-if="isBefore(new Date(), slot.endDate)" class="col-1">
                     <span class="q-mx-sm text-italic text-copper-grey-800">à venir</span>
                   </div>
-                  <div v-else>
+                  <div v-else class="col-1">
                     <q-icon size="12px" name="fas fa-times-circle" color="orange-700" />
                     <span class="text-orange-700">Absent(e)</span>
                   </div>
@@ -81,7 +81,7 @@
                 :props="props">
                 <q-icon name="stay_current_portrait" />
                 <div class="col-9">{{ step.name }}</div>
-                <ni-progress class="expanding-table-sub-progress" :value="step.progress.eLearning" />
+                <ni-progress class="expanding-table-sub-progress col-2" :value="step.progress.eLearning" />
               </div>
             </q-td>
           </template>

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -52,9 +52,7 @@
           </template>
           <template #expanding-row="{ props }">
             <q-td colspan="100%">
-              <div v-if="props.row.subProgram.liveSteps.length" class="text-weight-bold q-mb-sm">
-                Présences
-              </div>
+              <div v-if="props.row.subProgram.liveSteps.length" class="text-weight-bold q-mb-sm">Présences</div>
               <div v-for="step in props.row.subProgram.liveSteps" :key="step._id" :props="props" class="q-mb-xs">
                 <div v-for="slot in step.slots" :key="slot._id" class="q-ml-md row">
                   <q-icon :name="getStepTypeIcon(step.type)" />

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -53,21 +53,21 @@
           <template #expanding-row="{ props }">
             <q-td colspan="100%">
               <div v-if="props.row.subProgram.liveSteps.length" class="text-weight-bold q-mb-sm">Présences</div>
-              <div v-for="step in props.row.subProgram.liveSteps" :key="step._id" :props="props" class="q-mb-xs">
-                <div v-for="slot in step.slots" :key="slot._id" class="q-ml-md row">
+              <div v-for="step in props.row.subProgram.liveSteps" :key="step._id" :props="props" class="q-mb-sm">
+                <div v-for="slot in step.slots" :key="slot._id" class="q-ml-md slots">
                   <q-icon :name="getStepTypeIcon(step.type)" />
-                  <div class="col-6">{{ step.name }}</div>
-                  <div class="dates col-2">{{ formatDate(slot.startDate) }}</div>
-                  <div class="hours col-2">{{ formatIntervalHourly(slot) }} ({{ getDuration(slot) }})</div>
-                  <div v-if="slot.attendances.length" class="col-1">
-                    <q-icon size="12px" name="check_circle" color="green-600" />
+                  <div class="step-name">{{ step.name }}</div>
+                  <div class="dates">{{ formatDate(slot.startDate) }}</div>
+                  <div class="hours">{{ formatIntervalHourly(slot) }} ({{ getDuration(slot) }})</div>
+                  <div v-if="slot.attendances.length">
+                    <q-icon size="12px" name="check_circle" color="green-600 attendance" />
                     <span class="text-green-600">Présent(e)</span>
                   </div>
-                  <div v-else-if="isBefore(new Date(), slot.endDate)" class="col-1">
+                  <div v-else-if="isBefore(new Date(), slot.endDate)" class="attendance">
                     <span class="q-mx-sm text-italic text-copper-grey-800">à venir</span>
                   </div>
-                  <div v-else class="col-1">
-                    <q-icon size="12px" name="fas fa-times-circle" color="orange-700" />
+                  <div v-else>
+                    <q-icon size="12px" name="fas fa-times-circle" color="orange-700 attendance" />
                     <span class="text-orange-700">Absent(e)</span>
                   </div>
                 </div>
@@ -365,11 +365,23 @@ export default {
   display: flex
   color: $primary
 
+.slots
+  @media screen and (min-width: 767px)
+    display: flex
+
+.step-name
+  @media screen and (min-width: 767px)
+    width: 50%
+
 .dates
   @media screen and (min-width: 767px)
     width: 10%
 
 .hours
+  @media screen and (min-width: 767px)
+    width: 15%
+
+.attendance
   @media screen and (min-width: 767px)
     width: 15%
 

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -52,25 +52,23 @@
           </template>
           <template #expanding-row="{ props }">
             <q-td colspan="100%">
-              <div v-if="props.row.subProgram.liveSteps.length"
-                class="text-weight-bold q-mb-sm">
+              <div v-if="props.row.subProgram.liveSteps.length" class="text-weight-bold q-mb-sm">
                 Présences
               </div>
-              <div v-for="step in props.row.subProgram.liveSteps" :key="step._id"
-                :props="props" class="q-mb-xs">
+              <div v-for="step in props.row.subProgram.liveSteps" :key="step._id" :props="props" class="q-mb-xs">
                 <div v-for="slot in step.slots" :key="slot._id" class="q-ml-md row">
                   <q-icon :name="getStepTypeIcon(step.type)" />
                   <div class="col-6">{{ step.name }}</div>
                   <div class="dates col-2">{{ formatDate(slot.startDate) }}</div>
-                  <div class="hours  col-2">{{ formatIntervalHourly(slot) }} ({{ getDuration(slot) }})</div>
-                  <div v-if="slot.attendances.length" class="attendance">
+                  <div class="hours col-2">{{ formatIntervalHourly(slot) }} ({{ getDuration(slot) }})</div>
+                  <div v-if="slot.attendances.length">
                     <q-icon size="12px" name="check_circle" color="green-600" />
                     <span class="text-green-600">Présent(e)</span>
                   </div>
-                  <div v-else-if="isBefore(new Date(), slot.endDate)" class="attendance">
+                  <div v-else-if="isBefore(new Date(), slot.endDate)">
                     <span class="q-mx-sm text-italic text-copper-grey-800">à venir</span>
                   </div>
-                  <div v-else class="attendance">
+                  <div v-else>
                     <q-icon size="12px" name="fas fa-times-circle" color="orange-700" />
                     <span class="text-orange-700">Absent(e)</span>
                   </div>
@@ -79,8 +77,8 @@
               <div v-if="props.row.subProgram.elearningSteps.length" class="text-weight-bold q-my-sm">
                 Complétion eLearning
               </div>
-              <div v-for="step in props.row.subProgram.elearningSteps" :key="step._id"
-                :props="props" class="q-mb-xs q-ml-md row">
+              <div v-for="step in props.row.subProgram.elearningSteps" :key="step._id" class="q-mb-xs q-ml-md row"
+                :props="props">
                 <q-icon name="stay_current_portrait" />
                 <div class="col-9">{{ step.name }}</div>
                 <ni-progress class="expanding-table-sub-progress" :value="step.progress.eLearning" />


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : compani-foramtion interfaces vendeur et client / rof et coach

- Cas d'usage :
    -  dans la page d'un.e apprenant.e, le tableau de la "completion" des formations a changé
    - j'ai choisi de  changer par rapport a la strat :  je faire un formatage des formations juste apres les avoir recuperé depuis l'api. C'est a cause de l'affichage conditionnel des titres "presences" et "completion eLearning", sans ca il fallait appeler deux fois de suite "getStepsByType" dans l'html

- Comment tester ?
    - verifier avec figma
    - tester une formation 100% elearning, une formation mixte, une formation 100% live
    - mettre plusieurs creneaux sur une etape, verifier l'ordre chronologique au sein de l'etape
    - tester les trois types de presence : a venir, absent.e, present.e
    - verifier le pourcentage de completion d'une etape elearning

_Si tu as lu cette description, pense a réagir avec un :eye:_
