### PR TITLE
COM-2751: disable button + boyscout

### DIFF
--- a/src/modules/client/pages/ni/config/CustomersConfig.vue
+++ b/src/modules/client/pages/ni/config/CustomersConfig.vue
@@ -133,7 +133,7 @@
                     <div class="row no-wrap table-actions">
                       <ni-button icon="remove_red_eye" @click="openThirdPartyPayerDetailsModal(col.value)" />
                       <ni-button icon="edit" @click="openThirdPartyPayerEditionModal(col.value)" />
-                      <ni-button :disable="isTppUsedInFundings(props.row)" icon="delete"
+                      <ni-button :disable="props.row.isUsedInFundings" icon="delete"
                         @click="validateTppDeletion(col.value, props.row)" />
                     </div>
                   </template>
@@ -1298,10 +1298,6 @@ export default {
         cancel: 'Annuler',
       }).onOk(() => this.deleteThirdPartyPayer(thirdPartyPayerId, row))
         .onCancel(() => NotifyPositive('Suppression annulée.'));
-    },
-    isTppUsedInFundings (tpp) {
-      const index = this.getRowIndex(this.thirdPartyPayers, tpp);
-      return this.thirdPartyPayers[index].isUsedInFundings;
     },
   },
 };

--- a/src/modules/vendor/pages/ni/billing/BillingConfig.vue
+++ b/src/modules/vendor/pages/ni/billing/BillingConfig.vue
@@ -25,7 +25,8 @@
                   :class="col.name">
                   <template v-if="col.name === 'actions'">
                     <div class="row no-wrap table-actions">
-                      <ni-button icon="delete" @click="validateOrganisationDeletion(col.value)" />
+                      <ni-button icon="delete" @click="validateOrganisationDeletion(col.value)"
+                        :disable="!!props.row.courseBillCount" />
                     </div>
                   </template>
                   <template v-else>{{ col.value }}</template>


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage : je ne peux pas supprimer un financeur s'il est utilisé pour une facture (validée ou non)

- Comment tester ? : 
 - créer un financeur
 - l'assigner à une facture => je ne peux plus le supprimer
 - le désassigner de la facture => je peux le supprimer
 - valider la facture avec le financeur => je ne peux plus le supprimer
 - faire ces tests pour le disable en front et pour le blocage back (retirer le disable pour tester cette deuxième façon) 

_Si tu as lu cette description, pense a réagir avec un :eye:_
