### PR TITLE
COM-2858 - round inclTaxes amounts to pass validations

### DIFF
--- a/src/core/helpers/numbers.js
+++ b/src/core/helpers/numbers.js
@@ -2,7 +2,7 @@ const { BigNumber } = require('bignumber.js');
 
 exports.toString = a => BigNumber(a).toString();
 
-exports.toFixed = (a, decimalPlaces = 2) => parseFloat(BigNumber(a).toFixed(decimalPlaces));
+exports.toFixedToFloat = (a, decimalPlaces = 2) => parseFloat(BigNumber(a).toFixed(decimalPlaces));
 
 exports.multiply = (...nums) => nums.reduce((acc, n) => BigNumber(acc).multipliedBy(n).toString(), 1);
 

--- a/src/core/helpers/utils.js
+++ b/src/core/helpers/utils.js
@@ -3,7 +3,7 @@ import isObject from 'lodash/isObject';
 import get from 'lodash/get';
 import diacriticsMap from '@data/diacritics';
 import { descendingSort } from '@helpers/date';
-import { toFixed } from '@helpers/numbers';
+import { toFixedToFloat } from '@helpers/numbers';
 
 export const extend = (...sources) => {
   const extended = {};
@@ -77,7 +77,7 @@ export const roundFrenchPercentage = (number, digits = 2) => (number
 
 export const formatPrice = val => (val ? roundFrenchPrice(val) : roundFrenchPrice(0));
 
-export const formatStringToPrice = str => formatPrice(parseFloat(toFixed(str)));
+export const formatStringToPrice = str => formatPrice(toFixedToFloat(str));
 
 export const formatPriceWithSign = value => (value >= 0 ? `+${formatPrice(value)}` : formatPrice(value));
 

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -72,7 +72,7 @@ import { formatPrice, formatStringToPrice, getLastVersion, formatIdentity, forma
 import { strictPositiveNumber, minDate, maxDate, positiveNumber, fractionDigits } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
 import { getStartOfDay, getEndOfDay, formatDate } from '@helpers/date';
-import { divide, add, multiply, isEqualTo, toString, toFixed } from '@helpers/numbers';
+import { divide, add, multiply, isEqualTo, toString, toFixedToFloat } from '@helpers/numbers';
 import CreditNoteEditionModal from 'src/modules/client/components/customers/billing/CreditNoteEditionModal';
 import CreditNoteCreationModal from 'src/modules/client/components/customers/billing/CreditNoteCreationModal';
 
@@ -200,7 +200,7 @@ export default {
             },
             toString(0)
           );
-          this.newCreditNote.inclTaxesCustomer = toFixed(inclTaxesCustomerString);
+          this.newCreditNote.inclTaxesCustomer = toFixedToFloat(inclTaxesCustomerString);
         }
       },
     },
@@ -498,9 +498,9 @@ export default {
 
       return {
         exclTaxesCustomer,
-        inclTaxesCustomer: toFixed(inclTaxesCustomerString),
+        inclTaxesCustomer: toFixedToFloat(inclTaxesCustomerString),
         exclTaxesTpp,
-        inclTaxesTpp: toFixed(inclTaxesTppString),
+        inclTaxesTpp: toFixedToFloat(inclTaxesTppString),
       };
     },
     // Creation

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -498,9 +498,9 @@ export default {
 
       return {
         exclTaxesCustomer,
-        inclTaxesCustomer: parseFloat(inclTaxesCustomerString),
+        inclTaxesCustomer: toFixed(inclTaxesCustomerString),
         exclTaxesTpp,
-        inclTaxesTpp: parseFloat(inclTaxesTppString),
+        inclTaxesTpp: toFixed(inclTaxesTppString),
       };
     },
     // Creation


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin client

- Cas d'usage : je peux creer un avoir lié a des interventions pour un tiers-payeur (la validation bloquait la creation car le format de inclTaxesTpp et inclTaxesCustomer n'était pas bon)

- Comment tester ? :
   -  voir description api

_Si tu as lu cette description, pense a réagir avec un :eye:_
