### PR TITLE
Com 2731 2

### DIFF
--- a/src/core/components/courses/CourseBilling.vue
+++ b/src/core/components/courses/CourseBilling.vue
@@ -54,7 +54,7 @@
                 </q-card>
               </div>
               <div class="row justify-end">
-                <ni-button color="primary" icon="add" label="Ajouter un article"
+                <ni-button v-if="!isBilled(bill)" color="primary" icon="add" label="Ajouter un article"
                   :disable="billingPurchaseCreationLoading" @click="openBillingPurchaseAdditionModal(bill._id)" />
               </div>
             </div>

--- a/src/core/components/courses/CourseBilling.vue
+++ b/src/core/components/courses/CourseBilling.vue
@@ -12,7 +12,7 @@
                 </div>
                 <div @click.stop="openFunderEditionModal(bill)" class="payer">
                   Payeur : {{ get(bill, 'courseFundingOrganisation.name') || get(bill, 'company.name') }}
-                  <q-icon size="16px" name="edit" color="copper-grey-500" />
+                  <q-icon v-if="!isBilled(bill)" size="16px" name="edit" color="copper-grey-500" />
                 </div>
                 {{ bill.billedAt ? `Date : ${formatDate(bill.billedAt)}` : '' }}
               </q-item-section>

--- a/src/core/components/courses/CourseBilling.vue
+++ b/src/core/components/courses/CourseBilling.vue
@@ -99,7 +99,7 @@
     <ni-course-fee-edition-modal v-model="billingPurchaseEditionModal" :validations="validations.editedBillingPurchase"
       v-model:course-fee="editedBillingPurchase" :title="courseFeeEditionModalMetaInfo.title"
       @submit="editBillingPurchase" :loading="billingPurchaseEditionLoading" @hide="resetBillingPurchaseEditionModal"
-      :error-messages="editedBillingPurchaseErrorMessages" />
+      :error-messages="editedBillingPurchaseErrorMessages" :is-billed="courseFeeEditionModalMetaInfo.isBilled" />
 
     <ni-course-bill-validation-modal v-model="courseBillValidationModal" v-model:bill-to-validate="billToValidate"
       @submit="validateBill" @hide="resetCourseBillValidationModal" :loading="billValidationLoading"


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : formation vendeur

- Cas d'usage :
 - blocage de toutes les modifications sur une facture facturée (excepté les descriptions de commande)

- Comment tester ? : 
   - le crayon d'edition du payeur a disparu
   - le bputon d'ajout d'article a disparu
   - sur la modale d'edition d'une commande d'article, les champs prix et qtt sont grisés 

_Si tu as lu cette description, pense a réagir avec un :eye:_
