### PR TITLE
COM-2718: change theoretical hours in modal

### DIFF
--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -291,8 +291,8 @@ export default {
     },
     formatDuration (duration) {
       const durationInHours = duration.minutes / 60;
-      const hours = Math.trunc(durationInHours);
-      const paddedMinutes = (durationInHours - hours) * 60;
+      const hours = Math.floor(durationInHours);
+      const paddedMinutes = Math.round(durationInHours % 1 * 60);
 
       return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
     },

--- a/src/core/helpers/date.js
+++ b/src/core/helpers/date.js
@@ -115,6 +115,7 @@ export const formatIntervalHourly = timePeriod => `${moment(timePeriod.startDate
   + `${moment(timePeriod.endDate).format('HH:mm')}`;
 
 export const getHoursAndMinutes = (value) => {
+  if (!value) return { hours: '', minutes: '' };
   const hours = Math.floor(value);
   const minutes = Math.round(value % 1 * 60);
 

--- a/src/core/helpers/date.js
+++ b/src/core/helpers/date.js
@@ -113,3 +113,12 @@ export const formatDurationFromFloat = (durationHours = 0) => {
 
 export const formatIntervalHourly = timePeriod => `${moment(timePeriod.startDate).format('HH:mm')} - `
   + `${moment(timePeriod.endDate).format('HH:mm')}`;
+
+export const getHoursAndMinutes = (value) => {
+  const hours = Math.floor(value);
+  const minutes = Math.round(value % 1 * 60);
+
+  return { hours, minutes };
+};
+
+export const computeHours = ({ hours, minutes }) => Number(hours) + Number(minutes) / 60;

--- a/src/modules/vendor/components/programs/ProfileContent.vue
+++ b/src/modules/vendor/components/programs/ProfileContent.vue
@@ -98,7 +98,7 @@
 
     <step-edition-modal v-model="stepEditionModal" v-model:edited-step="editedStep" :validations="v$.editedStep"
       :theoretical-hours-error-msg="theoreticalHoursErrorMsg" @hide="resetStepEditionModal" @submit="editStep"
-      :loading="modalLoading" />
+      :loading="modalLoading" :theoretical-minutes-error-msg="theoreticalMinutesErrorMsg" />
 
     <activity-creation-modal v-model="activityCreationModal" v-model:new-activity="newActivity" :loading="modalLoading"
       @hide="resetActivityCreationModal" @submit="createActivity" :validations="v$.newActivity" />
@@ -141,8 +141,8 @@ import {
   REQUIRED_LABEL,
 } from '@data/constants';
 import { formatQuantity, formatAndSortOptions, sortStrings } from '@helpers/utils';
-import { formatDurationFromFloat } from '@helpers/date';
-import { strictPositiveNumber } from '@helpers/vuelidateCustomVal';
+import { formatDurationFromFloat, getHoursAndMinutes, computeHours } from '@helpers/date';
+import { integerNumber, positiveNumber } from '@helpers/vuelidateCustomVal';
 import Button from '@components/Button';
 import SubProgramCreationModal from 'src/modules/vendor/components/programs/SubProgramCreationModal';
 import StepAdditionModal from 'src/modules/vendor/components/programs/StepAdditionModal';
@@ -187,7 +187,7 @@ export default {
       newStep: { name: '', type: E_LEARNING },
       reusedStep: { _id: '', program: '' },
       stepEditionModal: false,
-      editedStep: { name: '', type: E_LEARNING, theoreticalHours: 0 },
+      editedStep: { name: '', type: E_LEARNING, theoreticalHours: { hours: 0, minutes: 0 } },
       activityCreationModal: false,
       newActivity: { name: '' },
       activityReuseModal: false,
@@ -216,7 +216,13 @@ export default {
       newSubProgram: { name: { required } },
       newStep: { name: { required }, type: { required } },
       reusedStep: { _id: { required }, program: { required } },
-      editedStep: { name: { required }, theoreticalHours: { required, strictPositiveNumber } },
+      editedStep: {
+        name: { required },
+        theoreticalHours: {
+          hours: { required, integerNumber, positiveNumber },
+          minutes: { required, integerNumber, positiveNumber },
+        },
+      },
       newActivity: { name: { required }, type: { required } },
       reusedActivity: { required },
     };
@@ -225,8 +231,17 @@ export default {
     ...mapState('program', ['program', 'openedStep']),
     theoreticalHoursErrorMsg () {
       const validation = this.v$.editedStep;
-      if (validation.theoreticalHours.required.$response === false) return REQUIRED_LABEL;
-      if (validation.theoreticalHours.strictPositiveNumber.$response === false) return 'Durée non valide';
+      if (validation.theoreticalHours.hours.required.$response === false) return REQUIRED_LABEL;
+      if (validation.theoreticalHours.hours.integerNumber.$response === false ||
+        validation.theoreticalHours.hours.positiveNumber.$response === false) return 'Durée non valide';
+
+      return '';
+    },
+    theoreticalMinutesErrorMsg () {
+      const validation = this.v$.editedStep;
+      if (validation.theoreticalHours.minutes.required.$response === false) return REQUIRED_LABEL;
+      if (validation.theoreticalHours.minutes.integerNumber.$response === false ||
+       validation.theoreticalHours.minutes.positiveNumber.$response === false) return 'Durée non valide';
 
       return '';
     },
@@ -389,7 +404,10 @@ export default {
         this.openNextModalAfterUnlocking = () => this.openStepEditionModal(step);
         this.openValidateUnlockingEditionModal(step);
       } else {
-        this.editedStep = pick(step, ['_id', 'name', 'type', 'theoreticalHours']);
+        this.editedStep = {
+          ...pick(step, ['_id', 'name', 'type']),
+          theoreticalHours: getHoursAndMinutes(step.theoreticalHours),
+        };
         this.stepEditionModal = true;
       }
     },
@@ -399,7 +417,10 @@ export default {
         this.v$.editedStep.$touch();
         if (this.v$.editedStep.$error) return NotifyWarning('Champ(s) invalide(s)');
 
-        await Steps.updateById(this.editedStep._id, pick(this.editedStep, ['name', 'theoreticalHours']));
+        await Steps.updateById(
+          this.editedStep._id,
+          { ...pick(this.editedStep, ['name']), theoreticalHours: computeHours(this.editedStep.theoreticalHours) }
+        );
         this.stepEditionModal = false;
         await this.refreshProgram();
         NotifyPositive('Étape modifiée.');
@@ -411,7 +432,7 @@ export default {
       }
     },
     resetStepEditionModal () {
-      this.editedStep = { name: '', theoreticalHours: 0 };
+      this.editedStep = { name: '', theoreticalHours: { hours: 0, minutes: 0 } };
       this.v$.editedStep.$reset();
     },
     // ACTIVITY

--- a/src/modules/vendor/components/programs/ProfileContent.vue
+++ b/src/modules/vendor/components/programs/ProfileContent.vue
@@ -121,7 +121,7 @@
 import { mapState } from 'vuex';
 import draggable from 'vuedraggable';
 import useVuelidate from '@vuelidate/core';
-import { required, helpers } from '@vuelidate/validators';
+import { required, helpers, maxValue } from '@vuelidate/validators';
 import pick from 'lodash/pick';
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
@@ -220,7 +220,7 @@ export default {
         name: { required },
         theoreticalHours: {
           hours: { required, integerNumber, positiveNumber },
-          minutes: { required, integerNumber, positiveNumber },
+          minutes: { required, integerNumber, positiveNumber, maxValue: maxValue(59) },
         },
       },
       newActivity: { name: { required }, type: { required } },
@@ -231,17 +231,18 @@ export default {
     ...mapState('program', ['program', 'openedStep']),
     theoreticalHoursErrorMsg () {
       const validation = this.v$.editedStep;
-      if (validation.theoreticalHours.hours.required.$response === false) return REQUIRED_LABEL;
-      if (validation.theoreticalHours.hours.integerNumber.$response === false ||
-        validation.theoreticalHours.hours.positiveNumber.$response === false) return 'Durée non valide';
+      if (!validation.theoreticalHours.hours.required.$response) return REQUIRED_LABEL;
+      if (!validation.theoreticalHours.hours.integerNumber.$response ||
+        !validation.theoreticalHours.hours.positiveNumber.$response) return 'Durée non valide';
 
       return '';
     },
     theoreticalMinutesErrorMsg () {
       const validation = this.v$.editedStep;
-      if (validation.theoreticalHours.minutes.required.$response === false) return REQUIRED_LABEL;
-      if (validation.theoreticalHours.minutes.integerNumber.$response === false ||
-       validation.theoreticalHours.minutes.positiveNumber.$response === false) return 'Durée non valide';
+      if (!validation.theoreticalHours.minutes.required.$response) return REQUIRED_LABEL;
+      if (!validation.theoreticalHours.minutes.integerNumber.$response ||
+       !validation.theoreticalHours.minutes.positiveNumber.$response ||
+       !validation.theoreticalHours.minutes.maxValue.$response) return 'Durée non valide';
 
       return '';
     },

--- a/src/modules/vendor/components/programs/StepEditionModal.vue
+++ b/src/modules/vendor/components/programs/StepEditionModal.vue
@@ -5,9 +5,16 @@
     </template>
     <ni-input in-modal :model-value="editedStep.name" :error="validations.name.$error" caption="Nom"
       @update:model-value="update($event.trim(), 'name')" @blur="validations.name.$touch" required-field />
-    <ni-input in-modal caption="Durée théorique" type="number" :model-value="editedStep.theoreticalHours"
-      :error="validations.theoreticalHours.$error" :error-message="theoreticalHoursErrorMsg" suffix="h" required-field
-      @blur="validations.theoreticalHours.$touch" @update:model-value="update($event, 'theoreticalHours')" />
+    <div class="row">
+      <ni-input in-modal caption="Durée théorique" type="number" :model-value="editedStep.theoreticalHours.hours"
+        :error="validations.theoreticalHours.hours.$error" :error-message="theoreticalHoursErrorMsg" suffix="h"
+        required-field @blur="validations.theoreticalHours.hours.$touch"
+        @update:model-value="updateTheoreticalHours($event, 'hours')" class="flex-1 q-pr-sm" />
+      <ni-input in-modal caption="" type="number" :model-value="editedStep.theoreticalHours.minutes"
+        :error="validations.theoreticalHours.minutes.$error" :error-message="theoreticalMinutesErrorMsg" suffix="min"
+        required-field @blur="validations.theoreticalHours.hours.$touch"
+        @update:model-value="updateTheoreticalHours($event, 'minutes')" class="flex-1 q-pl-sm" />
+    </div>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Éditer l'étape" color="primary" :loading="loading"
         icon-right="add" @click="submit" />
@@ -27,6 +34,7 @@ export default {
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
     theoreticalHoursErrorMsg: { type: String, default: '' },
+    theoreticalMinutesErrorMsg: { type: String, default: '' },
   },
   components: {
     'ni-input': Input,
@@ -45,6 +53,12 @@ export default {
     },
     update (event, prop) {
       this.$emit('update:edited-step', { ...this.editedStep, [prop]: event });
+    },
+    updateTheoreticalHours (event, prop) {
+      this.$emit(
+        'update:edited-step',
+        { ...this.editedStep, theoreticalHours: { ...this.editedStep.theoreticalHours, [prop]: event } }
+      );
     },
   },
 };


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage : dans la modale d'édition d'une étape, les heures et les minutes sont séparées

- Comment tester ? :
  - sur la branche dev (local) rajouter une durée théorique à une étape
  - se mettre sur la branche de la PR : 
    - la durée théorique affichée n'a pas changée
    - quand j'ouvre la modale, celle-ci contient les bonnes infos
    - quand je modifie la durée, elle s'affiche correctement et j'ai la bonne durée en base  

_Si tu as lu cette description, pense a réagir avec un :eye:_
