### PR TITLE
COM-2773: add columns

### DIFF
--- a/src/core/components/courses/ProfileBilling.vue
+++ b/src/core/components/courses/ProfileBilling.vue
@@ -64,7 +64,7 @@
                 </q-card-section>
               </q-card>
             </div>
-            <div class="row justify-end q-py-sm q-px-md">
+            <div class="row justify-end q-pa-sm">
               <ni-button v-if="!isBilled(bill)" color="primary" icon="add" label="Ajouter un article"
                 :disable="billingPurchaseCreationLoading" @click="openBillingPurchaseAdditionModal(bill._id)" />
               <ni-button v-else-if="!bill.courseCreditNote" color="primary" :disable="creditNoteCreationLoading"

--- a/src/core/components/courses/ProfileBilling.vue
+++ b/src/core/components/courses/ProfileBilling.vue
@@ -128,7 +128,7 @@ import { required } from '@vuelidate/validators';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
-import { strictPositiveNumber, integerNumber } from '@helpers/vuelidateCustomVal';
+import { strictPositiveNumber, integerNumber, minDate } from '@helpers/vuelidateCustomVal';
 import { formatAndSortOptions, formatPrice, readAPIResponseWithTypeArrayBuffer } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 import { downloadFile } from '@helpers/file';
@@ -191,7 +191,7 @@ export default {
     const courseFeeEditionModalMetaInfo = ref({ title: '', isBilled: false });
     const minCourseCreditNoteDate = ref('');
 
-    const rules = {
+    const rules = computed(() => ({
       newBill: {
         mainFee: {
           price: { required, strictPositiveNumber },
@@ -218,10 +218,10 @@ export default {
       },
       newCreditNote: {
         courseBill: { required },
-        date: { required },
+        date: { required, minDate: minDate(minCourseCreditNoteDate.value) },
         company: { required },
       },
-    };
+    }));
     const validations = useVuelidate(rules, {
       newBill,
       editedBill,

--- a/src/core/components/courses/ProfileBilling.vue
+++ b/src/core/components/courses/ProfileBilling.vue
@@ -68,7 +68,7 @@
               <ni-button v-if="!isBilled(bill)" color="primary" icon="add" label="Ajouter un article"
                 :disable="billingPurchaseCreationLoading" @click="openBillingPurchaseAdditionModal(bill._id)" />
               <ni-button v-else-if="!bill.courseCreditNote" color="primary" :disable="creditNoteCreationLoading"
-                @click="openCreditNoteCreationModal(bill._id)" label="Faire un avoir" icon="mdi-credit-card-refund" />
+                @click="openCreditNoteCreationModal(bill)" label="Faire un avoir" icon="mdi-credit-card-refund" />
             </div>
             <div v-if="!isBilled(bill)" class="row justify-end q-px-lg q-py-sm">
               <ni-button label="Facturer" color="white" class="bg-primary" icon="payment"
@@ -115,7 +115,7 @@
 
     <ni-course-credit-note-creation-modal v-model="creditNoteCreationModal" v-model:new-credit-note="newCreditNote"
       @submit="addCreditNote" @hide="resetCreditNoteCreationModal" :loading="creditNoteCreationLoading"
-      :validations="validations.newCreditNote" />
+      :validations="validations.newCreditNote" :min-date="minCourseCreditNoteDate" />
   </div>
 </template>
 
@@ -189,6 +189,7 @@ export default {
     const areDetailsVisible = ref(Object.fromEntries(courseBills.value.map(bill => [bill._id, false])));
     const billToValidate = ref({ _id: '', billedAt: '' });
     const courseFeeEditionModalMetaInfo = ref({ title: '', isBilled: false });
+    const minCourseCreditNoteDate = ref('');
 
     const rules = {
       newBill: {
@@ -493,14 +494,15 @@ export default {
         .onCancel(() => NotifyPositive('Suppression annulée.'));
     };
 
-    const openCreditNoteCreationModal = (billId) => {
+    const openCreditNoteCreationModal = (bill) => {
       newCreditNote.value = {
-        courseBill: billId,
+        courseBill: bill._id,
         date: '',
         misc: '',
         company: course.value.company._id,
       };
       creditNoteCreationModal.value = true;
+      minCourseCreditNoteDate.value = bill.billedAt;
     };
 
     const addCreditNote = async () => {
@@ -525,6 +527,7 @@ export default {
 
     const resetCreditNoteCreationModal = () => {
       newCreditNote.value = { courseBill: '', date: '', misc: '', company: '' };
+      minCourseCreditNoteDate.value = '';
       validations.value.newCreditNote.$reset();
     };
 
@@ -622,6 +625,7 @@ export default {
       courseBills,
       courseFeeEditionModalMetaInfo,
       areDetailsVisible,
+      minCourseCreditNoteDate,
       // Computed
       validations,
       course,

--- a/src/core/components/table/ExpandingTable.vue
+++ b/src/core/components/table/ExpandingTable.vue
@@ -27,6 +27,9 @@
         <ni-pagination :props="props" :pagination="pagination" :data="data" :options="paginationOptions"
           @update:pagination="update($event)" />
       </template>
+      <template #bottom-row="props">
+        <slot name="bottom-row" :props="props" />
+      </template>
     </q-table>
     <div v-else class="loading-container" />
     <q-inner-loading :showing="loading">

--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -285,6 +285,8 @@ export const BANK_TRANSFER = 'bank_transfer';
 export const CHECK = 'check';
 export const CESU = 'cesu';
 export const CASH = 'cash';
+export const CREDIT = 'credit';
+export const CREDIT_OPTION = { label: 'Crédit', value: CREDIT };
 export const PAYMENT_OPTIONS = [
   { label: 'Prélèvement', value: DIRECT_DEBIT },
   { label: 'Virement', value: BANK_TRANSFER },

--- a/src/core/helpers/utils.js
+++ b/src/core/helpers/utils.js
@@ -76,6 +76,8 @@ export const roundFrenchPercentage = (number, digits = 2) => (number
 
 export const formatPrice = val => (val ? roundFrenchPrice(val) : roundFrenchPrice(0));
 
+export const formatPriceWithSign = value => (value >= 0 ? `+${formatPrice(value)}` : formatPrice(value));
+
 export const formatIdentity = (identity, format) => {
   if (!identity) return '';
 

--- a/src/modules/vendor/components/billing/CourseCreditNoteCreationModal.vue
+++ b/src/modules/vendor/components/billing/CourseCreditNoteCreationModal.vue
@@ -4,7 +4,7 @@
       Créer un <span class="text-weight-bold">avoir</span>
     </template>
     <ni-date-input in-modal caption="Date" :model-value="newCreditNote.date" @blur="validations.date.$touch"
-      required-field :error="validations.date.$error" @update:model-value="update($event, 'date')" />
+      required-field :error="validations.date.$error" @update:model-value="update($event, 'date')" :min="minDate" />
     <ni-input in-modal caption="Motif" :model-value="newCreditNote.misc" @update:model-value="update($event, 'misc')" />
     <template #footer>
       <ni-button class="full-width modal-btn bg-primary" label="Créer l'avoir" icon-right="add" color="white"
@@ -27,6 +27,7 @@ export default {
     newCreditNote: { type: Object, default: () => ({}) },
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
+    minDate: { type: String, required: true },
   },
   components: {
     'ni-modal': Modal,

--- a/src/modules/vendor/components/billing/CourseCreditNoteCreationModal.vue
+++ b/src/modules/vendor/components/billing/CourseCreditNoteCreationModal.vue
@@ -4,7 +4,8 @@
       Créer un <span class="text-weight-bold">avoir</span>
     </template>
     <ni-date-input in-modal caption="Date" :model-value="newCreditNote.date" @blur="validations.date.$touch"
-      required-field :error="validations.date.$error" @update:model-value="update($event, 'date')" :min="minDate" />
+      required-field :error="validations.date.$error" @update:model-value="update($event, 'date')" :min="minDate"
+      :error-message="dateErrorMessage(validations)" />
     <ni-input in-modal caption="Motif" :model-value="newCreditNote.misc" @update:model-value="update($event, 'misc')" />
     <template #footer>
       <ni-button class="full-width modal-btn bg-primary" label="Créer l'avoir" icon-right="add" color="white"
@@ -14,11 +15,12 @@
 </template>
 
 <script>
+import set from 'lodash/set';
 import Modal from '@components/modal/Modal';
 import Input from '@components/form/Input';
 import Button from '@components/Button';
 import DateInput from '@components/form/DateInput';
-import set from 'lodash/set';
+import { REQUIRED_LABEL } from '@data/constants';
 
 export default {
   name: 'CourseCreditNoteCreationModal',
@@ -37,6 +39,12 @@ export default {
   },
   emits: ['hide', 'update:model-value', 'submit', 'update:new-credit-note'],
   setup (props, { emit }) {
+    const dateErrorMessage = (validations) => {
+      if (!validations.date.required.$response) return REQUIRED_LABEL;
+      if (!validations.date.minDate.$response) {
+        return 'La date de l\'avoir ne peut être antérieure à la date de facturation';
+      }
+    };
     const hide = () => { emit('hide'); };
     const input = (event) => { emit('update:model-value', event); };
     const submit = () => { emit('submit'); };
@@ -46,6 +54,7 @@ export default {
 
     return {
       // Methods
+      dateErrorMessage,
       hide,
       input,
       submit,

--- a/src/modules/vendor/components/companies/ProfileBilling.vue
+++ b/src/modules/vendor/components/companies/ProfileBilling.vue
@@ -14,6 +14,10 @@
                 <div class="program ellipsis">{{ `${get(props.row, 'course.subProgram.program.name')}` }}</div>
                 <div v-if="get(props.row, 'course.misc')" class="misc">- {{ get(props.row, 'course.misc') }}</div>
               </div>
+              <div class="row items-center" v-if="props.row.courseCreditNote">
+                <q-icon size="12px" name="fas fa-times-circle" color="orange-500 attendance" />
+                <div class="q-ml-xs text-orange-500">Annulée par avoir - {{ props.row.courseCreditNote.number }}</div>
+              </div>
             </template>
             <template v-else-if="col.name === 'progress' && col.value >= 0">
               <ni-progress class="q-ml-lg" :value="col.value" />
@@ -31,23 +35,37 @@
           </q-td>
         </template>
         <template #expanding-row="{ props }">
-          <q-td colspan="100%">
-            <div v-if="!props.row.coursePayments.length" class="text-italic text-center">
+          <q-td colspan="100%" class="cell">
+            <div v-if="!props.row.coursePayments.length && !props.row.courseCreditNote" class="text-italic text-center">
               Aucun règlement renseigné.
             </div>
-            <div v-else v-for="coursePayment in getSortedPayments(props.row.coursePayments)" :key="coursePayment._id"
-              :props="props" class="q-my-sm expanding-table-expanded-row">
-              <div>
-                {{ formatDate(coursePayment.date) }}
-                {{ coursePayment.number }}
-                ({{ getPaymentType(coursePayment.type) }})
+            <div v-else v-for="item in getSortedItems(props.row)" :key="item._id" :props="props" class="q-my-sm row">
+              <div class="date">{{ formatDate(item.date) }}</div>
+              <div class="payment">{{ item.number }} ({{ getItemType(item) }})</div>
+              <div class="area" />
+              <div v-if="item.netInclTaxes" class="paid">
+                {{ item.nature === REFUND ? '-' : '' }} {{ formatPrice(item.netInclTaxes) }}
               </div>
-              <div>{{ formatPrice(coursePayment.netInclTaxes) }}</div>
-              <q-icon size="16px" name="edit" color="copper-grey-500"
-                @click="openCoursePaymentEditionModal(props.row, coursePayment)" />
+              <div v-else class="paid">{{ formatPrice(props.row.netInclTaxes) }}</div>
+              <div v-if="item.netInclTaxes" class="edit">
+                <q-icon size="20px" name="edit" color="copper-grey-500"
+                  @click="openCoursePaymentEditionModal(props.row, item)" />
+              </div>
             </div>
           </q-td>
         </template>
+        <template #bottom-row="{ props }">
+      <q-tr class="text-weight-bold" :props="props">
+        <q-td />
+        <q-td />
+        <q-td />
+        <q-td />
+        <q-td><div class="flex justify-end items-center">Total</div></q-td>
+        <q-td><div class="flex justify-end items-center">{{ getTotal(courseBills) }}</div></q-td>
+        <q-td />
+        <q-td />
+      </q-tr>
+    </template>
       </ni-expanding-table>
 
       <ni-course-payment-creation-modal v-model:new-course-payment="newCoursePayment" @submit="createPayment"
@@ -75,7 +93,7 @@ import Button from '@components/Button';
 import Progress from '@components/CourseProgress';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import ExpandingTable from '@components/table/ExpandingTable';
-import { BALANCE, PAYMENT, PAYMENT_OPTIONS } from '@data/constants.js';
+import { BALANCE, PAYMENT, PAYMENT_OPTIONS, REFUND } from '@data/constants.js';
 import { formatDate, ascendingSort } from '@helpers/date';
 import { downloadFile } from '@helpers/file';
 import { formatPrice, readAPIResponseWithTypeArrayBuffer } from '@helpers/utils';
@@ -111,17 +129,41 @@ export default {
         field: 'billedAt',
         format: value => formatDate(value),
         align: 'left',
+        style: 'width: 10%',
       },
-      { name: 'number', label: '#', field: 'number', align: 'left', style: 'max-width: 250px' },
+      { name: 'number', label: '#', field: 'number', align: 'left', style: 'width: 30%' },
       {
         name: 'progress',
         label: 'Avancement formation',
         field: 'progress',
         align: 'center',
-        style: 'min-width: 150px; width: 20%',
+        style: 'width: 15%',
       },
-      { name: 'netInclTaxes', label: 'Montant', field: 'netInclTaxes', format: formatPrice, align: 'center' },
-      { name: 'payment', label: '', align: 'center', field: val => val.coursePayments || '' },
+      {
+        name: 'netInclTaxes',
+        label: 'Montant',
+        field: 'netInclTaxes',
+        format: formatPrice,
+        align: 'right',
+        style: 'width: 10%',
+      },
+      {
+        name: 'paid',
+        label: 'Réglé/crédité',
+        field: 'paid',
+        format: formatPrice,
+        align: 'right',
+        style: 'width: 10%',
+      },
+      {
+        name: 'total',
+        label: 'Solde',
+        field: 'total',
+        format: value => (value >= 0 ? `+${formatPrice(value)}` : formatPrice(value)),
+        align: 'right',
+        style: 'font-weight: 700; width: 10%',
+      },
+      { name: 'payment', label: '', align: 'center', field: val => val.coursePayments || '', style: 'width: 10%' },
       { name: 'expand', label: '', field: '' },
     ]);
     const pagination = ref({ sortBy: 'date', ascending: true, page: 1, rowsPerPage: 15 });
@@ -247,9 +289,20 @@ export default {
       validations.value.editedCoursePayment.$reset();
     };
 
-    const getPaymentType = type => PAYMENT_OPTIONS.find(option => option.value === type).label;
+    const getItemType = item => (item.type
+      ? PAYMENT_OPTIONS.find(option => option.value === item.type).label
+      : 'crédit');
 
-    const getSortedPayments = payments => payments.sort((a, b) => ascendingSort(a.date, b.date));
+    const getSortedItems = bill => (bill.courseCreditNote
+      ? [...bill.coursePayments, bill.courseCreditNote]
+        .sort((a, b) => ascendingSort(a.date, b.date))
+      : bill.coursePayments.sort((a, b) => ascendingSort(a.date, b.date)));
+
+    const getTotal = (bills) => {
+      const total = bills.map(bill => bill.total).reduce((acc, val) => acc + val, 0);
+
+      return total >= 0 ? `+${formatPrice(total)}` : formatPrice(total);
+    };
 
     const created = async () => {
       refreshCourseBills();
@@ -272,6 +325,7 @@ export default {
       paymentCreationLoading,
       paymentEditionLoading,
       PAYMENT_OPTIONS,
+      REFUND,
       // Computed
       validations,
       // Methods
@@ -284,8 +338,9 @@ export default {
       editPayment,
       resetCoursePaymentCreationModal,
       resetCoursePaymentEditionModal,
-      getPaymentType,
-      getSortedPayments,
+      getItemType,
+      getSortedItems,
+      getTotal,
       get,
       formatDate,
     };
@@ -307,4 +362,34 @@ export default {
   width: 20px
   height: 20px
   justify-content: center
+.cell
+  padding: 0
+  width: 100%
+.date
+  min-width: 10%
+  padding: 4px
+.payment
+  width: 30%
+  padding: 4px
+.paid
+  min-width: 10%
+  padding: 4px
+  justify-content: flex-end
+  display: flex
+.area
+  @media screen and (max-width: 767px)
+    width: 27%
+  @media screen and (min-width: 768px)
+    width: 25%
+  padding: 4px 8px
+  justify-content: flex-end
+  display: flex
+.edit
+  @media screen and (max-width: 767px)
+    width: 20%
+  @media screen and (min-width: 768px)
+    width: 25%
+  padding: 4px 8px
+  justify-content: flex-end
+  display: flex
 </style>

--- a/src/modules/vendor/components/companies/ProfileBilling.vue
+++ b/src/modules/vendor/components/companies/ProfileBilling.vue
@@ -42,11 +42,14 @@
             <div v-else v-for="item in getSortedItems(props.row)" :key="item._id" :props="props" class="q-my-sm row">
               <div class="date">{{ formatDate(item.date) }}</div>
               <div class="payment">{{ item.number }} ({{ getItemType(item) }})</div>
-              <div class="area" />
+              <div class="progress" />
+              <div class="netInclTaxes" />
               <div v-if="item.netInclTaxes" class="paid">
                 {{ item.nature === REFUND ? '-' : '' }} {{ formatPrice(item.netInclTaxes) }}
               </div>
               <div v-else class="paid">{{ formatPrice(props.row.netInclTaxes) }}</div>
+              <div class="netInclTaxes" />
+              <div class="netInclTaxes" />
               <div v-if="item.netInclTaxes" class="edit">
                 <q-icon size="20px" name="edit" color="copper-grey-500"
                   @click="openCoursePaymentEditionModal(props.row, item)" />
@@ -129,25 +132,25 @@ export default {
         field: 'billedAt',
         format: value => formatDate(value),
         align: 'left',
-        style: 'width: 10%',
+        classes: 'date',
       },
-      { name: 'number', label: '#', field: 'number', align: 'left', style: 'width: 30%' },
-      { name: 'progress', label: 'Avancement formation', field: 'progress', align: 'center', style: 'width: 15%' },
+      { name: 'number', label: '#', field: 'number', align: 'left', classes: 'payment' },
+      { name: 'progress', label: 'Avancement formation', field: 'progress', align: 'center', classes: 'progress' },
       {
         name: 'netInclTaxes',
         label: 'Montant',
         field: 'netInclTaxes',
         format: formatPrice,
         align: 'center',
-        style: 'width: 10%',
+        classes: 'netInclTaxes',
       },
       {
         name: 'paid',
         label: 'Réglé/crédité',
         field: 'paid',
         format: formatPrice,
-        align: 'center',
-        style: 'width: 10%',
+        align: 'right',
+        classes: 'paid',
       },
       {
         name: 'total',
@@ -155,9 +158,9 @@ export default {
         field: 'total',
         format: formatPriceWithSign,
         align: 'center',
-        style: 'font-weight: 700; width: 10%',
+        classes: 'text-weight-bold netInclTaxes',
       },
-      { name: 'payment', label: '', align: 'center', field: val => val.coursePayments || '', style: 'width: 10%' },
+      { name: 'payment', label: '', align: 'center', field: val => val.coursePayments || '', classes: 'netInclTaxes' },
       { name: 'expand', label: '', field: '' },
     ]);
     const pagination = ref({ sortBy: 'date', ascending: true, page: 1, rowsPerPage: 15 });
@@ -342,6 +345,9 @@ export default {
 </script>
 
 <style lang="sass" scoped>
+.q-td
+  @media screen and (max-width: 767px)
+    font-size: 9px
 .program
   max-width: fit-content
   flex: 1
@@ -359,28 +365,24 @@ export default {
   padding: 0
   width: 100%
 .date
-  min-width: 10%
+  width: 10%
   padding: 4px
 .payment
   width: 30%
   padding: 4px
-.paid
-  min-width: 10%
+.progress
+  width: 15%
   padding: 4px
-  justify-content: center
-  display: flex
-.area
-  @media screen and (max-width: 767px)
-    width: 27%
-  @media screen and (min-width: 768px)
-    width: 25%
-  padding: 4px 8px
+.netInclTaxes
+  width: 10%
+  padding: 4px
+.paid
+  width: 10%
+  padding: 4px
+  text-align: right
 .edit
-  @media screen and (max-width: 767px)
-    width: 20%
-  @media screen and (min-width: 768px)
-    width: 25%
-  padding: 4px 8px
-  justify-content: flex-end
   display: flex
+  justify-content: flex-end
+  width: 5%
+  padding-right: 4px
 </style>

--- a/src/modules/vendor/components/companies/ProfileBilling.vue
+++ b/src/modules/vendor/components/companies/ProfileBilling.vue
@@ -93,10 +93,10 @@ import Button from '@components/Button';
 import Progress from '@components/CourseProgress';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import ExpandingTable from '@components/table/ExpandingTable';
-import { BALANCE, PAYMENT, PAYMENT_OPTIONS, REFUND } from '@data/constants.js';
+import { BALANCE, PAYMENT, PAYMENT_OPTIONS, CREDIT_OPTION, REFUND } from '@data/constants.js';
 import { formatDate, ascendingSort } from '@helpers/date';
 import { downloadFile } from '@helpers/file';
-import { formatPrice, readAPIResponseWithTypeArrayBuffer } from '@helpers/utils';
+import { formatPrice, formatPriceWithSign, readAPIResponseWithTypeArrayBuffer } from '@helpers/utils';
 import { positiveNumber } from '@helpers/vuelidateCustomVal';
 import CoursePaymentCreationModal from '../billing/CoursePaymentCreationModal';
 import CoursePaymentEditionModal from '../billing/CoursePaymentEditionModal';
@@ -132,19 +132,13 @@ export default {
         style: 'width: 10%',
       },
       { name: 'number', label: '#', field: 'number', align: 'left', style: 'width: 30%' },
-      {
-        name: 'progress',
-        label: 'Avancement formation',
-        field: 'progress',
-        align: 'center',
-        style: 'width: 15%',
-      },
+      { name: 'progress', label: 'Avancement formation', field: 'progress', align: 'center', style: 'width: 15%' },
       {
         name: 'netInclTaxes',
         label: 'Montant',
         field: 'netInclTaxes',
         format: formatPrice,
-        align: 'right',
+        align: 'center',
         style: 'width: 10%',
       },
       {
@@ -152,15 +146,15 @@ export default {
         label: 'Réglé/crédité',
         field: 'paid',
         format: formatPrice,
-        align: 'right',
+        align: 'center',
         style: 'width: 10%',
       },
       {
         name: 'total',
         label: 'Solde',
         field: 'total',
-        format: value => (value >= 0 ? `+${formatPrice(value)}` : formatPrice(value)),
-        align: 'right',
+        format: formatPriceWithSign,
+        align: 'center',
         style: 'font-weight: 700; width: 10%',
       },
       { name: 'payment', label: '', align: 'center', field: val => val.coursePayments || '', style: 'width: 10%' },
@@ -291,17 +285,16 @@ export default {
 
     const getItemType = item => (item.type
       ? PAYMENT_OPTIONS.find(option => option.value === item.type).label
-      : 'crédit');
+      : CREDIT_OPTION.label);
 
     const getSortedItems = bill => (bill.courseCreditNote
-      ? [...bill.coursePayments, bill.courseCreditNote]
-        .sort((a, b) => ascendingSort(a.date, b.date))
+      ? [...bill.coursePayments, bill.courseCreditNote].sort((a, b) => ascendingSort(a.date, b.date))
       : bill.coursePayments.sort((a, b) => ascendingSort(a.date, b.date)));
 
     const getTotal = (bills) => {
-      const total = bills.map(bill => bill.total).reduce((acc, val) => acc + val, 0);
+      const total = bills.reduce((acc, val) => acc + val.total, 0);
 
-      return total >= 0 ? `+${formatPrice(total)}` : formatPrice(total);
+      return formatPriceWithSign(total);
     };
 
     const created = async () => {
@@ -374,7 +367,7 @@ export default {
 .paid
   min-width: 10%
   padding: 4px
-  justify-content: flex-end
+  justify-content: center
   display: flex
 .area
   @media screen and (max-width: 767px)
@@ -382,8 +375,6 @@ export default {
   @media screen and (min-width: 768px)
     width: 25%
   padding: 4px 8px
-  justify-content: flex-end
-  display: flex
 .edit
   @media screen and (max-width: 767px)
     width: 20%

--- a/src/modules/vendor/components/companies/ProfileBilling.vue
+++ b/src/modules/vendor/components/companies/ProfileBilling.vue
@@ -43,13 +43,13 @@
               <div class="date">{{ formatDate(item.date) }}</div>
               <div class="payment">{{ item.number }} ({{ getItemType(item) }})</div>
               <div class="progress" />
-              <div class="netInclTaxes" />
-              <div v-if="item.netInclTaxes" class="paid">
-                {{ item.nature === REFUND ? '-' : '' }} {{ formatPrice(item.netInclTaxes) }}
+              <div class="formatted-price" />
+              <div v-if="item.netInclTaxes" class="formatted-price">
+                {{ item.nature === REFUND ? '-' : '' }}{{ formatPrice(item.netInclTaxes) }}
               </div>
-              <div v-else class="paid">{{ formatPrice(props.row.netInclTaxes) }}</div>
-              <div class="netInclTaxes" />
-              <div class="netInclTaxes" />
+              <div v-else class="formatted-price">{{ formatPrice(props.row.netInclTaxes) }}</div>
+              <div class="formatted-price" />
+              <div class="formatted-price" />
               <div v-if="item.netInclTaxes" class="edit">
                 <q-icon size="20px" name="edit" color="copper-grey-500"
                   @click="openCoursePaymentEditionModal(props.row, item)" />
@@ -141,27 +141,27 @@ export default {
         label: 'Montant',
         field: 'netInclTaxes',
         format: formatPrice,
-        align: 'center',
-        classes: 'netInclTaxes',
+        align: 'right',
+        classes: 'formatted-price',
       },
       {
         name: 'paid',
-        label: 'Réglé/crédité',
+        label: 'Réglé / crédité',
         field: 'paid',
         format: formatPrice,
         align: 'right',
-        classes: 'paid',
+        classes: 'formatted-price',
       },
       {
         name: 'total',
         label: 'Solde',
         field: 'total',
         format: formatPriceWithSign,
-        align: 'center',
-        classes: 'text-weight-bold netInclTaxes',
+        align: 'right',
+        classes: 'text-weight-bold formatted-price',
       },
-      { name: 'payment', label: '', align: 'center', field: val => val.coursePayments || '', classes: 'netInclTaxes' },
-      { name: 'expand', label: '', field: '' },
+      { name: 'payment', align: 'center', field: val => val.coursePayments || '', classes: 'formatted-price' },
+      { name: 'expand', classes: 'expand' },
     ]);
     const pagination = ref({ sortBy: 'date', ascending: true, page: 1, rowsPerPage: 15 });
 
@@ -373,10 +373,7 @@ export default {
 .progress
   width: 15%
   padding: 4px
-.netInclTaxes
-  width: 10%
-  padding: 4px
-.paid
+.formatted-price
   width: 10%
   padding: 4px
   text-align: right
@@ -385,4 +382,7 @@ export default {
   justify-content: flex-end
   width: 5%
   padding-right: 4px
+.expand
+  width: 5%
+  padding: 4px
 </style>


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur /rof/admin

- Cas d'usage : sur le profil d'une structure je peux visualiser ses factures avec leur détail + boyscout bloquer date d'avoir antérieure à facturation

- Comment tester ? :
  - facturer une formation
  - sur le profil de la structure associée la facture apparait bien (aucun règlement)
  - lui ajouter des règlements/remboursements => ils apparaissent dans le détail et les colonnes solde et réglé/crédité sont mises à jour
  - faire un avoir sur la facture => je ne peux pas mettre une date d'avoir antérieur à la date de facturation + il apparait bien dans le détail et les colonnes solde et réglé/crédité sont mises à jour
  - facturer une autre formation de la même structure
  - refaire les étapes précédentes
  - le solde total est le bon

_Si tu as lu cette description, pense a réagir avec un :eye:_
