### PR TITLE
Com 2787

### DIFF
--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -569,3 +569,7 @@ export const CREDIT_NOTE_TYPE_OPTIONS = [
 // COURSE_BILLS
 export const LIST = 'list';
 export const BALANCE = 'balance';
+
+// END_TO_END TESTS
+export const BILLING = 'billing';
+export const AUTHENTICATION = 'authentication';

--- a/test/cypress/integration/authenticate.spec.js
+++ b/test/cypress/integration/authenticate.spec.js
@@ -1,6 +1,8 @@
+const { AUTHENTICATION } = require('../../../src/core/data/constants');
+
 describe('Login page tests', () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/authentication`);
+    cy.initiateTest({ seeds: AUTHENTICATION });
     cy.visit('/login');
   });
 

--- a/test/cypress/integration/authenticate.spec.js
+++ b/test/cypress/integration/authenticate.spec.js
@@ -2,7 +2,7 @@ const { AUTHENTICATION } = require('../../../src/core/data/constants');
 
 describe('Login page tests', () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: AUTHENTICATION });
+    cy.initiateTest({ seedType: AUTHENTICATION });
     cy.visit('/login');
   });
 

--- a/test/cypress/integration/auxiliary/planning/auxiliaryAgenda.spec.js
+++ b/test/cypress/integration/auxiliary/planning/auxiliaryAgenda.spec.js
@@ -1,7 +1,8 @@
+const { PLANNING } = require('../../../../../src/core/data/constants');
+
 describe('Auxiliary agenda - display', () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/planning`);
-    cy.login({ email: 'auxiliary@alenvi.io', password: '123456!eR' });
+    cy.initiateTest({ seeds: PLANNING, credentials: { email: 'auxiliary@alenvi.io', password: '123456!eR' } });
     cy.visit('/auxiliaries/agenda');
   });
 

--- a/test/cypress/integration/auxiliary/planning/auxiliaryAgenda.spec.js
+++ b/test/cypress/integration/auxiliary/planning/auxiliaryAgenda.spec.js
@@ -2,7 +2,7 @@ const { PLANNING } = require('../../../../../src/core/data/constants');
 
 describe('Auxiliary agenda - display', () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: PLANNING, credentials: { email: 'auxiliary@alenvi.io', password: '123456!eR' } });
+    cy.initiateTest({ seedType: PLANNING, credentials: { email: 'auxiliary@alenvi.io', password: '123456!eR' } });
     cy.visit('/auxiliaries/agenda');
   });
 

--- a/test/cypress/integration/customer/agenda.spec.js
+++ b/test/cypress/integration/customer/agenda.spec.js
@@ -2,7 +2,7 @@ const { PLANNING } = require('../../../../src/core/data/constants');
 
 describe('customers agenda tests', () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: PLANNING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
+    cy.initiateTest({ seedType: PLANNING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
     cy.visit('/customers/agenda');
   });
 

--- a/test/cypress/integration/customer/agenda.spec.js
+++ b/test/cypress/integration/customer/agenda.spec.js
@@ -1,7 +1,8 @@
+const { PLANNING } = require('../../../../src/core/data/constants');
+
 describe('customers agenda tests', () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/planning`);
-    cy.login({ email: 'helper@alenvi.io', password: '123456!eR' });
+    cy.initiateTest({ seeds: PLANNING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
     cy.visit('/customers/agenda');
   });
 

--- a/test/cypress/integration/customer/billing.spec.js
+++ b/test/cypress/integration/customer/billing.spec.js
@@ -2,7 +2,7 @@ const { BILLING } = require('../../../../src/core/data/constants');
 
 describe('Customer billing tests', () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: BILLING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
+    cy.initiateTest({ seedType: BILLING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
     cy.visit('/customers/documents');
     cy.get('#q-app').click(500, 500);
   });

--- a/test/cypress/integration/customer/billing.spec.js
+++ b/test/cypress/integration/customer/billing.spec.js
@@ -1,7 +1,8 @@
+const { BILLING } = require('../../../../src/core/data/constants');
+
 describe('Customer billing tests', () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/billing`);
-    cy.login({ email: 'helper@alenvi.io', password: '123456!eR' });
+    cy.initiateTest({ seeds: BILLING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
     cy.visit('/customers/documents');
     cy.get('#q-app').click(500, 500);
   });

--- a/test/cypress/integration/customer/contact.spec.js
+++ b/test/cypress/integration/customer/contact.spec.js
@@ -1,7 +1,8 @@
+const { PLANNING } = require('../../../../src/core/data/constants');
+
 describe('Customer contact tests', () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/planning`);
-    cy.login({ email: 'helper@alenvi.io', password: '123456!eR' });
+    cy.initiateTest({ seeds: PLANNING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
     cy.visit('/customers/contact');
   });
 

--- a/test/cypress/integration/customer/contact.spec.js
+++ b/test/cypress/integration/customer/contact.spec.js
@@ -2,7 +2,7 @@ const { PLANNING } = require('../../../../src/core/data/constants');
 
 describe('Customer contact tests', () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: PLANNING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
+    cy.initiateTest({ seedType: PLANNING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
     cy.visit('/customers/contact');
   });
 

--- a/test/cypress/integration/customer/subscription.spec.js
+++ b/test/cypress/integration/customer/subscription.spec.js
@@ -1,9 +1,9 @@
 const moment = require('moment');
+const { BILLING } = require('../../../../src/core/data/constants');
 
 describe('customers subscription tests', () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/billing`);
-    cy.login({ email: 'helper@alenvi.io', password: '123456!eR' });
+    cy.initiateTest({ seeds: BILLING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
     cy.visit('/customers/subscriptions');
   });
 

--- a/test/cypress/integration/customer/subscription.spec.js
+++ b/test/cypress/integration/customer/subscription.spec.js
@@ -3,7 +3,7 @@ const { BILLING } = require('../../../../src/core/data/constants');
 
 describe('customers subscription tests', () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: BILLING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
+    cy.initiateTest({ seedType: BILLING, credentials: { email: 'helper@alenvi.io', password: '123456!eR' } });
     cy.visit('/customers/subscriptions');
   });
 

--- a/test/cypress/integration/ni/billing/toBill.spec.js
+++ b/test/cypress/integration/ni/billing/toBill.spec.js
@@ -1,7 +1,8 @@
+const { BILLING } = require('../../../../../src/core/data/constants');
+
 describe('ToBill', () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/billing`);
-    cy.login({ email: 'client-admin@alenvi.io', password: '123456!eR' });
+    cy.initiateTest({ seeds: BILLING, credentials: { email: 'client-admin@alenvi.io', password: '123456!eR' } });
     cy.visit('/ni/billing/to-bill');
     cy.get('#q-app').click(500, 500);
   });

--- a/test/cypress/integration/ni/billing/toBill.spec.js
+++ b/test/cypress/integration/ni/billing/toBill.spec.js
@@ -2,7 +2,7 @@ const { BILLING } = require('../../../../../src/core/data/constants');
 
 describe('ToBill', () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: BILLING, credentials: { email: 'client-admin@alenvi.io', password: '123456!eR' } });
+    cy.initiateTest({ seedType: BILLING, credentials: { email: 'client-admin@alenvi.io', password: '123456!eR' } });
     cy.visit('/ni/billing/to-bill');
     cy.get('#q-app').click(500, 500);
   });

--- a/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
+++ b/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
@@ -1,9 +1,8 @@
-import { CLIENT_ADMIN, COACH, AUXILIARY, PLANNING_REFERENT } from '../../../../../src/core/data/constants';
+import { CLIENT_ADMIN, COACH, AUXILIARY, PLANNING_REFERENT, PLANNING } from '../../../../../src/core/data/constants';
 
 describe('Auxiliary planning - display', () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/planning`);
-    cy.login({ email: 'auxiliary@alenvi.io', password: '123456!eR' });
+    cy.initiateTest({ seeds: PLANNING, credentials: { email: 'auxiliary@alenvi.io', password: '123456!eR' } });
     cy.visit('/ni/planning/auxiliaries');
   });
 
@@ -44,7 +43,7 @@ const loggedUsers = [
 
 loggedUsers.forEach(user => describe(`Auxiliary planning - actions - ${user.role}`, () => {
   beforeEach(() => {
-    cy.initiateTest({ email: user.email, password: user.password });
+    cy.initiateTest({ seeds: PLANNING, credentials: { email: user.email, password: user.password } });
     cy.visit('/ni/planning/auxiliaries');
   });
 

--- a/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
+++ b/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
@@ -2,7 +2,7 @@ import { CLIENT_ADMIN, COACH, AUXILIARY, PLANNING_REFERENT, PLANNING } from '../
 
 describe('Auxiliary planning - display', () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: PLANNING, credentials: { email: 'auxiliary@alenvi.io', password: '123456!eR' } });
+    cy.initiateTest({ seedType: PLANNING, credentials: { email: 'auxiliary@alenvi.io', password: '123456!eR' } });
     cy.visit('/ni/planning/auxiliaries');
   });
 
@@ -43,7 +43,7 @@ const loggedUsers = [
 
 loggedUsers.forEach(user => describe(`Auxiliary planning - actions - ${user.role}`, () => {
   beforeEach(() => {
-    cy.initiateTest({ seeds: PLANNING, credentials: { email: user.email, password: user.password } });
+    cy.initiateTest({ seedType: PLANNING, credentials: { email: user.email, password: user.password } });
     cy.visit('/ni/planning/auxiliaries');
   });
 

--- a/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
+++ b/test/cypress/integration/ni/planning/auxiliaryPlanning.spec.js
@@ -36,16 +36,15 @@ describe('Auxiliary planning - display', () => {
 });
 
 const loggedUsers = [
-  { login: 'planning-referent@alenvi.io', password: '123456!eR', role: PLANNING_REFERENT },
-  { login: 'auxiliary@alenvi.io', password: '123456!eR', role: AUXILIARY },
-  { login: 'client-admin@alenvi.io', password: '123456!eR', role: CLIENT_ADMIN },
-  { login: 'coach@alenvi.io', password: '123456!eR', role: COACH },
+  { email: 'planning-referent@alenvi.io', password: '123456!eR', role: PLANNING_REFERENT },
+  { email: 'auxiliary@alenvi.io', password: '123456!eR', role: AUXILIARY },
+  { email: 'client-admin@alenvi.io', password: '123456!eR', role: CLIENT_ADMIN },
+  { email: 'coach@alenvi.io', password: '123456!eR', role: COACH },
 ];
 
 loggedUsers.forEach(user => describe(`Auxiliary planning - actions - ${user.role}`, () => {
   beforeEach(() => {
-    cy.request(`${Cypress.env('API_HOSTNAME')}/end-to-end/seed/planning`);
-    cy.login({ email: user.login, password: user.password });
+    cy.initiateTest({ email: user.email, password: user.password });
     cy.visit('/ni/planning/auxiliaries');
   });
 

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -22,11 +22,15 @@ module.exports = (on, config) => {
       return null;
     },
     async seedDb (seedType) {
-      await axios.get(`http://localhost:3001/end-to-end/seed/${seedType}`);
+      await axios.get(`${process.env.API_HOSTNAME}/end-to-end/seed/${seedType}`);
       return null;
     },
     async login (credentials) {
-      const auth = await axios.post('http://localhost:3001/users/authenticate', credentials, { withCredentials: true });
+      const auth = await axios.post(
+        `${process.env.API_HOSTNAME}/users/authenticate`,
+        credentials,
+        { withCredentials: true }
+      );
       return auth.data.data;
     },
   });

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -25,6 +25,14 @@ module.exports = (on, config) => {
       await axios.get('http://localhost:3001/end-to-end/seed/planning');
       return null;
     },
+    async seedBilling () {
+      await axios.get('http://localhost:3001/end-to-end/seed/billing');
+      return null;
+    },
+    async seedAuthentication () {
+      await axios.get('http://localhost:3001/end-to-end/seed/authentication');
+      return null;
+    },
     async login (credentials) {
       const auth = await axios.post('http://localhost:3001/users/authenticate', credentials, { withCredentials: true });
       return auth.data.data;

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -21,16 +21,8 @@ module.exports = (on, config) => {
       console.warn(message);
       return null;
     },
-    async seedPlanning () {
-      await axios.get('http://localhost:3001/end-to-end/seed/planning');
-      return null;
-    },
-    async seedBilling () {
-      await axios.get('http://localhost:3001/end-to-end/seed/billing');
-      return null;
-    },
-    async seedAuthentication () {
-      await axios.get('http://localhost:3001/end-to-end/seed/authentication');
+    async seedDb (seedType) {
+      await axios.get(`http://localhost:3001/end-to-end/seed/${seedType}`);
       return null;
     },
     async login (credentials) {

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -1,3 +1,4 @@
+const { default: axios } = require('axios');
 const ctx = require('../../../quasar.conf');
 
 const parseEnv = env => Object.keys(env).reduce((acc, key) => {
@@ -19,6 +20,14 @@ module.exports = (on, config) => {
       // eslint-disable-next-line no-console
       console.warn(message);
       return null;
+    },
+    async seedPlanning () {
+      await axios.get('http://localhost:3001/end-to-end/seed/planning');
+      return null;
+    },
+    async login (credentials) {
+      const auth = await axios.post('http://localhost:3001/users/authenticate', credentials, { withCredentials: true });
+      return auth.data.data;
     },
   });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1,9 +1,10 @@
 Cypress.Commands.overwrite('log', (subject, message) => cy.task('log', message));
 
 Cypress.Commands.add('dataCy', value => cy.get(`[data-cy=${value}]`));
-Cypress.Commands.add('login', (credentials) => {
-  cy.request('POST', `${Cypress.env('API_HOSTNAME')}/users/authenticate`, credentials).then((resp) => {
-    const { data } = resp.body;
+Cypress.Commands.add('initiateTest', (credentials) => {
+  cy.visit('/');
+  cy.task('seedPlanning');
+  cy.task('login', credentials).then((data) => {
     cy.setCookie('alenvi_token', `${data.token}`);
     cy.setCookie('refresh_token', `${data.refreshToken}`);
     cy.setCookie('user_id', `${data.user._id}`);

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -2,22 +2,9 @@ Cypress.Commands.overwrite('log', (subject, message) => cy.task('log', message))
 
 Cypress.Commands.add('dataCy', value => cy.get(`[data-cy=${value}]`));
 Cypress.Commands.add('initiateTest', (data) => {
-  const { seeds, credentials } = data;
+  const { seedType, credentials } = data;
   cy.visit('/');
-
-  switch (seeds) {
-    case 'planning':
-      cy.task('seedPlanning');
-      break;
-    case 'billing':
-      cy.task('seedBilling');
-      break;
-    case 'authentication':
-      cy.task('seedAuthentication');
-      break;
-    default:
-      throw Error('no seed');
-  }
+  cy.task('seedDb', seedType);
 
   if (credentials) {
     cy.task('login', credentials).then((resp) => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1,12 +1,29 @@
 Cypress.Commands.overwrite('log', (subject, message) => cy.task('log', message));
 
 Cypress.Commands.add('dataCy', value => cy.get(`[data-cy=${value}]`));
-Cypress.Commands.add('initiateTest', (credentials) => {
+Cypress.Commands.add('initiateTest', (data) => {
+  const { seeds, credentials } = data;
   cy.visit('/');
-  cy.task('seedPlanning');
-  cy.task('login', credentials).then((data) => {
-    cy.setCookie('alenvi_token', `${data.token}`);
-    cy.setCookie('refresh_token', `${data.refreshToken}`);
-    cy.setCookie('user_id', `${data.user._id}`);
-  });
+
+  switch (seeds) {
+    case 'planning':
+      cy.task('seedPlanning');
+      break;
+    case 'billing':
+      cy.task('seedBilling');
+      break;
+    case 'authentication':
+      cy.task('seedAuthentication');
+      break;
+    default:
+      throw Error('no seed');
+  }
+
+  if (credentials) {
+    cy.task('login', credentials).then((resp) => {
+      cy.setCookie('alenvi_token', `${resp.token}`);
+      cy.setCookie('refresh_token', `${resp.refreshToken}`);
+      cy.setCookie('user_id', `${resp.user._id}`);
+    });
+  }
 });


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles :  -np

- Cas d'usage : modifications des tests pour mieux isoler chaque test
 Dans le test que j'avais repere qui buguait parfois (update event dans auxiliaryPlanning) j'ai remarque qu'il y avait des appels a l'api venant de la fin du test d'avant --> j'ai donc d'abord renaviguer vers '/' pour remettre a 0 l'etat du navigateur. 
En regardant un peu j'ai vu que c'etait les tasks qu'il fallait utilisé plutot que les commandes pour faire les taches asynchrones et donc j'ai cree des taches pour les seeds et le login. source : https://spin.atomicobject.com/2021/07/30/cypress-tasks-vs-commands/

- Comment tester ? : Faire tourner les tests plusieurs fois (avec `npm run test:e2e` et `npm run test:e2e:ci` et verifier qu'ils passent toujours

_Si tu as lu cette description, pense a réagir avec un :eye:_
