### PR TITLE
COM-2720 print total elearning duration:

### DIFF
--- a/src/modules/client/pages/ni/courses/ELearningCourseProfile.vue
+++ b/src/modules/client/pages/ni/courses/ELearningCourseProfile.vue
@@ -34,7 +34,7 @@ export default {
     headerInfo () {
       return [{
         icon: 'hourglass_empty',
-        label: `Durée: ${formatDurationFromFloat(this.course.totalTheoreticalHours)}`,
+        label: `Durée : ${formatDurationFromFloat(this.course.totalTheoreticalHours)}`,
       }];
     },
   },

--- a/src/modules/client/pages/ni/courses/ELearningCourseProfile.vue
+++ b/src/modules/client/pages/ni/courses/ELearningCourseProfile.vue
@@ -1,6 +1,6 @@
 <template>
-    <q-page class="client-background" padding>
-      <ni-profile-header :title="courseName" />
+    <q-page v-if="course" class="client-background" padding>
+      <ni-profile-header :title="courseName" :header-info="headerInfo" />
       <profile-follow-up :profile-id="courseId" />
     </q-page>
 </template>
@@ -9,6 +9,7 @@
 import { createMetaMixin } from 'quasar';
 import { mapState } from 'vuex';
 import get from 'lodash/get';
+import { formatDurationFromFloat } from '@helpers/date';
 import ProfileHeader from '@components/ProfileHeader';
 import ProfileFollowUp from '@components/courses/ProfileFollowUp';
 import { NotifyNegative } from '@components/popup/notify';
@@ -29,6 +30,12 @@ export default {
     ...mapState('course', ['course']),
     courseName () {
       return get(this.course, 'subProgram.program.name');
+    },
+    headerInfo () {
+      return [{
+        icon: 'hourglass_empty',
+        label: `Durée: ${formatDurationFromFloat(this.course.totalTheoreticalHours)}`,
+      }];
     },
   },
   async created () {

--- a/src/modules/vendor/pages/ni/management/ELearningCourseProfile.vue
+++ b/src/modules/vendor/pages/ni/management/ELearningCourseProfile.vue
@@ -53,7 +53,7 @@ export default {
     const courseName = computed(() => get(course.value, 'subProgram.program.name'));
     const headerInfo = computed(() => [{
       icon: 'hourglass_empty',
-      label: `Durée: ${formatDurationFromFloat(course.value.totalTheoreticalHours)}`,
+      label: `Durée : ${formatDurationFromFloat(course.value.totalTheoreticalHours)}`,
     }]);
 
     const refreshCourse = async () => {

--- a/src/modules/vendor/pages/ni/management/ELearningCourseProfile.vue
+++ b/src/modules/vendor/pages/ni/management/ELearningCourseProfile.vue
@@ -1,6 +1,6 @@
 <template>
-    <q-page class="vendor-background" padding>
-      <ni-profile-header :title="courseName" />
+    <q-page v-if="course" class="vendor-background" padding>
+      <ni-profile-header :title="courseName" :header-info="headerInfo" />
       <profile-tabs :profile-id="courseId" :tabs-content="tabsContent" />
     </q-page>
 </template>
@@ -10,6 +10,7 @@ import { useMeta } from 'quasar';
 import { computed, onBeforeUnmount } from 'vue';
 import { useStore } from 'vuex';
 import get from 'lodash/get';
+import { formatDurationFromFloat } from '@helpers/date';
 import ProfileHeader from '@components/ProfileHeader';
 import ProfileTabs from '@components/ProfileTabs';
 import ProfileFollowUp from '@components/courses/ProfileFollowUp';
@@ -50,6 +51,10 @@ export default {
     const $store = useStore();
     const course = computed(() => $store.state.course.course);
     const courseName = computed(() => get(course.value, 'subProgram.program.name'));
+    const headerInfo = computed(() => [{
+      icon: 'hourglass_empty',
+      label: `Durée: ${formatDurationFromFloat(course.value.totalTheoreticalHours)}`,
+    }]);
 
     const refreshCourse = async () => {
       try {
@@ -72,6 +77,7 @@ export default {
       // Computed
       course,
       courseName,
+      headerInfo,
     };
   },
 };


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : formation vendeur et formation client / cof et coach

- Cas d'usage : 
  - sur une fiche formation eLearning, je peux voir la durée totale de la formation 

- Comment tester ? : 
    - sur une fiche formation elearning coté client : vérifier la durée 
    - sur une fiche formation elearning coté vendeur : vérifier la durée 
    - verifier que ca ne change rien sur les fiches formations mixtes coté client et vendeur

_Si tu as lu cette description, pense a réagir avec un :eye:_
