### PR TITLE
COM-2734 - Add misc to credit note pdf

### DIFF
--- a/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
+++ b/src/modules/client/components/customers/billing/CreditNoteCreationModal.vue
@@ -13,8 +13,8 @@
       @update:model-value="getEvents($event, 'thirdPartyPayer')" />
     <ni-date-input caption="Date de l'avoir" :model-value="newCreditNote.date" :error="validations.date.$error"
       @blur="validations.date.$touch" in-modal required-field @update:model-value="update($event, 'date')" />
-    <ni-input caption="Motif" in-modal :model-value="newCreditNote.misc" type="textarea" :debounce="500"
-      @update:model-value="update($event, 'misc')" />
+    <ni-input caption="Motif (visible par le client)" in-modal :model-value="newCreditNote.misc" type="textarea"
+      :debounce="500" @update:model-value="update($event, 'misc')" />
     <!-- Event -->
     <template v-if="creditNoteType === EVENTS">
       <ni-date-input @blur="validations.startDate.$touch" :max="minAndMaxDates.maxStartDate" in-modal

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -5,6 +5,7 @@
         <q-td class="bold">{{ formatDate(billingDates.startDate) }}</q-td>
         <q-td class="bold">Début de période</q-td>
         <q-td />
+        <q-td />
         <td class="bold" align="center">{{ formatPrice(startBalance) }}</td>
         <q-td />
       </q-tr>
@@ -62,6 +63,7 @@
         <q-td class="bold">{{ formatDate(billingDates.endDate) }}</q-td>
         <q-td class="bold">Fin de période</q-td>
         <q-td />
+        <q-td />
         <td class="bold" align="center">{{ formatPrice(endBalance) }}</td>
         <q-td />
       </q-tr>
@@ -92,7 +94,7 @@ import {
   COMPANI,
   MANUAL,
 } from '@data/constants';
-import { formatPrice } from '@helpers/utils';
+import { formatPrice, truncate } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 import { openPdf } from '@helpers/file';
 
@@ -124,7 +126,7 @@ export default {
       columns: [
         { name: 'date', label: 'Date', align: 'left', field: 'date', format: formatDate },
         { name: 'document', label: '', align: 'left' },
-        { name: 'misc', label: '', field: 'misc', align: 'left' },
+        { name: 'misc', label: '', field: row => (row.misc ? truncate(row.misc, 60) : ''), align: 'left' },
         {
           name: 'inclTaxes',
           label: 'Montant TTC',

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -37,6 +37,7 @@
             </template>
             <div v-else>{{ getPaymentTitle(props.row) }}</div>
           </template>
+          <template v-else-if="col.name === 'misc' && col.value">Motif: {{ col.value }}</template>
           <template v-else-if="col.name === 'balance'">
             <q-item class="row no-wrap items-center">
               <q-item-section side>
@@ -123,6 +124,7 @@ export default {
       columns: [
         { name: 'date', label: 'Date', align: 'left', field: 'date', format: formatDate },
         { name: 'document', label: '', align: 'left' },
+        { name: 'misc', label: '', field: 'misc', align: 'left' },
         {
           name: 'inclTaxes',
           label: 'Montant TTC',


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client / admin / coach / aidant

- Cas d'usage :
Sur le pdf de l'avoir (bénef / tpp), je vois le motif de l'avoir s'il existe

- Comment tester ? :
Pour un benef, faire plusieurs avoir : avec / sans motif, avec / sans tpp. Vérifier que le motif apprait bien où il doit apparaitre sur le pdf + dans le tableau

_Si tu as lu cette description, pense a réagir avec un :eye:_
