### PR TITLE
mini-fixes-mes-22-03: minor fixes

### DIFF
--- a/src/core/components/courses/CourseBilling.vue
+++ b/src/core/components/courses/CourseBilling.vue
@@ -288,6 +288,8 @@ export default {
     };
 
     const openFunderEditionModal = (bill) => {
+      if (isBilled(bill)) return null;
+
       setEditedBill(bill);
       funderEditionModal.value = true;
     };

--- a/src/modules/vendor/components/programs/StepEditionModal.vue
+++ b/src/modules/vendor/components/programs/StepEditionModal.vue
@@ -5,14 +5,14 @@
     </template>
     <ni-input in-modal :model-value="editedStep.name" :error="validations.name.$error" caption="Nom"
       @update:model-value="update($event.trim(), 'name')" @blur="validations.name.$touch" required-field />
-    <div class="row">
+    <div class="row items-end">
       <ni-input in-modal caption="Durée théorique" type="number" :model-value="editedStep.theoreticalHours.hours"
         :error="validations.theoreticalHours.hours.$error" :error-message="theoreticalHoursErrorMsg" suffix="h"
         required-field @blur="validations.theoreticalHours.hours.$touch"
         @update:model-value="updateTheoreticalHours($event, 'hours')" class="flex-1 q-pr-sm" />
       <ni-input in-modal caption="" type="number" :model-value="editedStep.theoreticalHours.minutes"
         :error="validations.theoreticalHours.minutes.$error" :error-message="theoreticalMinutesErrorMsg" suffix="min"
-        required-field @blur="validations.theoreticalHours.hours.$touch"
+        @blur="validations.theoreticalHours.hours.$touch"
         @update:model-value="updateTheoreticalHours($event, 'minutes')" class="flex-1 q-pl-sm" />
     </div>
     <template #footer>


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage : boyscout : plus d'astérisque sur le deuxième champ de la modèle d'édition d'étape + je ne peux plus ouvrir la modale d'édition de financeur si la facture est facturée

- Comment tester ? : c'est explicit ⬆️ 

_Si tu as lu cette description, pense a réagir avec un :eye:_
