### PR TITLE
Com 2793

### DIFF
--- a/src/core/components/courses/CourseCell.vue
+++ b/src/core/components/courses/CourseCell.vue
@@ -105,6 +105,15 @@ export default {
           ${slotsToPlanLength ? `dont ${slotsToPlanLength} à planifier, ` : ''}${this.slotsDurationTitle}`;
     },
     formatNearestDate () {
+      if (!this.courseSlotsCount && this.course.estimatedStartDate) {
+        const rangeToEstimatedStartDate = moment(this.course.estimatedStartDate).diff(moment().startOf('day'), 'd');
+
+        return rangeToEstimatedStartDate < 0
+          ? `Début souhaité il y a ${formatQuantity('jour', Math.abs(rangeToEstimatedStartDate))}`
+          : `Début souhaité ${rangeToEstimatedStartDate
+            ? `dans ${formatQuantity('jour', rangeToEstimatedStartDate)}`
+            : 'aujourd\'hui'}`;
+      }
       if (!this.courseSlotsCount && !this.course.slotsToPlan.length) return 'Pas de date prévue';
       if (!this.courseSlotsCount) return 'Prochaine date à planifier';
 

--- a/src/core/components/form/DateInput.vue
+++ b/src/core/components/form/DateInput.vue
@@ -5,7 +5,7 @@
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
     <q-input borderless dense :model-value="inputDate" bg-color="white" @update:model-value="input" :error="error"
-      placeholder="jj/mm/yyyy" :disable="disable" :class="{ 'borders': inModal }" :error-message="errorMessage"
+      :placeholder="placeholder" :disable="disable" :class="{ 'borders': inModal }" :error-message="errorMessage"
       @blur="blur" ref="dateInput" @focus="focus">
       <template #append>
         <q-icon name="event" class="cursor-pointer" @click="focus" color="copper-grey-500">
@@ -37,6 +37,7 @@ export default {
     inModal: { type: Boolean, default: false },
     requiredField: { type: Boolean, default: false },
     contentClass: { type: String, default: '' },
+    placeholder: { type: String, default: 'jj/mm/yyyy' },
   },
   emits: ['blur', 'focus', 'update:model-value'],
   computed: {

--- a/src/core/mixins/courseTimeline.js
+++ b/src/core/mixins/courseTimeline.js
@@ -7,11 +7,7 @@ export const courseTimelineMixin = {
       return this.courses
         .filter(this.isForthcoming)
         .map(course => ({ ...course, status: FORTHCOMING }))
-        .sort((a, b) => {
-          if (a.slotsToPlan.length && !b.slotsToPlan.length) return -1;
-          if (!a.slotsToPlan.length && b.slotsToPlan.length) return 1;
-          return this.getRangeNowToStartCourse(a) - this.getRangeNowToStartCourse(b);
-        });
+        .sort((a, b) => this.getRangeNowToStartCourse(a) - this.getRangeNowToStartCourse(b));
     },
     courseListInProgress () {
       return this.courses
@@ -47,7 +43,10 @@ export const courseTimelineMixin = {
       return !this.isForthcoming(course) && !this.isInProgress(course);
     },
     getRangeNowToStartCourse (course) {
-      if (!course.slots.length && course.slotsToPlan.length) return 0;
+      if (!course.slots.length && course.estimatedStartDate) {
+        return moment(course.estimatedStartDate).diff(moment(), 'd', true);
+      }
+      if (!course.slots.length && course.slotsToPlan.length) return Number.MAX_SAFE_INTEGER - 1;
       if (!course.slots.length) return Number.MAX_SAFE_INTEGER;
 
       const firstSlot = course.slots[0];

--- a/src/modules/client/pages/ni/courses/BlendedCoursesDirectory.vue
+++ b/src/modules/client/pages/ni/courses/BlendedCoursesDirectory.vue
@@ -7,6 +7,10 @@
         @update:model-value="updateSelectedTrainer" />
       <ni-select :options="programFilterOptions" :model-value="selectedProgram" clearable
         @update:model-value="updateSelectedProgram" />
+      <ni-date-input :model-value="selectedStartDate" @update:model-value="updateSelectedStartDate"
+        placeholder="Début de période" />
+      <ni-date-input :model-value="selectedEndDate" @update:model-value="updateSelectedEndDate"
+        placeholder="Fin de période" />
       <div class="reset-filters" @click="resetFilters">Effacer les filtres</div>
     </div>
     <ni-trello :courses="coursesFiltered" />
@@ -18,6 +22,7 @@ import { createMetaMixin } from 'quasar';
 import { mapState } from 'vuex';
 import get from 'lodash/get';
 import Courses from '@api/Courses';
+import DateInput from '@components/form/DateInput';
 import Select from '@components/form/Select';
 import DirectoryHeader from '@components/DirectoryHeader';
 import Trello from '@components/courses/Trello';
@@ -33,6 +38,7 @@ export default {
     'ni-select': Select,
     'ni-directory-header': DirectoryHeader,
     'ni-trello': Trello,
+    'ni-date-input': DateInput,
   },
   data () {
     return {

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -33,6 +33,7 @@ import useVuelidate from '@vuelidate/core';
 import { required, requiredIf } from '@vuelidate/validators';
 import { mapState } from 'vuex';
 import omit from 'lodash/omit';
+import pickBy from 'lodash/pickBy';
 import Courses from '@api/Courses';
 import Companies from '@api/Companies';
 import Programs from '@api/Programs';
@@ -161,7 +162,7 @@ export default {
         if (this.v$.newCourse.$error) return NotifyWarning('Champ(s) invalide(s)');
 
         this.modalLoading = true;
-        await Courses.create(omit(this.newCourse, 'program'));
+        await Courses.create(pickBy(omit(this.newCourse, 'program')));
 
         this.courseCreationModal = false;
         NotifyPositive('Formation créée.');

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -11,6 +11,10 @@
         @update:model-value="updateSelectedProgram" />
       <ni-select :options="salesRepresentativesFilterOptions" :model-value="selectedSalesRepresentative"
         @update:model-value="updateSelectedSalesRepresentative" />
+      <ni-date-input :model-value="selectedStartDate" @update:model-value="updateSelectedStartDate"
+        placeholder="Début de période" />
+      <ni-date-input :model-value="selectedEndDate" @update:model-value="updateSelectedEndDate"
+        placeholder="Fin de période" />
       <div class="reset-filters" @click="resetFilters">Effacer les filtres</div>
     </div>
     <ni-trello :courses="coursesFiltered" />
@@ -34,6 +38,7 @@ import Companies from '@api/Companies';
 import Programs from '@api/Programs';
 import Users from '@api/Users';
 import DirectoryHeader from '@components/DirectoryHeader';
+import DateInput from '@components/form/DateInput';
 import Select from '@components/form/Select';
 import CourseCreationModal from 'src/modules/vendor/components/courses/CourseCreationModal';
 import Trello from '@components/courses/Trello';
@@ -50,6 +55,7 @@ export default {
     'ni-select': Select,
     'course-creation-modal': CourseCreationModal,
     'ni-trello': Trello,
+    'ni-date-input': DateInput,
   },
   setup () {
     const metaInfo = { title: 'Catalogue' };

--- a/src/modules/vendor/pages/trainers/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/trainers/management/BlendedCoursesDirectory.vue
@@ -9,6 +9,10 @@
         @update:model-value="updateSelectedProgram" />
       <ni-select :options="salesRepresentativesFilterOptions" clearable
         :model-value="selectedSalesRepresentative" @update:model-value="updateSelectedSalesRepresentative" />
+      <ni-date-input :model-value="selectedStartDate" @update:model-value="updateSelectedStartDate"
+        placeholder="Début de période" />
+      <ni-date-input :model-value="selectedEndDate" @update:model-value="updateSelectedEndDate"
+        placeholder="Fin de période" />
       <div class="reset-filters" @click="resetFilters">Effacer les filtres</div>
     </div>
     <ni-trello :courses="coursesFiltered" />
@@ -20,6 +24,7 @@ import { mapState } from 'vuex';
 import Courses from '@api/Courses';
 import DirectoryHeader from '@components/DirectoryHeader';
 import Trello from '@components/courses/Trello';
+import DateInput from '@components/form/DateInput';
 import Select from '@components/form/Select';
 import { courseFiltersMixin } from '@mixins/courseFiltersMixin';
 import { BLENDED } from '@data/constants';
@@ -34,6 +39,7 @@ export default {
     'ni-directory-header': DirectoryHeader,
     'ni-trello': Trello,
     'ni-select': Select,
+    'ni-date-input': DateInput,
   },
   data () {
     return {

--- a/src/store/course.js
+++ b/src/store/course.js
@@ -11,6 +11,8 @@ export default {
     selectedProgram: '',
     selectedCompany: '',
     selectedSalesRepresentative: '',
+    selectedStartDate: '',
+    selectedEndDate: '',
   },
   mutations: {
     SET_COURSE: (state, data) => { state.course = data ? ({ ...data }) : data; },
@@ -18,6 +20,8 @@ export default {
     SET_SELECTED_PROGRAM: (state, data) => { state.selectedProgram = data; },
     SET_SELECTED_COMPANY: (state, data) => { state.selectedCompany = data; },
     SET_SELECTED_SALES_REPRESENTATIVE: (state, data) => { state.selectedSalesRepresentative = data; },
+    SET_SELECTED_START_DATE: (state, data) => { state.selectedStartDate = data; },
+    SET_SELECTED_END_DATE: (state, data) => { state.selectedEndDate = data; },
   },
   actions: {
     fetchCourse: async ({ commit }, params) => {
@@ -46,11 +50,15 @@ export default {
     setSelectedSalesRepresentative: ({ commit }, params) => {
       commit('SET_SELECTED_SALES_REPRESENTATIVE', params.salesRepresentativeId);
     },
+    setSelectedStartDate: ({ commit }, params) => { commit('SET_SELECTED_START_DATE', params.startDate); },
+    setSelectedEndDate: ({ commit }, params) => { commit('SET_SELECTED_END_DATE', params.endDate); },
     resetFilters: ({ commit }) => {
       commit('SET_SELECTED_TRAINER', '');
       commit('SET_SELECTED_PROGRAM', '');
       commit('SET_SELECTED_COMPANY', '');
       commit('SET_SELECTED_SALES_REPRESENTATIVE', '');
+      commit('SET_SELECTED_START_DATE', '');
+      commit('SET_SELECTED_END_DATE', '');
     },
   },
   getters: {},


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage : dans le répertoire des formations je peux trier sur la date

- Comment tester ? :
- trier avec une date de début => je n'ai que les formations avec un créneau ou une date de début souhaitée > que la date sélectionnée
- trier avec une date de fin => je n'ai que les formations avec un créneau ou une date de début souhaitée < que la date sélectionnée
- trier avec une date de début et une date de fin => je n'ai que les formations avec un créneau ou une date de début souhaitée dans l'intervalle de dates sélectionnées
- dans la colonne à venir les dates sont rangées dans l'ordre suivant : les formations avec des créneaux/date de début souhaitées rangés par ordre croissant / les formations avec juste des créneaux à planifier / les formations avec aucun créneaux

_Si tu as lu cette description, pense a réagir avec un :eye:_
