### PR TITLE
COM-2718: required if other field not defined + boyscout format

### DIFF
--- a/src/core/helpers/date.js
+++ b/src/core/helpers/date.js
@@ -105,10 +105,10 @@ export const getDuration = (timePeriod) => {
 export const formatDurationFromFloat = (durationHours = 0) => {
   const hours = Math.floor(durationHours);
   const minutes = Math.round(durationHours % 1 * 60);
-  if (!hours) return `${minutes}min`;
+  if (!hours) return `${minutes.toString().padStart(2, '0')}min`;
   if (!minutes) return `${hours}h`;
 
-  return `${hours}h ${minutes}min`;
+  return `${hours}h ${minutes.toString().padStart(2, '0')}min`;
 };
 
 export const formatIntervalHourly = timePeriod => `${moment(timePeriod.startDate).format('HH:mm')} - `

--- a/src/core/helpers/date.js
+++ b/src/core/helpers/date.js
@@ -105,7 +105,7 @@ export const getDuration = (timePeriod) => {
 export const formatDurationFromFloat = (durationHours = 0) => {
   const hours = Math.floor(durationHours);
   const minutes = Math.round(durationHours % 1 * 60);
-  if (!hours) return `${minutes.toString().padStart(2, '0')}min`;
+  if (!hours) return `${minutes}min`;
   if (!minutes) return `${hours}h`;
 
   return `${hours}h ${minutes.toString().padStart(2, '0')}min`;

--- a/src/modules/vendor/components/programs/ProfileContent.vue
+++ b/src/modules/vendor/components/programs/ProfileContent.vue
@@ -121,7 +121,7 @@
 import { mapState } from 'vuex';
 import draggable from 'vuedraggable';
 import useVuelidate from '@vuelidate/core';
-import { required, helpers, maxValue } from '@vuelidate/validators';
+import { required, requiredIf, helpers, maxValue } from '@vuelidate/validators';
 import pick from 'lodash/pick';
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
@@ -219,8 +219,13 @@ export default {
       editedStep: {
         name: { required },
         theoreticalHours: {
-          hours: { required, integerNumber, positiveNumber },
-          minutes: { required, integerNumber, positiveNumber, maxValue: maxValue(59) },
+          hours: { required: requiredIf(!this.editedStep.theoreticalHours.minutes), integerNumber, positiveNumber },
+          minutes: {
+            required: requiredIf(!this.editedStep.theoreticalHours.hours),
+            integerNumber,
+            positiveNumber,
+            maxValue: maxValue(59),
+          },
         },
       },
       newActivity: { name: { required }, type: { required } },


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client rof/admin coach/admin

- Cas d'usage : quand je défini une durée d'étape, je ne suis pas obligé de définir heures ET minutes si l'un des deux vaut 0 (ex: je peux remplir juste le champ heure pour une étape d'une heure) + boyscout sur le format des heures : 
  - heures + minutes = xh xxmin ou xxh xxmin (1 chiffre pour l’heure < 10, 2 chiffres pour l’heure > 10, 2 chiffres pour les 
  - minutes peu importe le nombre de minutes)
  - heures = xh (1 chiffre pour l’heure < 10, 2 chiffres pour l’heures > 10, rien pour les minutes)
  - minutes = xxmin (rien pour les heures, 2 chiffres pour les minutes peu importe le nombre de minutes) 

- Comment tester ? : 
  - modifier une durée d'étape avec une heure pile (exemple 2h) sans spécifier les minutes => j'ai la bonne durée
  - modifier une durée d'étape avec une durée de < 1h (exemple 45minutes) sans spécifier les heures => j'ai la bonne durée
  - si je laisse les 2 champs vides => erreur de validation
  - définir une durée avec heures, sans minutes => elle s'affiche de la forme xh
  - définir une durée avec heures et minutes < 10 => elle s'affiche de la forme xh 0xmin
  - définir une durée avec heures et minutes > 10 => elles s'affiche de la forme xh xxmin
  - définir une durée sans heures avec des minutes => xxmin
  - définir une durée avec heures à 1 chiffre => xh xxmin
  - définir une durée avec heures à 2 chiffres => xxh xxmin

_Si tu as lu cette description, pense a réagir avec un :eye:_
