### PR TITLE
COM-2766 remove warning on test launch

### DIFF
--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -6,10 +6,10 @@ const parseEnv = env => Object.keys(env).reduce((acc, key) => {
 }, {});
 
 module.exports = (on, config) => {
-  on('before:browser:launch', (browser = {}, args) => {
+  on('before:browser:launch', (browser, launchOptions) => {
     if (browser.name === 'chrome') {
-      args.push('--disable-blink-features=RootLayerScrolling');
-      return args;
+      launchOptions.args.push('--disable-blink-features=RootLayerScrolling');
+      return launchOptions;
     }
     return true;
   });


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : -np

- Cas d'usage : Suppression du warning quand on lance un test avec cypress

- Comment tester ? : Lancer un test avec cypress, il ne devrait pas y avoir le warning 
```
Deprecation Warning: The before:browser:launch plugin event changed its signature in version 4.0.0
```

Note : je pense que notre version de cypress est definie par l'extension que l'on utilise pour utiliser cypress avec quasar. J'ai vu qu'il y avait une nouvelle version de cette extension --> je propose d'en faire un ticket en dehors du sujet que l'on traite actuellement. Qu'en penses-tu ? 

_Si tu as lu cette description, pense a réagir avec un :eye:_
