### PR TITLE
COM-2729-fix-2 type is clearable

### DIFF
--- a/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
+++ b/src/modules/client/components/config/ThirdPartyPayerEditionModal.vue
@@ -20,9 +20,9 @@
       <ni-input in-modal caption="ID de télétransmission" :model-value="editedThirdPartyPayer.teletransmissionId"
         @update:model-value="update($event, 'teletransmissionId')" />
       <ni-select in-modal caption="Type d'aide" :model-value="editedThirdPartyPayer.teletransmissionType"
-        :options="thirdPartyPayerTypeOptions" :error="validations.teletransmissionType.$error"
+        :options="thirdPartyPayerTypeOptions" :clearable="!editedThirdPartyPayer.teletransmissionId"
         @blur="validations.teletransmissionType.$touch" @update:model-value="update($event, 'teletransmissionType')"
-        :required-field="!!editedThirdPartyPayer.teletransmissionId" />
+        :required-field="!!editedThirdPartyPayer.teletransmissionId" :error="validations.teletransmissionType.$error" />
       <ni-input in-modal caption="Identifiant structure" @update:model-value="update($event, 'companyCode')"
         :model-value="editedThirdPartyPayer.companyCode" :error="validations.companyCode.$error"
         @blur="validations.companyCode.$touch" :required-field="!!editedThirdPartyPayer.teletransmissionId" />


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : compani outils / admin

- Cas d'usage : dans la modela d'edition d'un tiers payeur,  je peux suppprimer le type d'aide si il n'y a pas d'ID de teletransmission

- Comment tester ? : supprimer l'id => le select devient "vidable"

_Si tu as lu cette description, pense a réagir avec un :eye:_
