### PR TITLE
COM-2769 use luxon instead of cypress.moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14470,6 +14470,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.1.tgz",
+      "integrity": "sha512-I8vnjOmhXsMSlNMZlMkSOvgrxKJl0uOsEzdGgGNZuZPaS9KlefpE9KV95QFftlJSC+1UyCC9/I69R02cz/zcCA==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "eslint-plugin-promise": "^5.2.0",
     "eslint-plugin-vue": "^8.2.0",
     "eslint-webpack-plugin": "^3.1.1",
-    "html-loader": "^3.0.1"
+    "html-loader": "^3.0.1",
+    "luxon": "^2.3.1"
   },
   "engines": {
     "node": "14.18.0",

--- a/test/cypress/integration/auxiliary/planning/auxiliaryAgenda.spec.js
+++ b/test/cypress/integration/auxiliary/planning/auxiliaryAgenda.spec.js
@@ -16,7 +16,7 @@ describe('Auxiliary agenda - display', () => {
     cy.get('[data-cy=event-end-hour]').eq(0).should('contain', '12:30');
 
     cy.get('[data-cy=planning_before]').click();
-    cy.get('[data-cy=week-number]').should('contain', Cypress.moment().subtract(1, 'week').subtract(1, 'day').week());
+    cy.get('[data-cy=week-number]').should('contain', Cypress.luxon.DateTime.now().minus({ weeks: 1 }).weekNumber);
     cy.get('.event-intervention').should('have.length', 2);
     cy.get('[data-cy=event-title]').eq(0).should('contain', 'R.BARDET');
     cy.get('[data-cy=event-start-hour]').eq(0).should('contain', '11:15');

--- a/test/cypress/integration/customer/agenda.spec.js
+++ b/test/cypress/integration/customer/agenda.spec.js
@@ -9,17 +9,12 @@ describe('customers agenda tests', () => {
     cy.get('#q-app').click(500, 500);
     cy.get('[data-cy=customer-identity]').should('have.value', 'Romain BARDET');
 
-    cy.get('[data-cy=week-number]').should('contain', Cypress.moment().subtract(1, 'day').week());
+    cy.get('[data-cy=week-number]').should('contain', Cypress.luxon.DateTime.now().weekNumber);
     cy.get('[data-cy=days-number]').eq(0).should(
       'contain',
-      Cypress.moment().subtract(1, 'day').startOf('week').add(1, 'day')
-        .format('DD')
+      Cypress.luxon.DateTime.now().startOf('week').toFormat('dd')
     );
-    cy.get('[data-cy=days-number]').eq(6).should(
-      'contain',
-      Cypress.moment().subtract(1, 'day').endOf('week').add(1, 'day')
-        .format('DD')
-    );
+    cy.get('[data-cy=days-number]').eq(6).should('contain', Cypress.luxon.DateTime.now().endOf('week').toFormat('dd'));
   });
 
   it('should go through agenda and display events', () => {
@@ -30,7 +25,7 @@ describe('customers agenda tests', () => {
     cy.get('[data-cy=event-end-hour]').eq(0).should('contain', '12:30');
 
     cy.get('[data-cy=planning_before]').click();
-    cy.get('[data-cy=week-number]').should('contain', Cypress.moment().subtract(1, 'week').subtract(1, 'day').week());
+    cy.get('[data-cy=week-number]').should('contain', Cypress.luxon.DateTime.now().minus({ weeks: 1 }).weekNumber);
     cy.get('.event-intervention').should('have.length', 3);
     cy.get('[data-cy=event-title]').eq(0).should('contain', 'Auxiliary O.');
     cy.get('[data-cy=event-start-hour]').eq(0).should('contain', '11:15');
@@ -43,11 +38,11 @@ describe('customers agenda tests', () => {
     cy.get('[data-cy=event-end-hour]').eq(2).should('contain', '20:30');
 
     cy.get('[data-cy=planning_after]').click();
-    cy.get('[data-cy=week-number]').should('contain', Cypress.moment().subtract(1, 'day').week());
+    cy.get('[data-cy=week-number]').should('contain', Cypress.luxon.DateTime.now().weekNumber);
 
     cy.get('[data-cy=planning_before]').click();
     cy.get('[data-cy=planning_before]').click();
     cy.get('[data-cy=planning_today]').click();
-    cy.get('[data-cy=week-number]').should('contain', Cypress.moment().subtract(1, 'day').week());
+    cy.get('[data-cy=week-number]').should('contain', Cypress.luxon.DateTime.now().weekNumber);
   });
 });

--- a/test/cypress/integration/customer/subscription.spec.js
+++ b/test/cypress/integration/customer/subscription.spec.js
@@ -115,7 +115,7 @@ describe('customers subscription tests', () => {
         iban: 'FR3617569000306699167186M11',
         companyName: 'Test SAS',
         companyAddress: '37 rue de Ponthieu 75008 Paris',
-        downloadDate: Cypress.moment().format('DD/MM/YYYY'),
+        downloadDate: Cypress.luxon.DateTime.now().toLocaleString(),
       });
     });
 

--- a/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
+++ b/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
@@ -20,7 +20,7 @@ describe('Auxiliary planning - display', () => {
     cy.get('[data-cy=event-end-hour]').eq(0).should('contain', '12:30');
 
     cy.get('[data-cy=planning_before]').click();
-    cy.get('[data-cy=week-number]').should('contain', Cypress.moment().subtract(1, 'week').subtract(1, 'day').week());
+    cy.get('[data-cy=week-number]').should('contain', Cypress.luxon.DateTime.now().minus({ weeks: 1 }).weekNumber);
     cy.get('.event-intervention').should('have.length', 2);
     cy.get('[data-cy=event-title]').eq(0).should('contain', 'R.BARDET');
     cy.get('[data-cy=event-start-hour]').eq(0).should('contain', '11:15');

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -1,5 +1,7 @@
 import './commands';
 
+const luxon = require('luxon');
+
 const resizeObserverLoopErrRe = /^ResizeObserver loop limit exceeded/;
 
 Cypress.on('uncaught:exception', (err) => {
@@ -8,3 +10,8 @@ Cypress.on('uncaught:exception', (err) => {
     return false;
   }
 });
+
+luxon.Settings.defaultLocale = 'fr';
+luxon.Settings.defaultZone = 'Europe/Paris';
+luxon.Settings.throwOnInvalid = true;
+Cypress.luxon = luxon;


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles :np

- Cas d'usage : Remplacement de Cypress.moment par luxon pour reparer le probleme du numero de la semaine. Je n'ai pas beaucoup creusé pourquoi est-ce que Cypress.moment ne nous renvoyait pas les bonnes valeurs car je suis assez vite tombé sur les changelog de cypress, qui indiquait que Cypress.moment etait deprecie et supprimé dans une version superieur. Du coup j'ai remplacé par luxon. (Dans l'exemple de cypress, ils utilisaient dayjs mais je me suis dit qu'il vallait mieux qu'on utilise luxon)
https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/blogs__dayjs/cypress/support/index.js
https://docs.cypress.io/guides/references/changelog#7-0-0

- Comment tester ? : Vérifier que les tests modifiés par cette pr passent bien 
    - auxiliaryAgenda `should display correctly auxiliary agenda`
    - customer/agenda `should display correctly the agenda page` et `should go through agenda and display events`
    - customer/subscription `should display correctly the payment part and open the modal for the mandate`
    - auxiliaryPlanning `should display correctly auxiliary planning`

_Si tu as lu cette description, pense a réagir avec un :eye:_
