### PR TITLE
COM-2852 display specific message when downloading template for remot…

### DIFF
--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -69,7 +69,12 @@ import QuestionnaireAnswersCell from '@components/courses/QuestionnaireAnswersCe
 import BiColorButton from '@components/BiColorButton';
 import Banner from '@components/Banner';
 import { SURVEY, OPEN_QUESTION, QUESTION_ANSWER, E_LEARNING } from '@data/constants';
-import { upperCaseFirstLetter, formatIdentity, formatQuantity } from '@helpers/utils';
+import {
+  upperCaseFirstLetter,
+  formatIdentity,
+  formatQuantity,
+  readAPIResponseWithTypeArrayBuffer,
+} from '@helpers/utils';
 import { formatDate, ascendingSort, getTotalDuration, getDuration, formatIntervalHourly } from '@helpers/date';
 import { downloadZip, downloadFile } from '@helpers/file';
 import { traineeFollowUpTableMixin } from '@mixins/traineeFollowUpTableMixin';
@@ -199,6 +204,8 @@ export default {
         downloadFile(pdf, 'emargement.pdf', 'application/octet-stream');
       } catch (e) {
         console.error(e);
+        const decodedRep = readAPIResponseWithTypeArrayBuffer(e);
+        if (decodedRep.statusCode === 404 && decodedRep.message) return NotifyNegative(decodedRep.message);
         NotifyNegative('Erreur lors du téléchargement de la feuille d\'émargement.');
       } finally {
         this.pdfLoading = false;


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof

- Cas d'usage : quand je telecharge une feuille d'emargement pour une formation distanciel, j'ai un message specifique

- Comment tester ? : telecharger une feuille d'emargementpour une formation distanciel --> message specifique
telecharger une feuille d'emargement pour une autre formation --> le telechargement se passe bien. 

_Si tu as lu cette description, pense a réagir avec un :eye:_
