### PR TITLE
COM-2743 - add loading

### DIFF
--- a/src/modules/client/pages/ni/billing/ToBill.vue
+++ b/src/modules/client/pages/ni/billing/ToBill.vue
@@ -5,8 +5,7 @@
         <div class="header-selects">
           <div class="row header-selects-container">
             <div class="col-xs-12 col-sm-4">
-              <ni-select class="q-ma-sm" :options="toBillOptions" v-model="toBillOption" data-cy="select-tpp"
-                />
+              <ni-select class="q-ma-sm" :options="toBillOptions" v-model="toBillOption" data-cy="select-tpp" />
             </div>
             <div class="col-xs-12 col-sm-8">
               <ni-date-range v-model="billingDates" @blur="getDraftBills" v-model:error="billingDatesHasError"
@@ -224,6 +223,7 @@ export default {
         this.v$.deliveryFile.$touch();
         if (this.v$.deliveryFile.$error) return NotifyWarning('Champ(s) invalide(s).');
 
+        this.modalLoading = true;
         const file = await Teletransmission.downloadDeliveryFile(this.deliveryFile);
         await downloadFile(file, this.getFileName());
 
@@ -231,6 +231,8 @@ export default {
       } catch (e) {
         NotifyNegative('Erreur lors du téléchargement du fichier.');
         console.error(e);
+      } finally {
+        this.modalLoading = false;
       }
     },
     formatPrice (value) {


### PR DESCRIPTION
- [ ] ~~J'ai vérifié la fonctionnalité sur mobile~~
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Client amdin

- Cas d'usage : Quand je télécharge un fichier de télétransmission, j'ai un loader sur le bouton de la modal

- Comment tester ? :
S'assurer d'avoir un tiers payeur en télétransmission + des bénéficiaires avec un financement sur ce tiers-payeur et des interventions sur ce mois
Sur la page "A facturer", ouvrir la modal de teletransmission, sélectionner ce tiers-payeur et le mois en cours
Valider le téléchargement => le loader tourne le temps de la requête

_Si tu as lu cette description, pense a réagir avec un :eye:_
