### PR TITLE
Com 2733

### DIFF
--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -55,9 +55,9 @@
         </template>
         <template v-if="newEvent.type !== ABSENCE && newEvent.repetition">
           <ni-select in-modal caption="Répétition de l'évènement" :model-value="newEvent.repetition.frequency"
-            :options="repetitionOptions" required-field @blur="validations.repetition.frequency.$touch"
-            :disable="!isRepetitionAllowed" @update:model-value="updateEvent('repetition.frequency', $event)"
-            :error="validations.repetition.frequency.$error" />
+            :options="getRepetitionOptions(newEvent.dates.startDate)" required-field :disable="!isRepetitionAllowed"
+            @blur="validations.repetition.frequency.$touch" :error="validations.repetition.frequency.$error"
+            @update:model-value="updateEvent('repetition.frequency', $event)" />
         </template>
         <template v-if="newEvent.type === INTERNAL_HOUR">
           <ni-search-address :model-value="newEvent.address" @update:model-value="updateEvent('address', $event)"

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -103,6 +103,7 @@ import {
   WORK_ACCIDENT,
   TRANSPORT_ACCIDENT,
   ILLNESS,
+  ABSENCE_TYPES,
 } from '@data/constants';
 import moment from '@helpers/moment';
 import { planningModalMixin } from 'src/modules/client/mixins/planningModalMixin';
@@ -177,6 +178,14 @@ export default {
     isAbsenceStartHourDisabled () {
       return !this.isIllnessOrWorkAccident(this.newEvent) && !this.isHourlyAbsence(this.newEvent) &&
         !this.isHalfDailyAbsence(this.newEvent);
+    },
+    absenceOptions () {
+      return this.newEvent && this.newEvent.absenceNature === HOURLY
+        ? ABSENCE_TYPES.filter(type => type.value === UNJUSTIFIED)
+        : ABSENCE_TYPES;
+    },
+    auxiliariesOptions () {
+      return this.getAuxiliariesOptions(this.newEvent);
     },
   },
   watch: {

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -75,7 +75,7 @@
             :disable="!selectedAuxiliary._id || historiesLoading" in-modal :extensions="extensions" drive-storage
             @delete="deleteDocument(editedEvent.attachment.driveId)" />
         </template>
-        <ni-input in-modal v-if="!editedEvent.shouldUpdateRepetition" type="textarea" :model-value="editedEvent.misc"
+        <ni-input in-modal type="textarea" :model-value="editedEvent.misc"
           caption="Notes" :disable="!canUpdateIntervention || historiesLoading" @blur="validations.misc.$touch"
           :error="validations.misc.$error" :required-field="isMiscRequired"
           @update:model-value="updateEvent('misc', $event)" />
@@ -93,7 +93,7 @@
             :error="validations.cancel.reason.$error" @update:model-value="updateEvent('cancel.reason', $event)"
             :disable="!canCancel || historiesLoading" />
         </div>
-        <template v-if="!editedEvent.shouldUpdateRepetition && editedEvent.type === INTERVENTION">
+        <template v-if="editedEvent.type === INTERVENTION">
           <ni-input in-modal caption="Déplacement véhiculé avec bénéficiaire" :model-value="editedEvent.kmDuringEvent"
             suffix="km" type="number" :error="validations.kmDuringEvent.$error" @blur="validations.kmDuringEvent.$touch"
             error-message="Le déplacement doit être positif ou nul" :disable="!canUpdateIntervention"
@@ -227,7 +227,7 @@ export default {
     },
     canCancel () {
       return this.editedEvent.type === INTERVENTION &&
-        !this.editedEvent.shouldUpdateRepetition &&
+        // !this.editedEvent.shouldUpdateRepetition &&
         !this.isBilledIntervention &&
         !this.startDateTimeStamped &&
         !this.endDateTimeStamped &&

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -74,7 +74,7 @@
             :disable="!selectedAuxiliary._id || historiesLoading" in-modal :extensions="extensions" drive-storage
             @delete="deleteDocument(editedEvent.attachment.driveId)" />
         </template>
-        <ni-input in-modal type="textarea" :model-value="editedEvent.misc"
+        <ni-input in-modal type="textarea" :model-value="editedEvent.misc" v-if="!editedEvent.shouldUpdateRepetition"
           caption="Notes" :disable="!canUpdateIntervention || historiesLoading" @blur="validations.misc.$touch"
           :error="validations.misc.$error" :required-field="isMiscRequired"
           @update:model-value="updateEvent('misc', $event)" />
@@ -105,7 +105,7 @@
           <div class="flex-row items-center justify-between">
             <div class="flex-row items-center">
               <q-icon size="sm" name="history" class="q-mr-sm" color="copper-grey-500" />
-              <div class="history-list-title text-weight-bold">Activité</div>
+              <div class="text-14 text-weight-bold">Activité</div>
             </div>
             <ni-button :label="historyButtonLabel" color="copper-grey-800" class="bg-copper-grey-100"
               @click="toggleHistory" :disable="historiesLoading" />
@@ -393,9 +393,6 @@ export default {
 .infos
   font-style: italic
   color: $copper-grey-400
-
-.history-list-title
-  font-size: 14px
 
 .repetition-infos-text
   color: $copper-grey-600

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -62,7 +62,7 @@
           <div v-if="!!editedEvent.extension"><div class="q-mb-md infos">{{ extensionInfos }}</div></div>
           <ni-select in-modal caption="Nature" :model-value="editedEvent.absenceNature" :options="absenceNatureOptions"
             :error="validations.absenceNature.$error" required-field disable />
-          <ni-select in-modal caption="Type d'absence" :model-value="editedEvent.absence" :options="absenceOptions"
+          <ni-select in-modal caption="Type d'absence" :model-value="editedEvent.absence" :options="ABSENCE_TYPES"
             :error="validations.absence.$error" required-field @blur="validations.absence.$touch"
             :disable="isHourlyAbsence(editedEvent) || historiesLoading" @update:model-value="updateAbsence($event)" />
           <ni-datetime-range caption="Dates et heures de l'évènement" :model-value="editedEvent.dates" required-field
@@ -196,6 +196,7 @@ export default {
       historyToCancel: {},
       isStartCancellation: true,
       timeStampCancellationReason: '',
+      ABSENCE_TYPES,
     };
   },
   validations () {
@@ -274,6 +275,9 @@ export default {
     },
     isAbsenceStartHourDisabled () {
       return this.isDailyAbsence(this.editedEvent) && !this.isIllnessOrWorkAccident(this.editedEvent);
+    },
+    auxiliariesOptions () {
+      return this.getAuxiliariesOptions(this.editedEvent);
     },
   },
   methods: {

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -38,10 +38,9 @@
             required-field />
           <ni-select in-modal caption="Répétition de l'évènement" :model-value="editedEvent.repetition.frequency"
             :options="getRepetitionOptions(editedEvent.dates.startDate)" disable />
-          <div class="repetition-infos-text q-mb-md">
+          <div v-if="isRepetition(editedEvent)" class="repetition-infos-text q-mb-md">
             L'annulation de l'évènement ou les modifications de notes, déplacement véhiculé ou transport spécifique ne
             s'appliqueront pas à la répétition
-            {{ editedEvent.repetition }}
           </div>
         </template>
         <template v-if="editedEvent.type === INTERNAL_HOUR">
@@ -52,12 +51,12 @@
             :error="validations.address.$error" @update:model-value="updateEvent('address', $event)"
             :disable="historiesLoading" :error-message="addressError" />
         </template>
-        <!-- <template v-if="isRepetition(editedEvent) && canUpdateIntervention && !editedEvent.isCancelled">
+        <template v-if="isRepetition(editedEvent) && !editedEvent.isCancelled && editedEvent.type !== INTERVENTION">
           <div class="row q-mb-md light-checkbox">
             <q-checkbox :model-value="editedEvent.shouldUpdateRepetition" label="Appliquer à la répétition"
               @update:model-value="toggleRepetition" dense :disable="historiesLoading" />
           </div>
-        </template> -->
+        </template>
         <template v-if="editedEvent.type === ABSENCE">
           <div v-if="!!editedEvent.extension"><div class="q-mb-md infos">{{ extensionInfos }}</div></div>
           <ni-select in-modal caption="Nature" :model-value="editedEvent.absenceNature" :options="absenceNatureOptions"
@@ -227,7 +226,7 @@ export default {
     },
     canCancel () {
       return this.editedEvent.type === INTERVENTION &&
-        // !this.editedEvent.shouldUpdateRepetition &&
+        !this.editedEvent.shouldUpdateRepetition &&
         !this.isBilledIntervention &&
         !this.startDateTimeStamped &&
         !this.endDateTimeStamped &&
@@ -297,11 +296,11 @@ export default {
         this.validations.cancel.$touch();
       }
     },
-    // toggleRepetition () {
-    //   this.updateEvent('cancel', {});
-    //   this.updateEvent('isCancelled', false);
-    //   this.updateEvent('shouldUpdateRepetition', !this.editedEvent.shouldUpdateRepetition);
-    // },
+    toggleRepetition () {
+      this.updateEvent('cancel', {});
+      this.updateEvent('isCancelled', false);
+      this.updateEvent('shouldUpdateRepetition', !this.editedEvent.shouldUpdateRepetition);
+    },
     isRepetition (event) {
       return ABSENCE !== event.type && event.repetition && event.repetition.frequency !== NEVER;
     },

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -36,6 +36,13 @@
             :model-value="editedEvent.subscription" :error="validations.subscription.$error" caption="Service" in-modal
             @blur="validations.subscription.$touch" :disable="!canUpdateIntervention || historiesLoading"
             required-field />
+          <ni-select in-modal caption="Répétition de l'évènement" :model-value="editedEvent.repetition.frequency"
+            :options="getRepetitionOptions(editedEvent.dates.startDate)" disable />
+          <div class="repetition-infos-text q-mb-md">
+            L'annulation de l'évènement ou les modifications de notes, déplacement véhiculé ou transport spécifique ne
+            s'appliqueront pas à la répétition
+            {{ editedEvent.repetition }}
+          </div>
         </template>
         <template v-if="editedEvent.type === INTERNAL_HOUR">
           <ni-select in-modal caption="Type d'heure interne" :model-value="editedEvent.internalHour"
@@ -45,12 +52,12 @@
             :error="validations.address.$error" @update:model-value="updateEvent('address', $event)"
             :disable="historiesLoading" :error-message="addressError" />
         </template>
-        <template v-if="isRepetition(editedEvent) && canUpdateIntervention && !editedEvent.isCancelled">
+        <!-- <template v-if="isRepetition(editedEvent) && canUpdateIntervention && !editedEvent.isCancelled">
           <div class="row q-mb-md light-checkbox">
             <q-checkbox :model-value="editedEvent.shouldUpdateRepetition" label="Appliquer à la répétition"
               @update:model-value="toggleRepetition" dense :disable="historiesLoading" />
           </div>
-        </template>
+        </template> -->
         <template v-if="editedEvent.type === ABSENCE">
           <div v-if="!!editedEvent.extension"><div class="q-mb-md infos">{{ extensionInfos }}</div></div>
           <ni-select in-modal caption="Nature" :model-value="editedEvent.absenceNature" :options="absenceNatureOptions"
@@ -286,11 +293,11 @@ export default {
         this.validations.cancel.$touch();
       }
     },
-    toggleRepetition () {
-      this.updateEvent('cancel', {});
-      this.updateEvent('isCancelled', false);
-      this.updateEvent('shouldUpdateRepetition', !this.editedEvent.shouldUpdateRepetition);
-    },
+    // toggleRepetition () {
+    //   this.updateEvent('cancel', {});
+    //   this.updateEvent('isCancelled', false);
+    //   this.updateEvent('shouldUpdateRepetition', !this.editedEvent.shouldUpdateRepetition);
+    // },
     isRepetition (event) {
       return ABSENCE !== event.type && event.repetition && event.repetition.frequency !== NEVER;
     },
@@ -386,4 +393,8 @@ export default {
 
 .history-list-title
   font-size: 14px
+
+.repetition-infos-text
+  color: $copper-grey-600
+  font-size: 12px
 </style>

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -373,6 +373,25 @@ export const planningActionMixin = {
           return 'Êtes-vous sûr(e) de vouloir modifier cette répétition ?';
       }
     },
+    areEditedFieldsApplicableToRepetition () {
+      const auxiliaryEvents = this.getRowEvents(this.editedEvent.auxiliary);
+      const initialEvent = auxiliaryEvents.find(e => e._id === this.editedEvent._id);
+
+      const formattedInitialEvent = {
+        startDate: initialEvent.startDate,
+        endDate: initialEvent.endDate,
+        serviceId: initialEvent.subscription._id,
+        customerId: initialEvent.customer._id,
+      };
+      const formattedEditedEvent = {
+        startDate: this.editedEvent.dates.startDate,
+        endDate: this.editedEvent.dates.endDate,
+        serviceId: this.editedEvent.subscription,
+        customerId: this.editedEvent.customer,
+      };
+
+      return !isEqual(formattedInitialEvent, formattedEditedEvent);
+    },
     async confirmEventEdition (shouldUpdateRepetition) {
       this.editedEvent.shouldUpdateRepetition = shouldUpdateRepetition;
       if (shouldUpdateRepetition) {
@@ -408,23 +427,7 @@ export const planningActionMixin = {
             .onOk(this.updateEvent)
             .onCancel(() => NotifyPositive('Modification annulée.'));
         } else if (this.editedEvent.type === INTERVENTION && this.editedEvent.auxiliary && isRepetition) {
-          const auxiliaryEvents = this.getRowEvents(this.editedEvent.auxiliary);
-          const initialEvent = auxiliaryEvents.find(e => e._id === this.editedEvent._id);
-
-          const formattedInitialEvent = {
-            startDate: initialEvent.startDate,
-            endDate: initialEvent.endDate,
-            serviceId: initialEvent.subscription._id,
-            customerId: initialEvent.customer._id,
-          };
-          const formattedEditedEvent = {
-            startDate: this.editedEvent.dates.startDate,
-            endDate: this.editedEvent.dates.endDate,
-            serviceId: this.editedEvent.subscription,
-            customerId: this.editedEvent.customer,
-          };
-          const editedFieldsAreApplicableToRepetition = !isEqual(formattedInitialEvent, formattedEditedEvent);
-
+          const editedFieldsAreApplicableToRepetition = this.areEditedFieldsApplicableToRepetition();
           if (editedFieldsAreApplicableToRepetition) {
             this.$q.dialog({
               title: 'Confirmation',

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -221,9 +221,7 @@ export const planningModalMixin = {
       ];
     },
     getAuxiliariesOptions (event) {
-      if (this.isCustomerPlanning && this.creationModal) {
-        return formatAndSortIdentityOptions(this.activeAuxiliaries);
-      }
+      if (this.isCustomerPlanning && this.creationModal) return formatAndSortIdentityOptions(this.activeAuxiliaries);
 
       const sector = this.filters.find(f => f.type === SECTOR && f._id === event.sector);
 

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -18,7 +18,6 @@ import {
   EVERY_WEEK_DAY,
   EVERY_WEEK,
   EVERY_TWO_WEEKS,
-  ABSENCE_TYPES,
   ABSENCE_NATURES,
   UNJUSTIFIED,
   DAILY,
@@ -81,11 +80,6 @@ export const planningModalMixin = {
     ...mapGetters({
       clientRole: 'main/getClientRole',
     }),
-    absenceOptions () {
-      return this.newEvent && this.newEvent.absenceNature === HOURLY
-        ? ABSENCE_TYPES.filter(type => type.value === UNJUSTIFIED)
-        : ABSENCE_TYPES;
-    },
     isCustomerPlanning () {
       return this.personKey === CUSTOMER;
     },
@@ -95,19 +89,6 @@ export const planningModalMixin = {
       }
 
       return EVENT_TYPES;
-    },
-    auxiliariesOptions () {
-      if (this.isCustomerPlanning && this.creationModal) {
-        return formatAndSortIdentityOptions(this.activeAuxiliaries);
-      }
-
-      const sectorId = this.newEvent ? this.newEvent.sector : this.editedEvent.sector;
-      const sector = this.filters.find(f => f.type === SECTOR && f._id === sectorId);
-
-      return [
-        { label: `À affecter ${sector ? sector.label : ''}`, value: '' },
-        ...formatAndSortIdentityOptions(this.activeAuxiliaries),
-      ];
     },
     internalHourOptions () {
       return this.internalHours.map(hour => ({ label: hour.name, value: hour._id }));
@@ -237,6 +218,18 @@ export const planningModalMixin = {
         { label: 'Tous les jours de la semaine (lundi au vendredi)', value: EVERY_WEEK_DAY },
         { label: oneWeekRepetitionLabel, value: EVERY_WEEK },
         { label: twoWeeksRepetitionLabel, value: EVERY_TWO_WEEKS },
+      ];
+    },
+    getAuxiliariesOptions (event) {
+      if (this.isCustomerPlanning && this.creationModal) {
+        return formatAndSortIdentityOptions(this.activeAuxiliaries);
+      }
+
+      const sector = this.filters.find(f => f.type === SECTOR && f._id === event.sector);
+
+      return [
+        { label: `À affecter ${sector ? sector.label : ''}`, value: '' },
+        ...formatAndSortIdentityOptions(this.activeAuxiliaries),
       ];
     },
   },

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -112,22 +112,6 @@ export const planningModalMixin = {
     internalHourOptions () {
       return this.internalHours.map(hour => ({ label: hour.name, value: hour._id }));
     },
-    repetitionOptions () {
-      const oneWeekRepetitionLabel = this.creationModal
-        ? `Tous les ${moment(this.newEvent.dates.startDate).format('dddd')}s`
-        : 'Tous les lundis';
-      const twoWeeksRepetitionLabel = this.creationModal
-        ? `Le ${moment(this.newEvent.dates.startDate).format('dddd')} une semaine sur deux`
-        : 'Le lundi une semaine sur deux';
-
-      return [
-        { label: 'Jamais', value: NEVER },
-        { label: 'Tous les jours', value: EVERY_DAY },
-        { label: 'Tous les jours de la semaine (lundi au vendredi)', value: EVERY_WEEK_DAY },
-        { label: oneWeekRepetitionLabel, value: EVERY_WEEK },
-        { label: twoWeeksRepetitionLabel, value: EVERY_TWO_WEEKS },
-      ];
-    },
     customerProfileRedirect () {
       return COACH_ROLES.includes(this.clientRole)
         ? { name: 'ni customers info', params: { customerId: this.selectedCustomer._id } }
@@ -242,6 +226,18 @@ export const planningModalMixin = {
       if (!get(this.selectedAuxiliary, 'contracts')) return [];
 
       return formatAndSortIdentityOptions(activeCustomers);
+    },
+    getRepetitionOptions (startDate) {
+      const oneWeekRepetitionLabel = `Tous les ${moment(startDate).format('dddd')}s`;
+      const twoWeeksRepetitionLabel = `Le ${moment(startDate).format('dddd')} une semaine sur deux`;
+
+      return [
+        { label: 'Jamais', value: NEVER },
+        { label: 'Tous les jours', value: EVERY_DAY },
+        { label: 'Tous les jours de la semaine (lundi au vendredi)', value: EVERY_WEEK_DAY },
+        { label: oneWeekRepetitionLabel, value: EVERY_WEEK },
+        { label: twoWeeksRepetitionLabel, value: EVERY_TWO_WEEKS },
+      ];
     },
   },
 };


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client

- Cas d'usage : 
Refacto UX de la modification des répétitions, on affiche désormais une modale pour sélectionner si la modification s'applique à la répétition ou à l'évènement uniquement 

- Comment tester ? :
Vérifier que la modification d'évènement / de répétition pour les indispo / heures internes est identiques au comportement sur dev.
Vérifier qu'on a bien la modale si on modifie une intervention liée à une répétition et tester les 2 options de la modale

_Si tu as lu cette description, pense a réagir avec un :eye:_
