### PR TITLE
COM-2792: display estimated start date field

### DIFF
--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -23,7 +23,8 @@
         </div>
       </div>
     </div>
-    <ni-slot-container :can-edit="canEditSlots" :loading="courseLoading" @refresh="refreshCourse" :is-admin="isAdmin" />
+    <ni-slot-container :can-edit="canEditSlots" :loading="courseLoading" @refresh="refreshCourse" :is-admin="isAdmin"
+      @update-estimated-start-date="updateEstimatedStartDate" />
     <ni-trainee-table :can-edit="canEditTrainees" :loading="courseLoading" @refresh="refreshCourse" />
     <q-page-sticky expand position="right">
       <course-history-feed v-if="displayHistory" @toggle-history="toggleHistory" :course-histories="courseHistories"
@@ -462,6 +463,16 @@ export default {
         NotifyNegative('Erreur lors du téléchargement de la convocation.');
       } finally {
         this.pdfLoading = false;
+      }
+    },
+    async updateEstimatedStartDate (value) {
+      try {
+        await Courses.update(this.course._id, { estimatedStartDate: value });
+        NotifyPositive('Date de démarrage souhaitée mise à jour.');
+        this.refreshCourse();
+      } catch (e) {
+        console.error(e);
+        NotifyNegative('Erreur lors de la mise à jour de la date de démarrage.');
       }
     },
   },

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -23,7 +23,7 @@
         </div>
       </div>
     </div>
-    <ni-slot-container :can-edit="canEditSlots" :loading="courseLoading" @refresh="refreshCourse" />
+    <ni-slot-container :can-edit="canEditSlots" :loading="courseLoading" @refresh="refreshCourse" :is-admin="isAdmin" />
     <ni-trainee-table :can-edit="canEditTrainees" :loading="courseLoading" @refresh="refreshCourse" />
     <q-page-sticky expand position="right">
       <course-history-feed v-if="displayHistory" @toggle-history="toggleHistory" :course-histories="courseHistories"

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -24,7 +24,7 @@
       </div>
     </div>
     <ni-slot-container :can-edit="canEditSlots" :loading="courseLoading" @refresh="refreshCourse" :is-admin="isAdmin"
-      @update-estimated-start-date="updateEstimatedStartDate" />
+      @update="updateCourse('estimatedStartDate')" />
     <ni-trainee-table :can-edit="canEditTrainees" :loading="courseLoading" @refresh="refreshCourse" />
     <q-page-sticky expand position="right">
       <course-history-feed v-if="displayHistory" @toggle-history="toggleHistory" :course-histories="courseHistories"
@@ -463,16 +463,6 @@ export default {
         NotifyNegative('Erreur lors du téléchargement de la convocation.');
       } finally {
         this.pdfLoading = false;
-      }
-    },
-    async updateEstimatedStartDate (value) {
-      try {
-        await Courses.update(this.course._id, { estimatedStartDate: value });
-        NotifyPositive('Date de démarrage souhaitée mise à jour.');
-        this.refreshCourse();
-      } catch (e) {
-        console.error(e);
-        NotifyNegative('Erreur lors de la mise à jour de la date de démarrage.');
       }
     },
   },

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -10,7 +10,7 @@
           <div class="slot-section-title-subtitle">{{ formatSlotTitle.subtitle }}</div>
         </q-item-section>
       </q-item>
-      <div v-if="!course.slots.length" class="row gutter-profile">
+      <div v-if="!course.slots.length && isVendorInterface && isAdmin" class="row gutter-profile">
         <ni-date-input caption="Date de démarrage souhaitée" :model-value="course.estimatedStartDate"
           @update:model-value="updateEstimatedStartDate($event)" class="col-4" />
       </div>
@@ -91,6 +91,7 @@ export default {
   props: {
     canEdit: { type: Boolean, default: false },
     loading: { type: Boolean, default: false },
+    isAdmin: { type: Boolean, default: false },
   },
   components: {
     'slot-edition-modal': SlotEditionModal,

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -12,7 +12,7 @@
       </q-item>
       <div v-if="!course.slots.length && isVendorInterface && isAdmin" class="row gutter-profile">
         <ni-date-input caption="Date de démarrage souhaitée" :model-value="course.estimatedStartDate"
-          @update:model-value="updateEstimatedStartDate($event)" class="col-4" />
+          @update:model-value="updateEstimatedStartDate($event)" class="col-xs-12 col-md-6" />
       </div>
       <div class="slots-cells-container row">
         <q-card class="slots-cells" v-for="(value, key, index) in courseSlots" :key="index" flat>
@@ -71,7 +71,6 @@ import pick from 'lodash/pick';
 import useVuelidate from '@vuelidate/core';
 import { required, requiredIf } from '@vuelidate/validators';
 import CourseSlots from '@api/CourseSlots';
-import Courses from '@api/Courses';
 import Button from '@components/Button';
 import SlotEditionModal from '@components/courses/SlotEditionModal';
 import SlotCreationModal from '@components/courses/SlotCreationModal';
@@ -99,7 +98,7 @@ export default {
     'ni-button': Button,
     'ni-date-input': DateInput,
   },
-  emits: ['refresh'],
+  emits: ['refresh', 'update-estimated-start-date'],
   setup () {
     return { v$: useVuelidate() };
   },
@@ -377,14 +376,7 @@ export default {
       else if (this.editionModal) set(this.editedCourseSlot, path, value);
     },
     async updateEstimatedStartDate (value) {
-      try {
-        await Courses.update(this.course._id, { estimatedStartDate: value });
-        NotifyPositive('Date de démarrage souhaitée mise à jour.');
-        this.$emit('refresh');
-      } catch (e) {
-        console.error(e);
-        NotifyNegative('Erreur lors de la mise à jour de la date de démarrage.');
-      }
+      this.$emit('update-estimated-start-date', value);
     },
   },
 

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -98,7 +98,7 @@ export default {
     'ni-button': Button,
     'ni-date-input': DateInput,
   },
-  emits: ['refresh', 'update-estimated-start-date'],
+  emits: ['refresh', 'update'],
   setup () {
     return { v$: useVuelidate() };
   },
@@ -375,8 +375,8 @@ export default {
       if (this.creationModal) set(this.newCourseSlot, path, value);
       else if (this.editionModal) set(this.editedCourseSlot, path, value);
     },
-    async updateEstimatedStartDate (value) {
-      this.$emit('update-estimated-start-date', value);
+    async updateEstimatedStartDate (event) {
+      this.$emit('update', set(this.course, 'estimatedStartDate', event));
     },
   },
 

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -10,6 +10,10 @@
           <div class="slot-section-title-subtitle">{{ formatSlotTitle.subtitle }}</div>
         </q-item-section>
       </q-item>
+      <div v-if="!course.slots.length" class="row gutter-profile">
+        <ni-date-input caption="Date de démarrage souhaitée" :model-value="course.estimatedStartDate"
+          @update:model-value="updateEstimatedStartDate($event)" class="col-4" />
+      </div>
       <div class="slots-cells-container row">
         <q-card class="slots-cells" v-for="(value, key, index) in courseSlots" :key="index" flat>
           <div class="slots-cells-title">
@@ -67,9 +71,11 @@ import pick from 'lodash/pick';
 import useVuelidate from '@vuelidate/core';
 import { required, requiredIf } from '@vuelidate/validators';
 import CourseSlots from '@api/CourseSlots';
+import Courses from '@api/Courses';
 import Button from '@components/Button';
 import SlotEditionModal from '@components/courses/SlotEditionModal';
 import SlotCreationModal from '@components/courses/SlotCreationModal';
+import DateInput from '@components/form/DateInput';
 import { NotifyNegative, NotifyWarning, NotifyPositive } from '@components/popup/notify';
 import { E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
 import { formatQuantity } from '@helpers/utils';
@@ -90,6 +96,7 @@ export default {
     'slot-edition-modal': SlotEditionModal,
     'slot-creation-modal': SlotCreationModal,
     'ni-button': Button,
+    'ni-date-input': DateInput,
   },
   emits: ['refresh'],
   setup () {
@@ -367,6 +374,16 @@ export default {
       const { path, value } = payload;
       if (this.creationModal) set(this.newCourseSlot, path, value);
       else if (this.editionModal) set(this.editedCourseSlot, path, value);
+    },
+    async updateEstimatedStartDate (value) {
+      try {
+        await Courses.update(this.course._id, { estimatedStartDate: value });
+        NotifyPositive('Date de démarrage souhaitée mise à jour.');
+        this.$emit('refresh');
+      } catch (e) {
+        console.error(e);
+        NotifyNegative('Erreur lors de la mise à jour de la date de démarrage.');
+      }
     },
   },
 

--- a/src/modules/vendor/components/courses/CourseCreationModal.vue
+++ b/src/modules/vendor/components/courses/CourseCreationModal.vue
@@ -17,6 +17,8 @@
       <ni-select v-if="isIntraCourse" in-modal :model-value="newCourse.company"
         @blur="validations.company.$touch" required-field caption="Structure" :options="companyOptions"
         :error="validations.company.$error" @update:model-value="update($event, 'company')" />
+      <ni-date-input caption="Date de démarrage souhaitée" :model-value="newCourse.estimatedStartDate" in-modal
+        @update:model-value="update($event, 'estimatedStartDate')" />
       <ni-input in-modal :model-value="newCourse.misc" @update:model-value="update($event.trim(), 'misc')"
         caption="Informations Complémentaires" />
       <template #footer>
@@ -31,6 +33,7 @@ import get from 'lodash/get';
 import omit from 'lodash/omit';
 import Modal from '@components/modal/Modal';
 import Select from '@components/form/Select';
+import DateInput from '@components/form/DateInput';
 import OptionGroup from '@components/form/OptionGroup';
 import Input from '@components/form/Input';
 import { COURSE_TYPES } from '@data/constants';
@@ -53,6 +56,7 @@ export default {
     'ni-modal': Modal,
     'ni-select': Select,
     'ni-input': Input,
+    'ni-date-input': DateInput,
   },
   emits: ['hide', 'update:model-value', 'submit', 'update:new-course'],
   data () {

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -67,6 +67,7 @@ export default {
         misc: '',
         type: INTRA,
         salesRepresentative: '',
+        estimatedStartDate: '',
       },
       programs: [],
       courseCreationModal: false,
@@ -139,7 +140,14 @@ export default {
     },
     resetCreationModal () {
       this.v$.newCourse.$reset();
-      this.newCourse = { program: '', company: '', misc: '', type: INTRA, salesRepresentative: '' };
+      this.newCourse = {
+        program: '',
+        company: '',
+        misc: '',
+        type: INTRA,
+        salesRepresentative: '',
+        estimatedStartDate: '',
+      };
     },
     async createCourse () {
       try {


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage : je peux ajouter une date de démarrage souhaitée pour une formation

- Comment tester ? :
  - sur la branche dev exporter les formations pour une période donnée
  - faire de même sur cette branche et s'assurer qu'on a bien la même chose (à l'exception de certains champs de "comptage" ou le vide a été remplacé par 0
  - créer une formation avec une date de démarrage dans la période précédemment utilisée et exporter les formations => j'ai bien ma formation dans l'export
  - ajouter un créneau à la formation, en dehors de la période donnée => la date de démarrage ne s'affiche plus sur le profile de la formation + la formation n'est plus dans l'export 

_Si tu as lu cette description, pense a réagir avec un :eye:_
