### PR TITLE
Com 2729

### DIFF
--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -150,7 +150,7 @@ export const BILLING_DIRECT = 'direct';
 export const APA = 'APA';
 export const PCH = 'PCH';
 export const AM = 'AM';
-export const THIRD_PARTY_PAYER_TYPE_OPTIONS = [
+export const TPP_TYPE_OPTIONS = [
   { label: 'APA', value: APA },
   { label: 'Aide ménagère', value: AM },
   { label: 'PCH', value: PCH },

--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -147,6 +147,14 @@ export const EVENT_TYPES = [
 // THIRD PARTY PAYERS
 export const BILLING_INDIRECT = 'indirect';
 export const BILLING_DIRECT = 'direct';
+export const APA = 'APA';
+export const PCH = 'PCH';
+export const AM = 'AM';
+export const THIRD_PARTY_PAYER_TYPE_OPTIONS = [
+  { label: 'APA', value: APA },
+  { label: 'Aide ménagère', value: AM },
+  { label: 'PCH', value: PCH },
+];
 
 // AVATAR
 export const DEFAULT_AVATAR = 'https://storage.googleapis.com/compani-main/default_avatar.png';

--- a/src/modules/client/components/config/ThirdPartyPayerDetailsModal.vue
+++ b/src/modules/client/components/config/ThirdPartyPayerDetailsModal.vue
@@ -1,0 +1,56 @@
+<template>
+  <ni-modal :model-value="modelValue" @hide="hide" @update:model-value="input">
+    <template #title>
+      Détail du tiers payeur <span class="text-weight-bold">{{ thirdPartyPayer.name }}</span>
+    </template>
+    <q-table class="q-mb-xl" :rows="[thirdPartyPayer]" :columns="columns" hide-bottom flat grid
+      :visible-columns="visibleColumns">
+      <template #item="props">
+        <q-card class="full-width q-mb-md" flat bordered>
+          <q-list separator dense>
+            <q-item v-for="col in props.cols" :key="col.name" class="row">
+              <q-item-section class="col-5">
+                <q-item-label :data-cy="`col-${col.name}`">{{ col.label }}</q-item-label>
+              </q-item-section>
+              <q-item-section class="col-7" side>
+                <q-item-label caption :data-cy="`col-side-${col.name}`">{{ col.value }}</q-item-label>
+              </q-item-section>
+            </q-item>
+          </q-list>
+        </q-card>
+      </template>
+    </q-table>
+    </ni-modal>
+</template>
+
+<script>
+import Modal from '@components/modal/Modal';
+
+export default {
+  name: 'ThirdPartyPayerDetailsModal',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    thirdPartyPayer: { type: Object, default: () => ({}) },
+    columns: { type: Array, default: () => ([]) },
+    visibleColumns: { type: Array, default: () => ([]) },
+  },
+  components: {
+    'ni-modal': Modal,
+  },
+  emits: ['hide', 'update:model-value'],
+  methods: {
+    hide () {
+      this.$emit('hide');
+    },
+    input (event) {
+      this.$emit('update:model-value', event);
+    },
+  },
+};
+</script>
+
+<style lang="sass" scoped>
+  .q-item__section--main
+    .q-item__label
+      font-size: 0.80rem
+</style>

--- a/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
+++ b/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
@@ -19,6 +19,11 @@
         @blur="validations.billingMode.$touch" @update:model-value="update($event, 'billingMode')" />
       <ni-input in-modal caption="ID de télétransmission" :model-value="editedThirdPartyPayer.teletransmissionId"
         @update:model-value="update($event, 'teletransmissionId')" />
+      <ni-select in-modal caption="Type d'aide" :model-value="editedThirdPartyPayer.teletransmissionType"
+        :options="thirdPartyPayerTypeOptions" :error="validations.teletransmissionType.$error"
+        @blur="validations.teletransmissionType.$touch" @update:model-value="update($event, 'teletransmissionType')" />
+      <ni-input in-modal caption="Identifiant structure" @update:model-value="update($event, 'companyCode')"
+        :model-value="editedThirdPartyPayer.companyCode" :error="validations.companyCode.$error" />
       <div class="row q-mb-md light-checkbox">
         <q-checkbox :model-value="editedThirdPartyPayer.isApa" label="Financement APA" dense
           @update:model-value="update($event, 'isApa')" />
@@ -44,6 +49,7 @@ export default {
     modelValue: { type: Boolean, default: false },
     editedThirdPartyPayer: { type: Object, default: () => ({}) },
     billingModeOptions: { type: Array, default: () => [] },
+    thirdPartyPayerTypeOptions: { type: Array, default: () => [] },
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
   },

--- a/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
+++ b/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
@@ -23,7 +23,8 @@
         :options="thirdPartyPayerTypeOptions" :error="validations.teletransmissionType.$error"
         @blur="validations.teletransmissionType.$touch" @update:model-value="update($event, 'teletransmissionType')" />
       <ni-input in-modal caption="Identifiant structure" @update:model-value="update($event, 'companyCode')"
-        :model-value="editedThirdPartyPayer.companyCode" :error="validations.companyCode.$error" />
+        :model-value="editedThirdPartyPayer.companyCode" :error="validations.companyCode.$error"
+        @blur="validations.companyCode.$touch" />
       <div class="row q-mb-md light-checkbox">
         <q-checkbox :model-value="editedThirdPartyPayer.isApa" label="Financement APA" dense
           @update:model-value="update($event, 'isApa')" />

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -194,7 +194,8 @@
 
     <third-party-payer-edition-modal v-model="thirdPartyPayerEditionModal" :validations="v$.editedThirdPartyPayer"
       :edited-third-party-payer="editedThirdPartyPayer" @submit="updateThirdPartyPayer" @update="setThirdPartyPayer"
-      @hide="resetThirdPartyPayerEdition" :loading="loading" :billing-mode-options="billingModeOptions" />
+      @hide="resetThirdPartyPayerEdition" :loading="loading" :billing-mode-options="billingModeOptions"
+      :third-party-payer-type-options="THIRD_PARTY_PAYER_TYPE_OPTIONS" />
   </q-page>
 </template>
 
@@ -234,6 +235,7 @@ import {
   HTML_EXTENSIONS,
   BILLING_ITEMS_TYPE_OPTIONS,
   PER_INTERVENTION,
+  THIRD_PARTY_PAYER_TYPE_OPTIONS,
 } from '@data/constants';
 import moment from '@helpers/moment';
 import { roundFrenchPercentage, formatPrice, formatAndSortOptions, sortStrings, getLastVersion } from '@helpers/utils';
@@ -597,6 +599,7 @@ export default {
         descending: true,
       },
       HTML_EXTENSIONS,
+      THIRD_PARTY_PAYER_TYPE_OPTIONS,
     };
   },
   validations () {
@@ -679,6 +682,8 @@ export default {
         billingMode: { required },
         unitTTCRate: { positiveNumber, twoFractionDigits },
         isApa: { required },
+        teletransmissionType: { required: requiredIf(get(this.editedThirdPartyPayer, 'teletransmissionId')) },
+        companyCode: { required: requiredIf(get(this.editedThirdPartyPayer, 'teletransmissionId')) },
       },
     };
   },
@@ -1130,7 +1135,17 @@ export default {
     openThirdPartyPayerEditionModal (tppId) {
       this.thirdPartyPayerEditionModal = true;
       const selectedTpp = this.thirdPartyPayers.find(tpp => tpp._id === tppId);
-      const { _id, name, address, email: tppEmail, unitTTCRate, billingMode, isApa, teletransmissionId } = selectedTpp;
+      const {
+        _id,
+        name, address,
+        email: tppEmail,
+        unitTTCRate,
+        billingMode,
+        isApa,
+        teletransmissionId,
+        teletransmissionType,
+        companyCode,
+      } = selectedTpp;
 
       this.editedThirdPartyPayer = {
         _id,
@@ -1141,6 +1156,8 @@ export default {
         billingMode: billingMode || '',
         isApa: isApa || false,
         teletransmissionId: teletransmissionId || '',
+        teletransmissionType: teletransmissionType || '',
+        companyCode: companyCode || '',
       };
     },
     resetThirdPartyPayerCreation () {

--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -196,10 +196,10 @@
     <third-party-payer-edition-modal v-model="thirdPartyPayerEditionModal" :validations="v$.editedThirdPartyPayer"
       :edited-third-party-payer="editedThirdPartyPayer" @submit="updateThirdPartyPayer" @update="setThirdPartyPayer"
       @hide="resetThirdPartyPayerEdition" :loading="loading" :billing-mode-options="billingModeOptions"
-      :third-party-payer-type-options="THIRD_PARTY_PAYER_TYPE_OPTIONS" />
+      :third-party-payer-type-options="TPP_TYPE_OPTIONS" />
 
     <third-party-payer-details-modal v-model="thirdPartyPayerDetailsModal" :third-party-payer="thirdPartyPayerDetail"
-      :columns="thirdPartyPayersColumns" :visible-columns="thirdPartyPayersVisibleColumns" />
+      :columns="thirdPartyPayersColumns" :visible-columns="thirdPartyPayerDetailsVisibleColumns" />
   </q-page>
 </template>
 
@@ -239,7 +239,7 @@ import {
   HTML_EXTENSIONS,
   BILLING_ITEMS_TYPE_OPTIONS,
   PER_INTERVENTION,
-  THIRD_PARTY_PAYER_TYPE_OPTIONS,
+  TPP_TYPE_OPTIONS,
 } from '@data/constants';
 import moment from '@helpers/moment';
 import { roundFrenchPercentage, formatPrice, formatAndSortOptions, sortStrings, getLastVersion } from '@helpers/utils';
@@ -588,10 +588,18 @@ export default {
         {
           name: 'actions',
           label: '',
-          align: 'center',
+          align: 'right',
           field: '_id',
-          style: !this.$q.platform.is.mobile && 'width: 100px',
         },
+      ],
+      thirdPartyPayersVisibleColumns: [
+        'name',
+        'address',
+        'unitTTCRate',
+        'billingMode',
+        'teletransmissionId',
+        'isApa',
+        'actions',
       ],
       tppsLoading: false,
       thirdPartyPayerCreationModal: false,
@@ -613,6 +621,17 @@ export default {
         address: {},
       },
       thirdPartyPayerDetailsModal: false,
+      thirdPartyPayerDetailsVisibleColumns: [
+        'name',
+        'address',
+        'email',
+        'unitTTCRate',
+        'billingMode',
+        'teletransmissionId',
+        'teletransmissionType',
+        'companyCode',
+        'isApa',
+      ],
       thirdPartyPayerDetail: {
         address: {},
       },
@@ -623,7 +642,7 @@ export default {
         descending: true,
       },
       HTML_EXTENSIONS,
-      THIRD_PARTY_PAYER_TYPE_OPTIONS,
+      TPP_TYPE_OPTIONS,
     };
   },
   validations () {
@@ -730,21 +749,6 @@ export default {
       }
 
       return '';
-    },
-    thirdPartyPayersVisibleColumns () {
-      return this.thirdPartyPayerDetailsModal
-        ? [
-          'name',
-          'address',
-          'email',
-          'unitTTCRate',
-          'billingMode',
-          'teletransmissionId',
-          'teletransmissionType',
-          'companyCode',
-          'isApa',
-        ]
-        : ['name', 'address', 'unitTTCRate', 'billingMode', 'teletransmissionId', 'isApa', 'actions'];
     },
   },
   async mounted () {
@@ -1175,7 +1179,8 @@ export default {
       const selectedTpp = this.thirdPartyPayers.find(tpp => tpp._id === tppId);
       const {
         _id,
-        name, address,
+        name,
+        address,
         email: tppEmail,
         unitTTCRate,
         billingMode,


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client - coach / admin

- Cas d'usage :
Je peux ajouter un identifiant strucutre et un type d'aide à un tier payeur sur la page config bénéficiaire.
Quand je clique sur l'oeil, ça ouvre une modal pour avoir les details de ces champs

- Comment tester ? :
Ajouter un tpp sans tppId, puis ajouter un tppId et les 2 nouveaux champs. Vérifier la validation.
_Si tu as lu cette description, pense a réagir avec un :eye:_
