### PR TITLE
Com 2764

### DIFF
--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -375,8 +375,8 @@ export const planningActionMixin = {
     },
     areEditedFieldsApplicableToRepetition () {
       const eventGroupId = this.editedEvent.auxiliary || this.editedEvent.sector;
-      const auxiliaryEvents = this.getRowEvents(eventGroupId);
-      const initialEvent = auxiliaryEvents.find(e => e._id === this.editedEvent._id);
+      const groupEvents = this.getRowEvents(eventGroupId);
+      const initialEvent = groupEvents.find(e => e._id === this.editedEvent._id);
 
       if (!initialEvent) return true;
 

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -374,7 +374,8 @@ export const planningActionMixin = {
       }
     },
     areEditedFieldsApplicableToRepetition () {
-      const auxiliaryEvents = this.getRowEvents(this.editedEvent.auxiliary);
+      const eventGroupId = this.editedEvent.auxiliary || this.editedEvent.sector;
+      const auxiliaryEvents = this.getRowEvents(eventGroupId);
       const initialEvent = auxiliaryEvents.find(e => e._id === this.editedEvent._id);
 
       if (!initialEvent) return true;
@@ -396,7 +397,7 @@ export const planningActionMixin = {
     },
     async confirmEventEdition (shouldUpdateRepetition) {
       this.editedEvent.shouldUpdateRepetition = shouldUpdateRepetition;
-      if (shouldUpdateRepetition) {
+      if (shouldUpdateRepetition && this.editedEvent.auxiliary) {
         this.$q.dialog({
           title: 'Confirmation',
           message: this.getEditionConfirmationMessage(),
@@ -428,7 +429,7 @@ export const planningActionMixin = {
           })
             .onOk(this.updateEvent)
             .onCancel(() => NotifyPositive('Modification annulée.'));
-        } else if (this.editedEvent.type === INTERVENTION && this.editedEvent.auxiliary && isRepetition) {
+        } else if (this.editedEvent.type === INTERVENTION && isRepetition) {
           const editedFieldsAreApplicableToRepetition = this.areEditedFieldsApplicableToRepetition();
           if (editedFieldsAreApplicableToRepetition) {
             this.$q.dialog({

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -377,6 +377,8 @@ export const planningActionMixin = {
       const auxiliaryEvents = this.getRowEvents(this.editedEvent.auxiliary);
       const initialEvent = auxiliaryEvents.find(e => e._id === this.editedEvent._id);
 
+      if (!initialEvent) return true;
+
       const formattedInitialEvent = {
         startDate: initialEvent.startDate,
         endDate: initialEvent.endDate,


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
**Périmètre interfaces / rôles :** client / admin coach

**Cas d'usage :**
Si je clique sur enregistrer sans rien changer, ça sort l'évènement de la répétition mais je ne suis pas au courant de cet effet.
Pour palier à ça, j'ai essayé de comparer l'évènement modifié à l'évènement initial mais les deux objets sont formattés différemment et c'est trop complexe dans le code pour un cas autant à la marge.
On ne peut pas non plus se baser sur la validation $anyDirty ou $dirty car celle ci passe à true si on focus un champ.

Je vous ai donc fait une proposition que je trouve sympathique : afficher une modale pour prévenir que l'évènement sort de la répétition si on le modifie sur des champs non applicable à la répétition.
Ce qui résout le bug car l'utilisateur est prévenu que son action à une conséquence et donc s'il ne voulait rien modifier, il peut quitter la modale directement.
Et ça permet d'être transparent sur le fait que l'évènement sort de la répétition même lorsqu'on fait un petit changement (par exemple lorsqu'on change la note)

Qu'en pensez-vous ?

Je demanderais un meilleur message à Romain, là j'ai mis un message bâteau pour vous présenter la solution. Si vous avez des idées, n'hésitez pas

+ J'ai aussi fix un bug qui empêchait de modifier l'auxiliaire

**Comment tester ? :**
Vérifier qu'on a bien la modale si on est dans le cas où on change quelque chose non applicable à la répétition

_Si tu as lu cette description, pense a réagir avec un :eye:_
