### PR TITLE
COM-2690 - Visual refacto for helpers subscriptions

### DIFF
--- a/src/modules/client/components/customers/SubscriptionCell.vue
+++ b/src/modules/client/components/customers/SubscriptionCell.vue
@@ -2,30 +2,30 @@
   <q-card class="cell-container text-copper-grey-500">
     <div class="row cell-header q-mb-md">
       <div class="text-weight-bold">{{ subscription.service.name }}</div>
-      <div>
-        <ni-button icon="history" @click="showHistory(subscription._id)" data-cy="show-subscription-history" />
-        <ni-button icon="mdi-calculator" :disable="!fundings.length" @click="showSubscriptionFundings"
-          data-cy="show-fundings-history" />
-      </div>
+      <ni-button icon="history" @click="showHistory(subscription._id)" data-cy="show-subscription-history" />
     </div>
     <div v-if="subscription.service.nature === HOURLY" class="q-mb-md">
       Prix horaire (TTC) :
-      <span class="text-weight-bold text-copper-grey-700">{{ subscription.unitTTCRate }} € / heure</span>
+      <span class="text-weight-bold text-copper-grey-700">{{ formatPrice(subscription.unitTTCRate) }} / heure</span>
     </div>
     <div v-else class="q-mb-md">
       Prix forfaitaire (TTC) :
-      <span class="text-weight-bold text-copper-grey-700">{{ subscription.unitTTCRate }} € / intervention</span>
+      <span class="text-weight-bold text-copper-grey-700">
+        {{ formatPrice(subscription.unitTTCRate) }} / intervention
+      </span>
     </div>
     <div v-if="get(subscription, 'service.billingItems.length')">
       Prix par intervention (TTC) :
-      <span class="text-weight-bold text-copper-grey-700">{{ getBillingItemsPrice() }} € / intervention</span>
+      <span class="text-weight-bold text-copper-grey-700">
+        {{ formatPrice(getBillingItemsPrice()) }} / intervention
+      </span>
       <div class="text-italic q-mb-md" style="font-size: 12px">Ce prix correspond à : {{ getBillingItemsNames() }}</div>
     </div>
     <div class="bg-copper-grey-100 text-copper-grey-700 weekly-infos">
       <div>
         Coût estimé pour une semaine :
-        <span class="text-weight-bold">{{ formatNumber(weeklyRate.total) }} € / semaine</span>
-        <span v-if="weeklyRate.totalSurcharge"> (dont {{ weeklyRate.totalSurcharge }} € de majoration)</span>
+        <span class="text-weight-bold">{{ formatPrice(weeklyRate.total) }} / semaine</span>
+        <span v-if="weeklyRate.totalSurcharge"> (dont {{ formatPrice(weeklyRate.totalSurcharge) }} de majoration)</span>
       </div>
       <div class="text-italic" style="font-size: 14px">
         <div>Estimation sur base de : </div>
@@ -37,6 +37,13 @@
           <li v-if="subscription.weeklyCount">
             {{ formatQuantity('intervention', subscription.weeklyCount) }} par semaine
           </li>
+          <li v-if="fundings.length">
+            Prise en charge par {{ fundings[0].thirdPartyPayer.name }} : {{ formatPrice(weeklyRate.fundingReduction) }}
+            <span class="cursor-pointer text-copper-400 funding-details"
+              @click="showSubscriptionFundings(subscription._id)">
+              (voir détails)
+            </span>
+          </li>
         </ul>
       </div>
     </div>
@@ -47,7 +54,7 @@
 import get from 'lodash/get';
 import Button from '@components/Button';
 import { HOURLY } from '@data/constants';
-import { formatQuantity } from '@helpers/utils';
+import { formatQuantity, formatPrice } from '@helpers/utils';
 import { subscriptionMixin } from 'src/modules/client/mixins/subscriptionMixin';
 
 export default {
@@ -89,15 +96,12 @@ export default {
       return surchargesHours.slice(0, -2);
     };
 
-    const getSubscriptionFundings = subscriptionId => this.fundings
-      .filter(fund => fund.subscription._id === subscriptionId);
-
     const showHistory = (id) => {
       context.emit('showHistory', id);
     };
 
-    const showSubscriptionFundings = () => {
-      context.emit('showSubscriptionFundings', props.subscription);
+    const showSubscriptionFundings = (id) => {
+      context.emit('showSubscriptionFundings', id);
     };
 
     return {
@@ -106,12 +110,12 @@ export default {
       // Methods
       getBillingItemsPrice,
       getBillingItemsNames,
-      getSubscriptionFundings,
       showHistory,
       showSubscriptionFundings,
       getSurchargesHours,
       get,
       formatQuantity,
+      formatPrice,
     };
   },
 };
@@ -132,4 +136,6 @@ export default {
     > div > ul
       margin: 0
       padding-inline-start: 24px
+  .funding-details
+    text-decoration: underline
 </style>

--- a/src/modules/client/components/customers/SubscriptionCell.vue
+++ b/src/modules/client/components/customers/SubscriptionCell.vue
@@ -74,15 +74,10 @@ export default {
     },
   },
   setup (props, context) {
-    const getBillingItemsPrice = () => {
-      if (!get(props.subscription, 'service.billingItems.length')) return 'sku';
-
-      return props.subscription.service.billingItems.reduce((acc, bi) => (acc += bi.defaultUnitAmount), 0);
-    };
+    const getBillingItemsPrice = () => props.subscription.service.billingItems
+      .reduce((acc, bi) => (acc += bi.defaultUnitAmount), 0);
 
     const getBillingItemsNames = () => {
-      if (!get(props.subscription, 'service.billingItems.length')) return 'sku';
-
       const billingItemsName = props.subscription.service.billingItems.reduce((acc, bi) => (acc += `${bi.name}, `), '');
       return billingItemsName.slice(0, -2);
     };

--- a/src/modules/client/components/customers/SubscriptionCell.vue
+++ b/src/modules/client/components/customers/SubscriptionCell.vue
@@ -2,14 +2,15 @@
   <q-card class="cell-container text-copper-grey-500">
     <div class="row cell-header q-mb-md">
       <div class="text-weight-bold">{{ subscription.service.name }}</div>
-      <ni-button icon="history" @click="showHistory(subscription._id)" data-cy="show-subscription-history" />
+      <ni-button icon="history" @click="showHistory(subscription._id)" data-cy="show-subscription-history"
+        color="copper-grey-500" />
     </div>
     <div v-if="subscription.service.nature === HOURLY" class="q-mb-md">
       Prix horaire (TTC) :
       <span class="text-weight-bold text-copper-grey-700">{{ formatPrice(subscription.unitTTCRate) }} / heure</span>
     </div>
     <div v-else class="q-mb-md">
-      Prix forfaitaire (TTC) :
+      Coût forfaitaire (TTC) :
       <span class="text-weight-bold text-copper-grey-700">
         {{ formatPrice(subscription.unitTTCRate) }} / intervention
       </span>
@@ -19,7 +20,7 @@
       <span class="text-weight-bold text-copper-grey-700">
         {{ formatPrice(getBillingItemsPrice()) }} / intervention
       </span>
-      <div class="text-italic q-mb-md" style="font-size: 12px">Ce prix correspond à : {{ getBillingItemsNames() }}</div>
+      <div class="text-italic q-mb-md" style="font-size: 12px">Ce prix correspond à : {{ getBillingItemsName() }}</div>
     </div>
     <div class="bg-copper-grey-100 text-copper-grey-700 weekly-infos">
       <div>
@@ -31,8 +32,8 @@
         <div>Estimation sur base de : </div>
         <ul>
           <li v-if="subscription.weeklyHours">
-            {{ subscription.weeklyHours }} h d'intervention par semaine
-            <span v-if="getSurchargesHours()">(dont majorées : {{ getSurchargesHours() }})</span>
+            {{ subscription.weeklyHours }}h d'intervention par semaine
+            <span v-if="getSurchargedHours()">(dont majorées : {{ getSurchargedHours() }})</span>
           </li>
           <li v-if="subscription.weeklyCount">
             {{ formatQuantity('intervention', subscription.weeklyCount) }} par semaine
@@ -77,37 +78,33 @@ export default {
     const getBillingItemsPrice = () => props.subscription.service.billingItems
       .reduce((acc, bi) => (acc += bi.defaultUnitAmount), 0);
 
-    const getBillingItemsNames = () => {
+    const getBillingItemsName = () => {
       const billingItemsName = props.subscription.service.billingItems.reduce((acc, bi) => (acc += `${bi.name}, `), '');
       return billingItemsName.slice(0, -2);
     };
 
-    const getSurchargesHours = () => {
-      let surchargesHours = '';
-      if (props.subscription.saturdays) surchargesHours += `${props.subscription.saturdays} h le samedi, `;
-      if (props.subscription.sundays) surchargesHours += `${props.subscription.sundays} h le dimanche, `;
-      if (props.subscription.evenings) surchargesHours += `${props.subscription.evenings} h en soirée, `;
+    const getSurchargedHours = () => {
+      let surchargedHours = '';
+      if (props.subscription.saturdays) surchargedHours += `${props.subscription.saturdays}h le samedi, `;
+      if (props.subscription.sundays) surchargedHours += `${props.subscription.sundays}h le dimanche, `;
+      if (props.subscription.evenings) surchargedHours += `${props.subscription.evenings}h en soirée, `;
 
-      return surchargesHours.slice(0, -2);
+      return surchargedHours.slice(0, -2);
     };
 
-    const showHistory = (id) => {
-      context.emit('showHistory', id);
-    };
+    const showHistory = (id) => { context.emit('showHistory', id); };
 
-    const showSubscriptionFundings = (id) => {
-      context.emit('showSubscriptionFundings', id);
-    };
+    const showSubscriptionFundings = (id) => { context.emit('showSubscriptionFundings', id); };
 
     return {
       // Data
       HOURLY,
       // Methods
       getBillingItemsPrice,
-      getBillingItemsNames,
+      getBillingItemsName,
       showHistory,
       showSubscriptionFundings,
-      getSurchargesHours,
+      getSurchargedHours,
       get,
       formatQuantity,
       formatPrice,

--- a/src/modules/client/components/customers/SubscriptionCell.vue
+++ b/src/modules/client/components/customers/SubscriptionCell.vue
@@ -1,0 +1,135 @@
+<template>
+  <q-card class="cell-container text-copper-grey-500">
+    <div class="row cell-header q-mb-md">
+      <div class="text-weight-bold">{{ subscription.service.name }}</div>
+      <div>
+        <ni-button icon="history" @click="showHistory(subscription._id)" data-cy="show-subscription-history" />
+        <ni-button icon="mdi-calculator" :disable="!fundings.length" @click="showSubscriptionFundings"
+          data-cy="show-fundings-history" />
+      </div>
+    </div>
+    <div v-if="subscription.service.nature === HOURLY" class="q-mb-md">
+      Prix horaire (TTC) :
+      <span class="text-weight-bold text-copper-grey-700">{{ subscription.unitTTCRate }} € / heure</span>
+    </div>
+    <div v-else class="q-mb-md">
+      Prix forfaitaire (TTC) :
+      <span class="text-weight-bold text-copper-grey-700">{{ subscription.unitTTCRate }} € / intervention</span>
+    </div>
+    <div v-if="get(subscription, 'service.billingItems.length')">
+      Prix par intervention (TTC) :
+      <span class="text-weight-bold text-copper-grey-700">{{ getBillingItemsPrice() }} € / intervention</span>
+      <div class="text-italic q-mb-md" style="font-size: 12px">Ce prix correspond à : {{ getBillingItemsNames() }}</div>
+    </div>
+    <div class="bg-copper-grey-100 text-copper-grey-700 weekly-infos">
+      <div>
+        Coût estimé pour une semaine :
+        <span class="text-weight-bold">{{ formatNumber(weeklyRate.total) }} € / semaine</span>
+        <span v-if="weeklyRate.totalSurcharge"> (dont {{ weeklyRate.totalSurcharge }} € de majoration)</span>
+      </div>
+      <div class="text-italic" style="font-size: 14px">
+        <div>Estimation sur base de : </div>
+        <ul>
+          <li v-if="subscription.weeklyHours">
+            {{ subscription.weeklyHours }} h d'intervention par semaine
+            <span v-if="getSurchargesHours()">(dont majorées : {{ getSurchargesHours() }})</span>
+          </li>
+          <li v-if="subscription.weeklyCount">
+            {{ formatQuantity('intervention', subscription.weeklyCount) }} par semaine
+          </li>
+        </ul>
+      </div>
+    </div>
+  </q-card>
+</template>
+
+<script>
+import get from 'lodash/get';
+import Button from '@components/Button';
+import { HOURLY } from '@data/constants';
+import { formatQuantity } from '@helpers/utils';
+import { subscriptionMixin } from 'src/modules/client/mixins/subscriptionMixin';
+
+export default {
+  name: 'SubscriptionCell',
+  props: {
+    subscription: { type: Object, required: true },
+    fundings: { type: Array, default: () => ([]) },
+  },
+  components: {
+    'ni-button': Button,
+  },
+  mixins: [subscriptionMixin],
+  emits: ['showHistory', 'showSubscriptionFundings'],
+  computed: {
+    weeklyRate () {
+      return this.computeWeeklyRate(this.subscription, this.getMatchingFunding(this.subscription));
+    },
+  },
+  setup (props, context) {
+    const getBillingItemsPrice = () => {
+      if (!get(props.subscription, 'service.billingItems.length')) return 'sku';
+
+      return props.subscription.service.billingItems.reduce((acc, bi) => (acc += bi.defaultUnitAmount), 0);
+    };
+
+    const getBillingItemsNames = () => {
+      if (!get(props.subscription, 'service.billingItems.length')) return 'sku';
+
+      const billingItemsName = props.subscription.service.billingItems.reduce((acc, bi) => (acc += `${bi.name}, `), '');
+      return billingItemsName.slice(0, -2);
+    };
+
+    const getSurchargesHours = () => {
+      let surchargesHours = '';
+      if (props.subscription.saturdays) surchargesHours += `${props.subscription.saturdays} h le samedi, `;
+      if (props.subscription.sundays) surchargesHours += `${props.subscription.sundays} h le dimanche, `;
+      if (props.subscription.evenings) surchargesHours += `${props.subscription.evenings} h en soirée, `;
+
+      return surchargesHours.slice(0, -2);
+    };
+
+    const getSubscriptionFundings = subscriptionId => this.fundings
+      .filter(fund => fund.subscription._id === subscriptionId);
+
+    const showHistory = (id) => {
+      context.emit('showHistory', id);
+    };
+
+    const showSubscriptionFundings = () => {
+      context.emit('showSubscriptionFundings', props.subscription);
+    };
+
+    return {
+      // Data
+      HOURLY,
+      // Methods
+      getBillingItemsPrice,
+      getBillingItemsNames,
+      getSubscriptionFundings,
+      showHistory,
+      showSubscriptionFundings,
+      getSurchargesHours,
+      get,
+      formatQuantity,
+    };
+  },
+};
+</script>
+
+<style lang="sass" scoped>
+  .cell-container
+    background: white
+    width: 100%
+    margin-bottom: 10px
+    padding: 16px
+  .cell-header
+    justify-content: space-between
+    align-items: center
+  .weekly-infos
+    border-radius: 16px !important
+    padding: 16px
+    > div > ul
+      margin: 0
+      padding-inline-start: 24px
+</style>

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -929,7 +929,7 @@ export default {
 
         const subscriptions = quote.subscriptions.map(subscription => ({
           ...subscription,
-          estimatedWeeklyRate: this.computeWeeklyRate(subscription),
+          estimatedWeeklyRate: this.computeWeeklyRate(subscription).total,
         }));
 
         const data = getTagsToDownloadQuote(this.customer, this.company, { ...quote, subscriptions });

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -287,6 +287,7 @@ import { required, requiredIf, email, minValue } from '@vuelidate/validators';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
+import capitalize from 'lodash/capitalize';
 import Services from '@api/Services';
 import Customers from '@api/Customers';
 import GoogleDrive from '@api/GoogleDrive';
@@ -309,10 +310,11 @@ import {
   CIVILITY_OPTIONS,
   DOC_EXTENSIONS,
   ONCE,
+  NATURE_OPTIONS,
 } from '@data/constants';
 import { downloadDriveDocx } from '@helpers/file';
 import { formatDate, isSameOrBefore } from '@helpers/date';
-import { getLastVersion } from '@helpers/utils';
+import { getLastVersion, formatPrice } from '@helpers/utils';
 import { frPhoneNumber, iban, bic, frAddress, minDate, integerNumber } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
 import { getTagsToGenerateQuote, getTagsToDownloadQuote, getMandateTags } from 'src/modules/client/helpers/tags';
@@ -377,6 +379,44 @@ export default {
       isLoaded: false,
       tmpInput: '',
       subscriptions: [],
+      subscriptionsColumns: [
+        { name: 'service', label: 'Service', align: 'left', field: row => get(row, 'service.name') },
+        {
+          name: 'nature',
+          label: 'Nature',
+          align: 'left',
+          format: (value) => {
+            const nature = NATURE_OPTIONS.find(option => option.value === value);
+            return nature ? capitalize(nature.label) : '';
+          },
+          field: row => get(row, 'service.nature'),
+        },
+        {
+          name: 'unitTTCRate',
+          label: 'Prix unitaire TTC',
+          align: 'center',
+          field: row => row.unitTTCRate && `${this.formatPrice(row.unitTTCRate)}`,
+        },
+        {
+          name: 'weeklyHours',
+          label: 'Volume horaire hebdomadaire estimatif',
+          align: 'center',
+          field: row => (row.weeklyHours ? `${row.weeklyHours}h` : ''),
+        },
+        {
+          name: 'weeklyCount',
+          label: 'Nombre d\'interventions hebdomadaire estimatif',
+          align: 'center',
+          field: row => (row.weeklyCount || ''),
+        },
+        {
+          name: 'weeklyRate',
+          label: 'Coût hebdomadaire TTC *',
+          align: 'center',
+          field: row => `${this.formatPrice(this.computeWeeklyRate(row, this.getMatchingFunding(row)).total)}`,
+        },
+        { name: 'actions', label: '', align: 'left', field: '_id' },
+      ],
       services: [],
       quotesColumns: [
         { name: 'quoteNumber', label: 'Numéro du devis', align: 'left', field: 'quoteNumber' },
@@ -614,6 +654,7 @@ export default {
   },
   methods: {
     get,
+    formatPrice,
     disableSubscriptionDeletion (sub) {
       const hasFunding = this.fundings.some(f => f.subscription._id === sub._id);
 

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -968,10 +968,10 @@ export default {
         const quoteDriveId = get(this.company, 'customersConfig.templates.quote.driveId', null);
         if (!quoteDriveId) return NotifyWarning('Template manquant');
 
-        const subscriptions = quote.subscriptions.map(subscription => ({
-          ...subscription,
-          estimatedWeeklyRate: this.computeWeeklyRate(subscription).total,
-        }));
+        const subscriptions = quote.subscriptions.map((subscription) => {
+          const { total } = this.computeWeeklyRate(subscription);
+          return { ...subscription, estimatedWeeklyRate: total };
+        });
 
         const data = getTagsToDownloadQuote(this.customer, this.company, { ...quote, subscriptions });
         const params = { driveId: quoteDriveId };

--- a/src/modules/client/mixins/subscriptionMixin.js
+++ b/src/modules/client/mixins/subscriptionMixin.js
@@ -1,7 +1,7 @@
 import get from 'lodash/get';
 import has from 'lodash/has';
 import { MONTHLY, FIXED, HOURLY, WEEKS_PER_MONTH } from '@data/constants';
-import { getLastVersion } from '@helpers/utils';
+import { getLastVersion, formatPrice } from '@helpers/utils';
 import moment from '@helpers/moment';
 
 export const subscriptionMixin = {
@@ -22,7 +22,7 @@ export const subscriptionMixin = {
           name: 'unitTTCRate',
           label: 'Prix unitaire TTC',
           align: 'center',
-          field: row => `${this.formatNumber(row.unitTTCRate)}€`,
+          field: row => `${this.formatPrice(row.unitTTCRate)}`,
         },
         {
           name: 'weeklyVolume',
@@ -54,6 +54,7 @@ export const subscriptionMixin = {
     };
   },
   methods: {
+    formatPrice,
     computeWeeklyRate (subscription, funding) {
       let weeklyRate = subscription.weeklyHours
         ? subscription.unitTTCRate * subscription.weeklyHours

--- a/src/modules/client/mixins/subscriptionMixin.js
+++ b/src/modules/client/mixins/subscriptionMixin.js
@@ -1,7 +1,6 @@
 import get from 'lodash/get';
 import has from 'lodash/has';
-import capitalize from 'lodash/capitalize';
-import { MONTHLY, FIXED, HOURLY, NATURE_OPTIONS, WEEKS_PER_MONTH } from '@data/constants';
+import { MONTHLY, FIXED, HOURLY, WEEKS_PER_MONTH } from '@data/constants';
 import { getLastVersion } from '@helpers/utils';
 import moment from '@helpers/moment';
 
@@ -11,44 +10,6 @@ export const subscriptionMixin = {
       subscriptions: [],
       selectedSubscription: {},
       subscriptionHistoryModal: false,
-      subscriptionsColumns: [
-        { name: 'service', label: 'Service', align: 'left', field: row => get(row, 'service.name') },
-        {
-          name: 'nature',
-          label: 'Nature',
-          align: 'left',
-          format: (value) => {
-            const nature = NATURE_OPTIONS.find(option => option.value === value);
-            return nature ? capitalize(nature.label) : '';
-          },
-          field: row => get(row, 'service.nature'),
-        },
-        {
-          name: 'unitTTCRate',
-          label: 'Prix unitaire TTC',
-          align: 'center',
-          field: row => row.unitTTCRate && `${this.formatNumber(row.unitTTCRate)}€`,
-        },
-        {
-          name: 'weeklyHours',
-          label: 'Volume horaire hebdomadaire estimatif',
-          align: 'center',
-          field: row => (row.weeklyHours ? `${row.weeklyHours}h` : ''),
-        },
-        {
-          name: 'weeklyCount',
-          label: 'Nombre d\'interventions hebdomadaire estimatif',
-          align: 'center',
-          field: row => (row.weeklyCount || ''),
-        },
-        {
-          name: 'weeklyRate',
-          label: 'Coût hebdomadaire TTC *',
-          align: 'center',
-          field: row => `${this.formatNumber(this.computeWeeklyRate(row, this.getMatchingFunding(row)).total)}€`,
-        },
-        { name: 'actions', label: '', align: 'left', field: '_id' },
-      ],
       subscriptionHistoryColumns: [
         {
           name: 'createdAt',
@@ -93,9 +54,6 @@ export const subscriptionMixin = {
     };
   },
   methods: {
-    formatNumber (number) {
-      return parseFloat(Math.round(number * 100) / 100).toFixed(2);
-    },
     computeWeeklyRate (subscription, funding) {
       let weeklyRate = subscription.weeklyHours
         ? subscription.unitTTCRate * subscription.weeklyHours

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -3,9 +3,9 @@
     <template v-if="customer">
       <div class="q-mb-lg">
         <ni-title-header title="Abonnement" class="q-mb-xl" />
-        <p class="title">Souscriptions</p>
+        <p class="title">Souscription(s)</p>
         <p v-if="subscriptions.length === 0">Aucun service souscrit.</p>
-        <div v-if="subscriptions && subscriptions.length > 0 && !subscriptionsLoading">
+        <div v-if="subscriptions.length > 0 && !subscriptionsLoading">
           <div v-for="subscription of subscriptions" :key="subscription._id" class="q-mb-md">
             <ni-subscription-cell :subscription="subscription" @show-subscription-fundings="showSubscriptionFundings"
               @show-history="showHistory" :fundings="getSubscriptionFundings(subscription._id)" />

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -4,6 +4,10 @@
       <div class="q-mb-lg">
         <ni-title-header title="Abonnement" class="q-mb-xl" />
         <p class="title">Souscriptions</p>
+        <div v-for="subscription of subscriptions" :key="subscription._id">
+          <ni-subscription-cell :subscription="subscription" @show-history="showHistory"
+            :fundings="getSubscriptionFundings(subscription._id)" />
+        </div>
         <p v-if="subscriptions.length === 0">Aucun service souscrit.</p>
         <q-card v-if="subscriptions.length > 0" class="contract-cell">
           <ni-responsive-table :data="subscriptions" :columns="subscriptionsColumns" :loading="subscriptionsLoading"
@@ -146,6 +150,7 @@ import Input from '@components/form/Input';
 import MultipleFilesUploader from '@components/form/MultipleFilesUploader';
 import Button from '@components/Button';
 import BiColorButton from '@components/BiColorButton';
+import SubscriptionCell from 'src/modules/client/components/customers/SubscriptionCell';
 import Modal from '@components/modal/Modal';
 import HtmlModal from '@components/modal/HtmlModal';
 import ResponsiveTable from '@components/table/ResponsiveTable';
@@ -173,6 +178,7 @@ export default {
     'ni-responsive-table': ResponsiveTable,
     'ni-funding-grid-table': FundingGridTable,
     'ni-bi-color-button': BiColorButton,
+    'ni-subscription-cell': SubscriptionCell,
   },
   mixins: [customerMixin, subscriptionMixin, financialCertificatesMixin, fundingMixin, tableMixin],
   data () {
@@ -480,10 +486,6 @@ export default {
   .nota-bene
     font-size: 0.8em
     margin-bottom: 20px
-  .contract-cell
-    background: white
-    width: 100%
-    margin-bottom: 10px
   .q-header
     position: sticky
   .iframe-normal

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -4,34 +4,13 @@
       <div class="q-mb-lg">
         <ni-title-header title="Abonnement" class="q-mb-xl" />
         <p class="title">Souscriptions</p>
-        <div v-for="subscription of subscriptions" :key="subscription._id">
-          <ni-subscription-cell :subscription="subscription" @show-history="showHistory"
-            :fundings="getSubscriptionFundings(subscription._id)" />
-        </div>
         <p v-if="subscriptions.length === 0">Aucun service souscrit.</p>
-        <q-card v-if="subscriptions.length > 0" class="contract-cell">
-          <ni-responsive-table :data="subscriptions" :columns="subscriptionsColumns" :loading="subscriptionsLoading"
-            data-cy="subscriptions-table">
-            <template #body="{ props }">
-              <q-tr :props="props">
-                <q-td v-for="col in props.cols" :key="col.name" :data-label="col.label" :props="props" :class="col.name"
-                  :style="col.style" :data-cy="`col-${col.name}`">
-                  <template v-if="col.name === 'actions'">
-                    <div class="row no-wrap table-actions">
-                      <ni-button icon="history" @click="showHistory(col.value)" data-cy="show-subscription-history" />
-                      <ni-button :disable="!getSubscriptionFundings(col.value).length" icon="mdi-calculator"
-                        @click="showSubscriptionFundings(col.value)" data-cy="show-fundings-history" />
-                    </div>
-                  </template>
-                  <template v-else>{{ col.value }}</template>
-                </q-td>
-              </q-tr>
-            </template>
-          </ni-responsive-table>
-        </q-card>
-        <p v-if="subscriptions.length > 0" class="nota-bene">
-          * intègre les éventuelles majorations soir / dimanche
-        </p>
+        <div v-if="subscriptions && subscriptions.length > 0">
+          <div v-for="subscription of subscriptions" :key="subscription._id" class="q-mb-md">
+            <ni-subscription-cell :subscription="subscription" @show-subscription-fundings="showSubscriptionFundings"
+              @show-history="showHistory" :fundings="getSubscriptionFundings(subscription._id)" />
+          </div>
+        </div>
         <div v-if="subscriptions && subscriptions.length > 0" class="row">
           <div class="col-xs-12">
             <q-checkbox v-model="customer.subscriptionsAccepted" class="q-mr-sm" @update:model-value="confirmAgreement"

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -465,6 +465,10 @@ export default {
   .nota-bene
     font-size: 0.8em
     margin-bottom: 20px
+  .contract-cell
+    background: white
+    width: 100%
+    margin-bottom: 10px
   .q-header
     position: sticky
   .iframe-normal

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -5,7 +5,7 @@
         <ni-title-header title="Abonnement" class="q-mb-xl" />
         <p class="title">Souscriptions</p>
         <p v-if="subscriptions.length === 0">Aucun service souscrit.</p>
-        <div v-if="subscriptions && subscriptions.length > 0">
+        <div v-if="subscriptions && subscriptions.length > 0 && !subscriptionsLoading">
           <div v-for="subscription of subscriptions" :key="subscription._id" class="q-mb-md">
             <ni-subscription-cell :subscription="subscription" @show-subscription-fundings="showSubscriptionFundings"
               @show-history="showHistory" :fundings="getSubscriptionFundings(subscription._id)" />


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- ~~[ ] J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : aidant

- Cas d'usage :
Refacto du design des souscriptions de l'aidant

- Comment tester ? :
Comparer le design au [Figma](https://www.figma.com/file/PlYziIhmznu7y7EEK7uoBD/Prochain-Sprint?node-id=8630%3A38242) pour des souscriptions en jouant sur : le prix, la nature du service, les majorations, les financements, ...
Vérifier aussi que le tableau des souscription côté coach n'a pas cassé

_Si tu as lu cette description, pense a réagir avec un :eye:_
