### PR TITLE
COM-2837: move slots to plan section

### DIFF
--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -26,15 +26,6 @@
               </div>
             </div>
             <div v-if="!isElearningStep(step)" class="slots-container">
-              <div v-if="isStepToPlan(step) && !!get(courseSlotsByStepAndDate[step.key], SLOTS_TO_PLAN_KEY)"
-                class="to-plan-slot">
-                <div v-for="slot in Object.values(get(courseSlotsByStepAndDate[step.key], SLOTS_TO_PLAN_KEY)).flat()"
-                  :key="slot._id" @click="openEditionModal(slot)"
-                  :class="['row items-center q-ml-xl q-mb-md', canEdit && 'cursor-pointer hover-orange']">
-                  <div class="clickable-name text-orange-500 q-mr-md">créneau à planifier</div>
-                  <q-icon v-if="canEdit" name="edit" size="12px" color="copper-grey-500" />
-                </div>
-              </div>
               <div v-for="day in Object.entries(omit(courseSlotsByStepAndDate[step.key], SLOTS_TO_PLAN_KEY))"
                 :key="day" class="row q-ml-xl q-my-sm">
                 <div class="text-weight-bold q-mr-md">{{ day[0] }}</div>
@@ -51,6 +42,15 @@
                     </div>
                     <q-icon v-if="canEdit" name="edit" size="12px" color="copper-grey-500" />
                   </div>
+                </div>
+              </div>
+              <div v-if="isStepToPlan(step) && !!get(courseSlotsByStepAndDate[step.key], SLOTS_TO_PLAN_KEY)"
+                class="to-plan-slot">
+                <div v-for="slot in Object.values(get(courseSlotsByStepAndDate[step.key], SLOTS_TO_PLAN_KEY)).flat()"
+                  :key="slot._id" @click="openEditionModal(slot)"
+                  :class="['row items-center q-ml-xl q-mb-md', canEdit && 'cursor-pointer hover-orange']">
+                  <div class="clickable-name text-orange-500 q-mr-md">créneau à planifier</div>
+                  <q-icon v-if="canEdit" name="edit" size="12px" color="copper-grey-500" />
                 </div>
               </div>
               <div class="q-mt-sm" v-if="canEdit && isAdmin && isVendorInterface" align="right">


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : rof/admin/coach/trainer

- Cas d'usage : retour de Romain : les créneaux à planifier sont en dessous des créneaux déjà planifier dans une cellule d'étape

- Comment tester ? : ajouter un créneau à planifier à une étape => il s'affiche en dessous des créneaux déjà planifier dans l'étape

_Si tu as lu cette description, pense a réagir avec un :eye:_
