### PR TITLE
COM-2695: add confirmation modal

### DIFF
--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -23,7 +23,7 @@
     <ni-customer-absence-edition-modal v-model:edited-customer-absence="editedCustomerAbsence"
       :customer-absence-edition-modal="customerAbsenceModal" :validations="eventValidation.editedCustomerAbsence"
       @close="closeCustomerAbsenceModal" @hide="resetCustomerAbsenceEditionForm"
-      @submit="updateCustomerAbsence" />
+      @submit="validateCustomerAbsenceEdition" />
   </q-page>
 </template>
 
@@ -268,7 +268,18 @@ export default {
       const { absenceType, dates } = this.editedCustomerAbsence;
       return { absenceType, startDate: dates.startDate, endDate: dates.endDate };
     },
-    async updateCustomerAbsence (value) {
+    validateCustomerAbsenceEdition () {
+      this.$q.dialog({
+        title: 'Confirmation',
+        message: `Êtes-vous sûr(e) de vouloir modifier l'absence bénéficiaire ?<br />
+          Les interventions prévues sur la période d'absence seront supprimées.`,
+        html: true,
+        ok: 'OK',
+        cancel: 'Annuler',
+      }).onOk(this.updateCustomerAbsence)
+        .onCancel(() => NotifyPositive('Modification annulée.'));
+    },
+    async updateCustomerAbsence () {
       try {
         this.eventValidation.editedCustomerAbsence.$touch();
         if (this.eventValidation.editedCustomerAbsence.$error) return NotifyWarning('Champ(s) invalide(s)');


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client admin/coach/auxiliaire

- Cas d'usage : quand j'édite une absence bénéficiaire j'ai une modale de confirmation + boyscout retrait du paramètre inutile de updateCustomerAbsence

- Comment tester ? : modifier une absence bénéficiaire et s'assurer qu'on a bien la modale de confirmation

_Si tu as lu cette description, pense a réagir avec un :eye:_
