### PR TITLE
COM-2833 add checkbox in teletransmission for onlyPastEvents

### DIFF
--- a/src/modules/client/components/customers/billing/DeliveryDownloadModal.vue
+++ b/src/modules/client/components/customers/billing/DeliveryDownloadModal.vue
@@ -10,7 +10,7 @@
     </div>
     <ni-select caption="Mois" :model-value="deliveryFile.month" required-field @blur="validations.month.$touch"
       :error="validations.month.$error" @update:model-value="update($event, 'month')" :options="monthOptions"
-      in-modal />
+      in-modal :disable="deliveryFile.onlyPastEvents" />
     <div v-if="deliveryFile.month === moment().format('MM-YYYY')" class="row q-pb-md q-pt-md">
       <q-checkbox class="checkbox" :model-value="deliveryFile.onlyPastEvents" dense
         @update:model-value="update($event, 'onlyPastEvents')"

--- a/src/modules/client/components/customers/billing/DeliveryDownloadModal.vue
+++ b/src/modules/client/components/customers/billing/DeliveryDownloadModal.vue
@@ -12,9 +12,9 @@
       :error="validations.month.$error" @update:model-value="update($event, 'month')" :options="monthOptions"
       in-modal />
     <div class="row q-pb-md q-pt-md">
-      <q-checkbox class="checkbox" :model-value="deliveryFile.onlyPastEvents"
-        @update:model-value="update($event, 'onlyPastEvents')" dense
-        label="Ne prendre en compte que les évènement passés jusqu’à hier (inclus)" />
+      <q-checkbox class="checkbox" :model-value="deliveryFile.onlyPastEvents" dense
+        @update:model-value="update($event, 'onlyPastEvents')"
+        label="Ne prendre en compte que les évènements passés (jusqu’à hier inclus)" />
     </div>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Télécharger le fichier" icon-right="add" color="primary"

--- a/src/modules/client/components/customers/billing/DeliveryDownloadModal.vue
+++ b/src/modules/client/components/customers/billing/DeliveryDownloadModal.vue
@@ -11,10 +11,10 @@
     <ni-select caption="Mois" :model-value="deliveryFile.month" required-field @blur="validations.month.$touch"
       :error="validations.month.$error" @update:model-value="update($event, 'month')" :options="monthOptions"
       in-modal />
-    <div class="row q-pb-md q-pt-md">
+    <div v-if="deliveryFile.month === moment().format('MM-YYYY')" class="row q-pb-md q-pt-md">
       <q-checkbox class="checkbox" :model-value="deliveryFile.onlyPastEvents" dense
         @update:model-value="update($event, 'onlyPastEvents')"
-        label="Ne prendre en compte que les évènements passés (jusqu’à hier inclus)" />
+        label="Inclure uniquement les évènements antérieurs à aujourd'hui" />
     </div>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Télécharger le fichier" icon-right="add" color="primary"
@@ -25,6 +25,7 @@
 
 <script>
 import set from 'lodash/set';
+import moment from '@helpers/moment';
 import Select from '@components/form/Select';
 import OptionGroup from '@components/form/OptionGroup';
 import Modal from '@components/modal/Modal';
@@ -58,6 +59,7 @@ export default {
     update (event, prop) {
       this.$emit('update:delivery-file', set(this.deliveryFile, prop, event));
     },
+    moment,
   },
 };
 </script>

--- a/src/modules/client/components/customers/billing/DeliveryDownloadModal.vue
+++ b/src/modules/client/components/customers/billing/DeliveryDownloadModal.vue
@@ -11,6 +11,11 @@
     <ni-select caption="Mois" :model-value="deliveryFile.month" required-field @blur="validations.month.$touch"
       :error="validations.month.$error" @update:model-value="update($event, 'month')" :options="monthOptions"
       in-modal />
+    <div class="row q-pb-md q-pt-md">
+      <q-checkbox class="checkbox" :model-value="deliveryFile.onlyPastEvents"
+        @update:model-value="update($event, 'onlyPastEvents')" dense
+        label="Ne prendre en compte que les évènement passés jusqu’à hier (inclus)" />
+    </div>
     <template #footer>
       <q-btn no-caps class="full-width modal-btn" label="Télécharger le fichier" icon-right="add" color="primary"
         :loading="loading" @click="submit" />
@@ -56,3 +61,8 @@ export default {
   },
 };
 </script>
+
+<style lang="sass" scoped>
+  .checkbox
+    font-size: 14px !important
+</style>

--- a/src/modules/client/pages/ni/billing/ToBill.vue
+++ b/src/modules/client/pages/ni/billing/ToBill.vue
@@ -138,7 +138,7 @@ export default {
       ],
       toBillOption: 0,
       deliveryDownloadModal: false,
-      deliveryFile: { thirdPartyPayers: [], month: moment().format('MM-YYYY') },
+      deliveryFile: { thirdPartyPayers: [], month: moment().format('MM-YYYY'), onlyPastEvents: false },
       thirdPartyPayerOptions: [],
       thirdPartyPayers: [],
       monthOptions: [
@@ -208,7 +208,7 @@ export default {
     },
     resetDeliveryDownloadModal () {
       this.v$.deliveryFile.$reset();
-      this.deliveryFile = { thirdPartyPayers: [], month: moment().format('MM-YYYY') };
+      this.deliveryFile = { thirdPartyPayers: [], month: moment().format('MM-YYYY'), onlyPastEvents: false };
     },
     getFileName () {
       const tpp = this.thirdPartyPayers.find(t => this.deliveryFile.thirdPartyPayers.includes(t._id));


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin

- Cas d'usage : sur la facturation, je peux telecharger le doc de teletransmission uniquement pour les evenements passés

- Comment tester ? : telecharger le fichier de teletransmission pour le mois entier et uniquement pour les evenements passés et verifier que c'est coherent + verifier que pour l'id CIDDHExchangedDocument, on a bien l'id de l'evenement

_Si tu as lu cette description, pense a réagir avec un :eye:_
