### PR TITLE
COM-2729 - Fix Ulysse's reviews

### DIFF
--- a/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
+++ b/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
@@ -21,10 +21,11 @@
         @update:model-value="update($event, 'teletransmissionId')" />
       <ni-select in-modal caption="Type d'aide" :model-value="editedThirdPartyPayer.teletransmissionType"
         :options="thirdPartyPayerTypeOptions" :error="validations.teletransmissionType.$error"
-        @blur="validations.teletransmissionType.$touch" @update:model-value="update($event, 'teletransmissionType')" />
+        @blur="validations.teletransmissionType.$touch" @update:model-value="update($event, 'teletransmissionType')"
+        :required-field="!!editedThirdPartyPayer.teletransmissionId" />
       <ni-input in-modal caption="Identifiant structure" @update:model-value="update($event, 'companyCode')"
         :model-value="editedThirdPartyPayer.companyCode" :error="validations.companyCode.$error"
-        @blur="validations.companyCode.$touch" />
+        @blur="validations.companyCode.$touch" :required-field="!!editedThirdPartyPayer.teletransmissionId" />
       <div class="row q-mb-md light-checkbox">
         <q-checkbox :model-value="editedThirdPartyPayer.isApa" label="Financement APA" dense
           @update:model-value="update($event, 'isApa')" />


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client / coach - admin

- Cas d'usage :
Dans la modale d'édition d'un tier payeur, si j'ai rempli le champ de `ID de télétransmission`, les champs Identifiant structure et Type d'aide sont affichés comme requis

- Comment tester ? :
C'est assez explicite

_Si tu as lu cette description, pense a réagir avec un :eye:_
