### PR TITLE
COM-2816: hide button for clients

### DIFF
--- a/src/core/components/courses/CourseHistory.vue
+++ b/src/core/components/courses/CourseHistory.vue
@@ -99,12 +99,8 @@ export default {
       return { pre: 'Nouveau', type: 'créneau', post: 'le', infos };
     },
     getSlotCreationDetails () {
-      if (get(this.courseHistory, 'slot.address.fullAddress')) {
-        return get(this.courseHistory, 'slot.address.fullAddress');
-      }
-      if (get(this.courseHistory, 'slot.meetingLink')) return get(this.courseHistory, 'slot.meetingLink');
-
-      return 'Pas d\'adresse renseignée.';
+      return get(this.courseHistory, 'slot.address.fullAddress') || get(this.courseHistory, 'slot.meetingLink') ||
+        'Pas d\'adresse renseignée.';
     },
     getSlotDeletionTitle () {
       const date = moment(this.courseHistory.slot.startDate).format('DD/MM');

--- a/src/core/components/courses/CourseHistory.vue
+++ b/src/core/components/courses/CourseHistory.vue
@@ -99,7 +99,12 @@ export default {
       return { pre: 'Nouveau', type: 'créneau', post: 'le', infos };
     },
     getSlotCreationDetails () {
-      return get(this.courseHistory, 'slot.address.fullAddress', 'Pas d\'adresse renseignée.');
+      if (get(this.courseHistory, 'slot.address.fullAddress')) {
+        return get(this.courseHistory, 'slot.address.fullAddress');
+      }
+      if (get(this.courseHistory, 'slot.meetingLink')) return get(this.courseHistory, 'slot.meetingLink');
+
+      return 'Pas d\'adresse renseignée.';
     },
     getSlotDeletionTitle () {
       const date = moment(this.courseHistory.slot.startDate).format('DD/MM');
@@ -107,11 +112,15 @@ export default {
       return { pre: 'Suppression du', type: 'créneau', post: 'du', infos: `${date}` };
     },
     getSlotDeletionDetails () {
-      const address = get(this.courseHistory, 'slot.address.fullAddress', '');
+      let address = '.\r\nPas d\'adresse renseignée.';
+      if (get(this.courseHistory, 'slot.address.fullAddress')) {
+        address = ` au ${get(this.courseHistory, 'slot.address.fullAddress')}`;
+      } else if (get(this.courseHistory, 'slot.meetingLink')) {
+        address = ` sur ${get(this.courseHistory, 'slot.meetingLink')}`;
+      }
 
       return `Créneau initialement prévu de ${formatHoursWithMinutes(this.courseHistory.slot.startDate)}`
-        + ` à ${formatHoursWithMinutes(this.courseHistory.slot.endDate)}`
-        + `${address ? `, au ${address}.` : '.\r\nPas d\'adresse renseignée.'}`;
+        + ` à ${formatHoursWithMinutes(this.courseHistory.slot.endDate)}${address}`;
     },
     getSlotEditionTitle () {
       if (this.courseHistory.update.startDate) {

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -43,7 +43,7 @@
           <div class="to-plan-text">Créneau à planifier</div>
         </q-card>
       </div>
-      <div class="q-mt-md" v-if="canEdit" align="right">
+      <div class="q-mt-md" v-if="canEdit && isAdmin && isVendorInterface" align="right">
         <ni-button class="add-slot" label="Ajouter un créneau" color="white" icon="add"
           :disable="loading || addDateToPlanloading" @click="openSlotCreationModal" />
         <ni-button v-if="isVendorInterface" class="add-slot" label="Ajouter une date à planifier" color="white"
@@ -57,7 +57,8 @@
 
     <slot-edition-modal v-model="editionModal" :edited-course-slot="editedCourseSlot" :step-options="stepOptions"
       :validations="v$.editedCourseSlot" @hide="resetEditionModal" :loading="modalLoading" @delete="deleteCourseSlot"
-      @submit="updateCourseSlot" :link-error-message="linkErrorMessage" @update="setCourseSlot" />
+      @submit="updateCourseSlot" :link-error-message="linkErrorMessage" @update="setCourseSlot" :is-admin="isAdmin"
+      :is-vendor-interface="isVendorInterface" />
 </div>
 </template>
 
@@ -360,6 +361,7 @@ export default {
       } catch (e) {
         console.error(e);
         if (e.data.statusCode === 409) return NotifyWarning('Créneau émargé : impossible de le supprimer');
+        if (e.data.statusCode === 403) return NotifyWarning('Seul créneau de l\'étape : impossible de le supprimer');
         NotifyNegative('Erreur lors de la suppression du créneau.');
       } finally {
         this.modalLoading = false;

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -360,8 +360,8 @@ export default {
         this.editionModal = false;
       } catch (e) {
         console.error(e);
-        if (e.data.statusCode === 409) return NotifyWarning('Créneau émargé : impossible de le supprimer');
-        if (e.data.statusCode === 403) return NotifyWarning('Seul créneau de l\'étape : impossible de le supprimer');
+        if (e.data.statusCode === 409) return NotifyWarning('Créneau émargé : impossible de le supprimer.');
+        if (e.data.statusCode === 403) return NotifyWarning('Seul créneau de l\'étape : impossible de le supprimer.');
         NotifyNegative('Erreur lors de la suppression du créneau.');
       } finally {
         this.modalLoading = false;

--- a/src/core/components/courses/SlotEditionModal.vue
+++ b/src/core/components/courses/SlotEditionModal.vue
@@ -4,7 +4,7 @@
       Editer un <span class="text-weight-bold">créneau</span>
     </template>
     <div class="modal-icon">
-      <ni-button icon="delete" @click="validateDeletion(editedCourseSlot._id)" />
+      <ni-button v-if="isAdmin && isVendorInterface" icon="delete" @click="validateDeletion(editedCourseSlot._id)" />
     </div>
     <ni-select in-modal caption="Etape" :options="stepOptions" :model-value="editedCourseSlot.step" required-field
       @blur="validations.step.$touch" :error="validations.step.$error" @update:model-value="updateStep" />
@@ -43,6 +43,8 @@ export default {
     validations: { type: Object, default: () => ({}) },
     loading: { type: Boolean, default: false },
     linkErrorMessage: { type: String, default: '' },
+    isAdmin: { type: Boolean, default: false },
+    isVendorInterface: { type: Boolean, default: false },
   },
   components: {
     'ni-button': Button,


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client rof/admin_vendeur/admin_client/trainer/coach

- Cas d'usage : seul les admin vendeur/rof peuvent créer et supprimer des créneaux + boyscout création d'historique : meetinglink pris en compte + pas d'historique à la suppression de créneaux à planifier

- Comment tester ? : 
  - côté vendeur (rof/admin) : 
    - créer un créneau dans une formation => je ne peux pas le supprimer si c'est le seul de l'étape
    - je supprime un créneau à planifier => je n'ai pas d'historique créé
    - je créé/supprime un créneau d'une étape distancielle avec un lien de visio => le lien est dans l'historique
  - côté client (coach/admin) / côté vendeur (trainer) : 
    - je ne peux pas supprimer ni créer de créneau
    - je peux éditer un créneau   

_Si tu as lu cette description, pense a réagir avec un :eye:_
