### PR TITLE
COM-2731 deisable mainFee.count and mainFee.price when billed

### DIFF
--- a/src/core/components/courses/CourseBilling.vue
+++ b/src/core/components/courses/CourseBilling.vue
@@ -46,7 +46,7 @@
                       </div>
                     </div>
                     <div>
-                      <ni-button icon="edit" @click="openBillingPurchaseEditionModal(bill._id, billingPurchase)" />
+                      <ni-button icon="edit" @click="openBillingPurchaseEditionModal(bill, billingPurchase)" />
                       <ni-button v-if="!isBilled(bill)" icon="delete"
                         @click="validatePurchaseDeletion(bill._id, billingPurchase._id)" />
                     </div>
@@ -86,7 +86,8 @@
     <!-- main fee edition modal -->
     <ni-course-fee-edition-modal v-model="mainFeeEditionModal" v-model:course-fee="editedBill.mainFee"
       @submit="editBill" :validations="validations.editedBill.mainFee" @hide="resetMainFeeEditionModal"
-      :loading="billEditionLoading" :error-messages="mainFeeErrorMessages" :title="courseFeeEditionModalTitle" />
+      :loading="billEditionLoading" :error-messages="mainFeeErrorMessages"
+      :title="courseFeeEditionModalMetaInfo.title" :is-billed="courseFeeEditionModalMetaInfo.isBilled" />
 
     <ni-billing-purchase-addition-modal v-model="billingPurchaseAdditionModal"
       v-model:new-billing-purchase="newBillingPurchase" @submit="addBillingPurchase"
@@ -96,8 +97,8 @@
 
     <!-- billing purchase edition modal -->
     <ni-course-fee-edition-modal v-model="billingPurchaseEditionModal" :validations="validations.editedBillingPurchase"
-      v-model:course-fee="editedBillingPurchase" @hide="resetBillingPurchaseEditionModal"
-      @submit="editBillingPurchase" :loading="billingPurchaseEditionLoading" :title="courseFeeEditionModalTitle"
+      v-model:course-fee="editedBillingPurchase" :title="courseFeeEditionModalMetaInfo.title"
+      @submit="editBillingPurchase" :loading="billingPurchaseEditionLoading" @hide="resetBillingPurchaseEditionModal"
       :error-messages="editedBillingPurchaseErrorMessages" />
 
     <ni-course-bill-validation-modal v-model="courseBillValidationModal" v-model:bill-to-validate="billToValidate"
@@ -171,7 +172,7 @@ export default {
     const editedBillingPurchase = ref({ _id: '', billId: '', price: 0, count: 1, description: '' });
     const areDetailsVisible = ref(Object.fromEntries(courseBills.value.map(bill => [bill._id, false])));
     const billToValidate = ref({ _id: '', billedAt: '' });
-    const courseFeeEditionModalTitle = ref('');
+    const courseFeeEditionModalMetaInfo = ref({ title: '', isBilled: false });
 
     const rules = {
       newBill: {
@@ -293,7 +294,10 @@ export default {
 
     const openMainFeeEditionModal = (bill) => {
       setEditedBill(bill);
-      courseFeeEditionModalTitle.value = get(course, 'value.subProgram.program.name');
+      courseFeeEditionModalMetaInfo.value = {
+        title: get(course, 'value.subProgram.program.name'),
+        isBilled: isBilled(bill),
+      };
       mainFeeEditionModal.value = true;
     };
 
@@ -302,15 +306,18 @@ export default {
       billingPurchaseAdditionModal.value = true;
     };
 
-    const openBillingPurchaseEditionModal = (billId, billingPurchase) => {
+    const openBillingPurchaseEditionModal = (bill, billingPurchase) => {
       editedBillingPurchase.value = {
         _id: billingPurchase._id,
-        billId,
+        billId: bill._id,
         price: billingPurchase.price,
         count: billingPurchase.count,
         description: billingPurchase.description,
       };
-      courseFeeEditionModalTitle.value = getBillingItemName(billingPurchase.billingItem);
+      courseFeeEditionModalMetaInfo.value = {
+        title: getBillingItemName(billingPurchase.billingItem),
+        isBilled: isBilled(bill),
+      };
       billingPurchaseEditionModal.value = true;
     };
 
@@ -331,7 +338,7 @@ export default {
 
     const resetMainFeeEditionModal = () => {
       resetEditedBill();
-      courseFeeEditionModalTitle.value = '';
+      courseFeeEditionModalMetaInfo.value = { title: '', isBilled: false };
     };
 
     const resetBillingPurchaseAdditionModal = () => {
@@ -342,7 +349,7 @@ export default {
     const resetBillingPurchaseEditionModal = () => {
       editedBillingPurchase.value = { billId: '', price: 0, count: 1, description: '' };
       validations.value.editedBillingPurchase.$reset();
-      courseFeeEditionModalTitle.value = '';
+      courseFeeEditionModalMetaInfo.value = { title: '', isBilled: false };
     };
 
     const resetCourseBillValidationModal = () => {
@@ -543,7 +550,7 @@ export default {
       billToValidate,
       payerList,
       courseBills,
-      courseFeeEditionModalTitle,
+      courseFeeEditionModalMetaInfo,
       // Computed
       validations,
       course,

--- a/src/modules/vendor/components/billing/CourseFeeEditionModal.vue
+++ b/src/modules/vendor/components/billing/CourseFeeEditionModal.vue
@@ -3,10 +3,10 @@
     <template #title>
       <span class="text-weight-bold">{{ title }}</span>
     </template>
-    <ni-input in-modal caption="Prix unitaire" :error="validations.price.$error" type="number"
+    <ni-input in-modal caption="Prix unitaire" :error="validations.price.$error" type="number" :disable="isBilled"
       :model-value="courseFee.price" @blur="validations.price.$touch" suffix="€" required-field
       :error-message="errorMessages.price" @update:model-value="update($event, 'price')" />
-    <ni-input in-modal caption="Quantité" :error="validations.count.$error" type="number"
+    <ni-input in-modal caption="Quantité" :error="validations.count.$error" type="number" :disable="isBilled"
       :model-value="courseFee.count" @blur="validations.count.$touch" required-field
       :error-message="errorMessages.count" @update:model-value="update($event, 'count')" />
     <ni-input in-modal caption="Description" type="textarea" :model-value="courseFee.description"
@@ -33,6 +33,7 @@ export default {
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
     title: { type: String, default: '' },
+    isBilled: { type: Boolean, default: false },
   },
   components: {
     'ni-modal': Modal,


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : formation vendeur / rof

- Cas d'usage :
   - je ne peux pas modifier le prix ou la quantité d'une commande de base qd la facture est facturée.
   - NB: je n'ai pas pris en compte les autres points du ticket

- Comment tester ? :
   - sur une facture facturée
      - sur la commande de base, les champs prix et quantité sont grisés
      - sur la commande de base, je peux modifier la description
   - sur une facture non facturé
      - sur la commande de base,  je peux toujours modifier ce que je veux
   - sur la branch dev coté webapp (et COM-2731 coté api)
      - lorsque je modifie le prix ou la qtt, j'ai une erreur qui pop 

_Si tu as lu cette description, pense a réagir avec un :eye:_
