### PR TITLE
COM-2837: display slots by step

### DIFF
--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -24,7 +24,7 @@
       </div>
     </div>
     <ni-slot-container :can-edit="canEditSlots" :loading="courseLoading" @refresh="refreshCourse" :is-admin="isAdmin"
-      @update="updateCourse('estimatedStartDate')" :course-slots-by-step-and-date="courseSlotsByStepAndDate" />
+      @update="updateCourse('estimatedStartDate')" />
     <ni-trainee-table :can-edit="canEditTrainees" :loading="courseLoading" @refresh="refreshCourse" />
     <q-page-sticky expand position="right">
       <course-history-feed v-if="displayHistory" @toggle-history="toggleHistory" :course-histories="courseHistories"
@@ -93,7 +93,6 @@ import { mapState } from 'vuex';
 import useVuelidate from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import get from 'lodash/get';
-import groupBy from 'lodash/groupBy';
 import uniqBy from 'lodash/uniqBy';
 import cloneDeep from 'lodash/cloneDeep';
 import Users from '@api/Users';
@@ -269,16 +268,6 @@ export default {
     },
     isMissingContactPhone () {
       return !!get(this.course, 'contact._id') && get(this.v$, 'course.contact.contact.phone.$error');
-    },
-    courseSlotsByStepAndDate () {
-      if (!this.course.slots.length && !this.course.slotsToPlan.length) return {};
-      const formattedSlots = [...this.course.slots, ...this.course.slotsToPlan]
-        .map(slot => ({ ...slot, step: typeof slot.step === 'object' ? slot.step._id : slot.step }));
-      const slotsByStep = groupBy(formattedSlots, 'step');
-      const slotsByStepAndDateList = Object.keys(slotsByStep)
-        .map(key => groupBy(slotsByStep[key], s => formatDate(s.startDate)));
-
-      return Object.fromEntries(Object.keys(slotsByStep).map((key, index) => [key, slotsByStepAndDateList[index]]));
     },
   },
   async created () {

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -24,7 +24,7 @@
       </div>
     </div>
     <ni-slot-container :can-edit="canEditSlots" :loading="courseLoading" @refresh="refreshCourse" :is-admin="isAdmin"
-      @update="updateCourse('estimatedStartDate')" />
+      @update="updateCourse('estimatedStartDate')" :course-slots-by-step-and-date="courseSlotsByStepAndDate" />
     <ni-trainee-table :can-edit="canEditTrainees" :loading="courseLoading" @refresh="refreshCourse" />
     <q-page-sticky expand position="right">
       <course-history-feed v-if="displayHistory" @toggle-history="toggleHistory" :course-histories="courseHistories"
@@ -93,6 +93,7 @@ import { mapState } from 'vuex';
 import useVuelidate from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import get from 'lodash/get';
+import groupBy from 'lodash/groupBy';
 import uniqBy from 'lodash/uniqBy';
 import cloneDeep from 'lodash/cloneDeep';
 import Users from '@api/Users';
@@ -268,6 +269,16 @@ export default {
     },
     isMissingContactPhone () {
       return !!get(this.course, 'contact._id') && get(this.v$, 'course.contact.contact.phone.$error');
+    },
+    courseSlotsByStepAndDate () {
+      if (!this.course.slots.length && !this.course.slotsToPlan.length) return {};
+      const formattedSlots = [...this.course.slots, ...this.course.slotsToPlan]
+        .map(slot => ({ ...slot, step: typeof slot.step === 'object' ? slot.step._id : slot.step }));
+      const slotsByStep = groupBy(formattedSlots, 'step');
+      const slotsByStepAndDateList = Object.keys(slotsByStep)
+        .map(key => groupBy(slotsByStep[key], s => formatDate(s.startDate)));
+
+      return Object.fromEntries(Object.keys(slotsByStep).map((key, index) => [key, slotsByStepAndDateList[index]]));
     },
   },
   async created () {

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -25,7 +25,7 @@
               </div>
             </div>
           </div>
-          <div v-else-if="!!Object.keys(courseSlotsByStepAndDate).length &&
+          <div v-else-if="!!courseSlotsByStepAndDate[step.key] &&
             Object.keys(courseSlotsByStepAndDate[step.key]).some(key => key === '')">
             <div class="to-plan q-mx-lg">
               <div class="to-plan-header">Créneaux à programmer</div>
@@ -62,7 +62,8 @@
               </div>
             </div>
           </div>
-          <div v-else-if="!!Object.keys(courseSlotsByStepAndDate).length">
+          <div v-else-if="!!courseSlotsByStepAndDate[step.key] &&
+            Object.keys(courseSlotsByStepAndDate[step.key]).every(key => key !== '')">
             <div class="defined q-mx-lg">
               <div class="row items-center q-pa-md">
                 <div class="index">{{ index + 1 }}</div>
@@ -82,6 +83,22 @@
                       <ni-button icon="edit" @click="openEditionModal(slot)" size="10px" color="copper-grey-500" />
                     </div>
                   </div>
+                </div>
+              </div>
+              <div class="q-mt-md" v-if="canEdit && isAdmin && isVendorInterface" align="right">
+                <ni-button label="Ajouter un créneau" color="primary" icon="add"
+                  @click="addDateToPlan(step.key)" :disable="addDateToPlanLoading" />
+              </div>
+            </div>
+          </div>
+          <div v-else>
+            <div class="to-plan q-mx-lg">
+              <div class="to-plan-header">Créneaux à programmer</div>
+              <div class="row items-center q-pa-md">
+                <div class="index">{{ index + 1 }}</div>
+                <div class="q-mx-md">
+                  <div>{{ step.name }}</div>
+                  <div class="type">{{ step.type }}</div>
                 </div>
               </div>
               <div class="q-mt-md" v-if="canEdit && isAdmin && isVendorInterface" align="right">

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -16,7 +16,7 @@
       </div>
       <q-card>
         <q-card v-for="(step, index) in stepList" :key="step.key" class="q-pa-md">
-          <div v-if="step.type === 'eLearning'" class="q-mx-lg">
+          <div v-if="step.type === 'eLearning'">
             <div class="row items-center q-pa-md">
               <div class="index">{{ index + 1 }}</div>
               <div class="q-mx-md">
@@ -27,7 +27,7 @@
           </div>
           <div v-else-if="!!courseSlotsByStepAndDate[step.key] &&
             Object.keys(courseSlotsByStepAndDate[step.key]).some(key => key === '')">
-            <div class="to-plan q-mx-lg">
+            <div class="to-plan">
               <div class="to-plan-header">Créneaux à programmer</div>
               <div class="row items-center q-pa-md">
                 <div class="index">{{ index + 1 }}</div>
@@ -64,7 +64,7 @@
           </div>
           <div v-else-if="!!courseSlotsByStepAndDate[step.key] &&
             Object.keys(courseSlotsByStepAndDate[step.key]).every(key => key !== '')">
-            <div class="defined q-mx-lg">
+            <div class="defined">
               <div class="row items-center q-pa-md">
                 <div class="index">{{ index + 1 }}</div>
                 <div class="q-mx-md">
@@ -92,7 +92,7 @@
             </div>
           </div>
           <div v-else>
-            <div class="to-plan q-mx-lg">
+            <div class="to-plan">
               <div class="to-plan-header">Créneaux à programmer</div>
               <div class="row items-center q-pa-md">
                 <div class="index">{{ index + 1 }}</div>

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -27,7 +27,7 @@
             </div>
             <div v-if="!isElearningStep(step)" class="slots-container">
               <div v-if="isStepToPlan(step) && !!get(courseSlotsByStepAndDate[step.key], SLOTS_TO_PLAN_KEY)"
-                class="flex">
+                class="to-plan-slot">
                 <div v-for="slot in Object.values(get(courseSlotsByStepAndDate[step.key], SLOTS_TO_PLAN_KEY)).flat()"
                   :key="slot._id" class="row items-center q-ml-xl q-mb-md cursor-pointer hover-orange"
                   @click="openEditionModal(slot)">
@@ -36,7 +36,7 @@
                 </div>
               </div>
               <div v-for="day in Object.entries(omit(courseSlotsByStepAndDate[step.key], SLOTS_TO_PLAN_KEY))"
-                :key="day" class="row q-ml-xl q-my-md">
+                :key="day" class="row q-ml-xl q-my-sm">
                 <div class="text-weight-bold q-mr-md">{{ day[0] }}</div>
                 <div>
                   <div v-for="slot in day[1]" :key="slot._id" @click="openEditionModal(slot)"
@@ -47,7 +47,7 @@
                   </div>
                 </div>
               </div>
-              <div class="q-mt-md" v-if="canEdit && isAdmin && isVendorInterface" align="right">
+              <div class="q-mt-sm" v-if="canEdit && isAdmin && isVendorInterface" align="right">
                 <ni-button label="Ajouter un créneau" color="primary" icon="add" @click="addDateToPlan(step.key)"
                   :disable="addDateToPlanLoading" />
               </div>
@@ -374,6 +374,9 @@ export default {
   padding: 8px 16px
   border-radius: 15px 15px 0px 0px
   color: $orange-900
+
+.to-plan-slot
+  width: fit-content
 
 .index
   background-color: $copper-500

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -36,16 +36,16 @@
                   <div class="type">{{ step.type }}</div>
                 </div>
               </div>
-              <div class="q-mx-xl">
+              <div class="slots-container">
                 <div v-for="slot in Object.values(pick(courseSlotsByStepAndDate[step.key], '')).flat()" :key="slot._id"
-                  class="row q-mx-xl q-mb-md">
+                  class="row q-ml-xl q-mb-md">
                   <div class="clickable-name text-orange-500 cursor-pointer q-mr-md" @click="openEditionModal(slot)">
                     créneau à planifier
                   </div>
                   <ni-button icon="edit" @click="openEditionModal(slot)" size="10px" color="copper-grey-500" />
                 </div>
                 <div v-for="day in Object.entries(omit(courseSlotsByStepAndDate[step.key], ''))" :key="day"
-                  class="row q-mx-xl q-my-md">
+                  class="row q-ml-xl q-my-md">
                   <div class="text-weight-bold q-mr-md">{{ day[0] }}</div>
                   <div>
                     <div v-for="slot in day[1]" :key="slot._id" class="row justify-between">
@@ -72,9 +72,9 @@
                   <div class="type">{{ step.type }}</div>
                 </div>
               </div>
-              <div class="q-mx-xl">
+              <div class="slots-container">
                 <div v-for="day in Object.entries(courseSlotsByStepAndDate[step.key])" :key="day"
-                  class="row q-mx-xl q-my-md">
+                  class="row q-ml-xl q-my-md">
                   <div class="text-weight-bold q-mr-md">{{ day[0] }}</div>
                   <div>
                     <div v-for="slot in day[1]" :key="slot._id" class="row justify-between">
@@ -412,4 +412,8 @@ export default {
   text-align: center
   color: white
   margin: 0px 4px
+
+.slots-container
+   @media screen and (min-width: 767px)
+    margin-left: 32px
 </style>

--- a/src/css/quasar.variables.sass
+++ b/src/css/quasar.variables.sass
@@ -30,8 +30,8 @@ $orange-600: #DD6B20
 $orange-500: #F5970B
 $orange-400: #F9B233
 $orange-300: #FCC74D
-$orange-200: #FDDE8A
-$orange-100: #FEF1C7
+$orange-200: #FEE7C8
+$orange-100: #FFF7EB
 $orange-50: #FFFBEB
 
 // PEACH


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client/vendeur coach/rof/trainer

- Cas d'usage : les créneaux sont rangés par étape, en tant que rof je peux les créer, en tant que coach/formateur je peux les modifier : 
- bloc blanc => étape elearning / pas d'interaction
- bloc orange => étape avec des créneaux à planifier
- bloc bleu => étape sans créneaux à planifier
- si je rajoute des créneaux à planifier dans une étape bleu => orange
- si je rempli des créneaux à planifier dans une étape orange => bleu

- Comment tester ? :  
  - en tant que rof : 
    - je peux créer des créneaux à planifier dans une étape
    - je peux modifier des créneaux
  - en tant que coach/trainer : je peux modifier des créneaux  

_Si tu as lu cette description, pense a réagir avec un :eye:_
