### PR TITLE
COM-2823 rename field

### DIFF
--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -658,7 +658,7 @@ export default {
     disableSubscriptionDeletion (sub) {
       const hasFunding = this.fundings.some(f => f.subscription._id === sub._id);
 
-      return sub.eventCount > 0 || sub.repetitionCount > 0 || hasFunding;
+      return sub.isUsedInEvents > 0 || sub.isUsedInRepetitions > 0 || hasFunding;
     },
     getFundingValidation (funding) {
       return {


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
Périmètre interfaces / rôles : coach

Cas d'usage : Modification des countDocuments de countSubscriptionUsage pour n'avoir que 0 ou 1 suivant si la subscription est lié à un évènement ou non.

Comment tester ? :

Sur la page profile d'un bénéficiaire, je ne peux pas supprimer une souscription si il a au moins un évènement ou une repetition. --> Seul endroit ou les champs sont effectivement utilisés
Autres endroits à vérifier car il y a l'utilisation de Customer.findOne
- Je peux supprimer un bénéficiaire
- Je peux générer un qrcode pour un bénéficiaire
- Je peux créer une répétition
- Je peux créer et modifier un financement
- Je peux modifier le rib d'un beneficiaire et je vois un nouveau mandat
- ETQ aidant je peux signer un mandat
- Je peux générer un devis
- Je peux changer le referent d'un beneficiaire
- Je peux créer une absence beneficiaire

Egalement modifié dans cette pr : si je supprime un bénéficiaire, ces absences sont également supprimées.
_Si tu as lu cette description, pense a réagir avec un :eye:_
