### PR TITLE
COM-2791: can't click outside of program name

### DIFF
--- a/src/modules/vendor/components/companies/ProfileBilling.vue
+++ b/src/modules/vendor/components/companies/ProfileBilling.vue
@@ -363,6 +363,7 @@ export default {
   color: $copper-grey-600
 .course
   display: flex
+  max-width: fit-content
   &:hover
     text-decoration: underline
     text-decoration-color: $copper-grey-600


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage : quand je clique sur le nom d'une formation depuis l'onglet factu sur une fiche structure, je ne peux cliquer que sur le nom pour être redirigé et non plus juste à côté du nom

- Comment tester ? : cf cas d'usage

_Si tu as lu cette description, pense a réagir avec un :eye:_
