### PR TITLE
COM-2690 - Fix Romain's review

### DIFF
--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -103,3 +103,9 @@ div h4:only-child
 
 .flex-1
   flex: 1
+
+.text-12
+  font-size: 12px
+
+.text-14
+  font-size: 14px

--- a/src/modules/client/components/customers/SubscriptionCell.vue
+++ b/src/modules/client/components/customers/SubscriptionCell.vue
@@ -38,12 +38,16 @@
           <li v-if="subscription.weeklyCount">
             {{ formatQuantity('intervention', subscription.weeklyCount) }} par semaine
           </li>
-          <li v-if="fundings.length">
+          <li v-if="fundings.length && fundings[0].nature !== FIXED">
             Prise en charge par {{ fundings[0].thirdPartyPayer.name }} : {{ formatPrice(weeklyRate.fundingReduction) }}
+            / semaine
             <span class="cursor-pointer text-copper-400 funding-details"
               @click="showSubscriptionFundings(subscription._id)">
               (voir détails)
             </span>
+            <div style="font-size: 12px">
+              (cette estimation peut varier selon l’évolution du plan d’aide et du volume horaire)
+            </div>
           </li>
         </ul>
       </div>
@@ -54,7 +58,7 @@
 <script>
 import get from 'lodash/get';
 import Button from '@components/Button';
-import { HOURLY } from '@data/constants';
+import { HOURLY, FIXED } from '@data/constants';
 import { formatQuantity, formatPrice } from '@helpers/utils';
 import { subscriptionMixin } from 'src/modules/client/mixins/subscriptionMixin';
 
@@ -99,6 +103,7 @@ export default {
     return {
       // Data
       HOURLY,
+      FIXED,
       // Methods
       getBillingItemsPrice,
       getBillingItemsName,

--- a/src/modules/client/components/customers/SubscriptionCell.vue
+++ b/src/modules/client/components/customers/SubscriptionCell.vue
@@ -20,7 +20,7 @@
       <span class="text-weight-bold text-copper-grey-700">
         {{ formatPrice(getBillingItemsPrice()) }} / intervention
       </span>
-      <div class="text-italic q-mb-md" style="font-size: 12px">Ce prix correspond à : {{ getBillingItemsName() }}</div>
+      <div class="text-italic q-mb-md text-12">Ce prix correspond à : {{ getBillingItemsName() }}</div>
     </div>
     <div class="bg-copper-grey-100 text-copper-grey-700 weekly-infos">
       <div>
@@ -28,7 +28,7 @@
         <span class="text-weight-bold">{{ formatPrice(weeklyRate.total) }} / semaine</span>
         <span v-if="weeklyRate.totalSurcharge"> (dont {{ formatPrice(weeklyRate.totalSurcharge) }} de majoration)</span>
       </div>
-      <div class="text-italic" style="font-size: 14px">
+      <div class="text-italic text-14">
         <div>Estimation sur base de : </div>
         <ul>
           <li v-if="subscription.weeklyHours">
@@ -45,7 +45,7 @@
               @click="showSubscriptionFundings(subscription._id)">
               (voir détails)
             </span>
-            <div style="font-size: 12px">
+            <div class="text-12">
               (cette estimation peut varier selon l’évolution du plan d’aide et du volume horaire)
             </div>
           </li>
@@ -119,20 +119,20 @@ export default {
 </script>
 
 <style lang="sass" scoped>
-  .cell-container
-    background: white
-    width: 100%
-    margin-bottom: 10px
-    padding: 16px
-  .cell-header
-    justify-content: space-between
-    align-items: center
-  .weekly-infos
-    border-radius: 16px !important
-    padding: 16px
-    > div > ul
-      margin: 0
-      padding-inline-start: 24px
-  .funding-details
-    text-decoration: underline
+.cell-container
+  background: white
+  width: 100%
+  margin-bottom: 10px
+  padding: 16px
+.cell-header
+  justify-content: space-between
+  align-items: center
+.weekly-infos
+  border-radius: 16px !important
+  padding: 16px
+  > div > ul
+    margin: 0
+    padding-inline-start: 24px
+.funding-details
+  text-decoration: underline
 </style>


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : aidant

- Cas d'usage : 
Fix des retours de Romain : 
```
Rajouter “ / semaine” après le montant pris en charge, cf maquettes mises à jour

Rajouter le petit texte “(cette estimation peut varier selon l’évolution du plan d’aide et du volume horaire)” sous la ligne concernant le TP, cf maquettes mises à jour. Attention, notez bien que c’est en police 12, plus petit que le reste du texte

Lorsque le financement est forfaitaire, actuellement ça affiche une prise en charge de 0,00€. Ce que je propose : ne pas afficher la ligne relative à la prise en charge lorsque le financement est forfaitaire.
```

- Comment tester ? :
Vérifier que les retours de Romain sont pris en compte

_Si tu as lu cette description, pense a réagir avec un :eye:_
