### PR TITLE
COM-2772: add text and subtext in modal

### DIFF
--- a/src/core/components/courses/ProfileBilling.vue
+++ b/src/core/components/courses/ProfileBilling.vue
@@ -509,7 +509,8 @@ export default {
       creditNoteMetaInfo.value = {
         number,
         netInclTaxes,
-        courseName: `${get(course, 'value.company.name')} - ${get(course, 'value.subProgram.program.name')}`,
+        courseName: `${get(course, 'value.company.name')} - ${get(course, 'value.subProgram.program.name')}
+          ${get(course, 'value.misc') ? ` - ${get(course, 'value.misc')}` : ''}`,
       };
     };
 

--- a/src/core/components/courses/ProfileBilling.vue
+++ b/src/core/components/courses/ProfileBilling.vue
@@ -115,7 +115,8 @@
 
     <ni-course-credit-note-creation-modal v-model="creditNoteCreationModal" v-model:new-credit-note="newCreditNote"
       @submit="addCreditNote" @hide="resetCreditNoteCreationModal" :loading="creditNoteCreationLoading"
-      :validations="validations.newCreditNote" :min-date="minCourseCreditNoteDate" />
+      :validations="validations.newCreditNote" :min-date="minCourseCreditNoteDate"
+      :credit-note-meta-info="creditNoteMetaInfo" />
   </div>
 </template>
 
@@ -186,6 +187,7 @@ export default {
     const newBillingPurchase = ref({ billId: '', billingItem: '', price: 0, count: 1, description: '' });
     const editedBillingPurchase = ref({ _id: '', billId: '', price: 0, count: 1, description: '' });
     const newCreditNote = ref({ courseBill: '', misc: '', date: '', company: '' });
+    const creditNoteMetaInfo = ref({ number: '', netInclTaxes: '', courseName: '' });
     const areDetailsVisible = ref(Object.fromEntries(courseBills.value.map(bill => [bill._id, false])));
     const billToValidate = ref({ _id: '', billedAt: '' });
     const courseFeeEditionModalMetaInfo = ref({ title: '', isBilled: false });
@@ -495,14 +497,20 @@ export default {
     };
 
     const openCreditNoteCreationModal = (bill) => {
+      const { _id: billId, number, netInclTaxes } = bill;
       newCreditNote.value = {
-        courseBill: bill._id,
+        courseBill: billId,
         date: '',
         misc: '',
         company: course.value.company._id,
       };
       creditNoteCreationModal.value = true;
       minCourseCreditNoteDate.value = bill.billedAt;
+      creditNoteMetaInfo.value = {
+        number,
+        netInclTaxes,
+        courseName: `${get(course, 'value.company.name')} - ${get(course, 'value.subProgram.program.name')}`,
+      };
     };
 
     const addCreditNote = async () => {
@@ -528,6 +536,7 @@ export default {
     const resetCreditNoteCreationModal = () => {
       newCreditNote.value = { courseBill: '', date: '', misc: '', company: '' };
       minCourseCreditNoteDate.value = '';
+      creditNoteMetaInfo.value = { number: '', netInclTaxes: '', courseName: '' };
       validations.value.newCreditNote.$reset();
     };
 
@@ -626,6 +635,7 @@ export default {
       courseFeeEditionModalMetaInfo,
       areDetailsVisible,
       minCourseCreditNoteDate,
+      creditNoteMetaInfo,
       // Computed
       validations,
       course,

--- a/src/modules/vendor/components/billing/CourseCreditNoteCreationModal.vue
+++ b/src/modules/vendor/components/billing/CourseCreditNoteCreationModal.vue
@@ -3,6 +3,13 @@
     <template #title>
       Créer un <span class="text-weight-bold">avoir</span>
     </template>
+    <div>
+      Cet avoir annule la facture
+      <span class="text-weight-bold">
+          {{ creditNoteMetaInfo.number }} - {{ formatPrice(creditNoteMetaInfo.netInclTaxes) }}
+      </span>
+    </div>
+    <div class="name">{{ creditNoteMetaInfo.courseName }}</div>
     <ni-date-input in-modal caption="Date" :model-value="newCreditNote.date" @blur="validations.date.$touch"
       required-field :error="validations.date.$error" @update:model-value="update($event, 'date')" :min="minDate"
       :error-message="dateErrorMessage(validations)" />
@@ -21,6 +28,7 @@ import Input from '@components/form/Input';
 import Button from '@components/Button';
 import DateInput from '@components/form/DateInput';
 import { REQUIRED_LABEL } from '@data/constants';
+import { formatPrice } from '@helpers/utils';
 
 export default {
   name: 'CourseCreditNoteCreationModal',
@@ -30,6 +38,7 @@ export default {
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
     minDate: { type: String, required: true },
+    creditNoteMetaInfo: { type: Object, default: () => ({}) },
   },
   components: {
     'ni-modal': Modal,
@@ -59,7 +68,15 @@ export default {
       input,
       submit,
       update,
+      formatPrice,
     };
   },
 };
 </script>
+
+<style lang="sass" scoped>
+.name
+  color: $copper-grey-500
+  font-size: 14px
+  margin-bottom: 16px
+</style>

--- a/src/modules/vendor/components/billing/CourseCreditNoteCreationModal.vue
+++ b/src/modules/vendor/components/billing/CourseCreditNoteCreationModal.vue
@@ -13,7 +13,8 @@
     <ni-date-input in-modal caption="Date" :model-value="newCreditNote.date" @blur="validations.date.$touch"
       required-field :error="validations.date.$error" @update:model-value="update($event, 'date')" :min="minDate"
       :error-message="dateErrorMessage(validations)" />
-    <ni-input in-modal caption="Motif" :model-value="newCreditNote.misc" @update:model-value="update($event, 'misc')" />
+    <ni-input in-modal caption="Motif" :model-value="newCreditNote.misc" @update:model-value="update($event, 'misc')"
+      type="textarea" />
     <template #footer>
       <ni-button class="full-width modal-btn bg-primary" label="Créer l'avoir" icon-right="add" color="white"
         :loading="loading" @click="submit" />


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage : lorsque je crée un avoir, dans la modale j'ai une référence à la facture associée, à son prix et au nom de la formation

- Comment tester ? : créer un avoir sur une formation et s'assurer qu'on a les bonnes infos dans la modale de création

_Si tu as lu cette description, pense a réagir avec un :eye:_
