### PR TITLE
COM-2753 forbid bill validation if no client address

### DIFF
--- a/src/core/components/courses/CourseBilling.vue
+++ b/src/core/components/courses/CourseBilling.vue
@@ -485,6 +485,7 @@ export default {
         await refreshCourseBills();
       } catch (e) {
         console.error(e);
+        if (e.status === 403) return NotifyNegative(e.data.message);
         NotifyNegative('Erreur lors de la validation de la facture.');
       } finally {
         billValidationLoading.value = false;


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : formation / rof

- Cas d'usage :
  - je vois plus d'info sur une facture
     - le numero de la facture, la date
     - le nom. l'adresse et le siret du créditeur
     - le nom et l'adresse du debiteur
     - le nom de la structure cliente
     - un footer avec un rappel sur la TVA
  - sur demande de ROmain, j'ai bloqué la facturation si il manque l'adresse du debiteur (pas de financeur et il manque l'addresse de la structure cliente)

- Comment tester ? : 
   - verifier toutes les infos sur une facture telechargée 
   - ajouter un financeur sur une facture, verifier le nom et l'adresse du financeur sur la facture
   - ne pas ajouter de financeur, verifier le nom et l'adresse de la structure cliente sur la facture
   - valider une facturation sans adresse sur la structure cliente (qui est aussi le debiteur) => erreur 403

_Si tu as lu cette description, pense a réagir avec un :eye:_
