### PR TITLE
COM-2861 - add shouldPayHolidays checkbox

### DIFF
--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -28,10 +28,20 @@
       <div class="q-mb-xl">
         <p class="text-weight-bold">Contrats prestataires</p>
         <div class="row gutter-profile">
-          <ni-input caption="Taux horaire brut par défaut" :error="v$.company.rhConfig.grossHourlyRate.$error"
-            :error-message="nbrError('company.rhConfig.grossHourlyRate')" type="number"
-            v-model="company.rhConfig.grossHourlyRate" @focus="saveTmp('rhConfig.grossHourlyRate')" suffix="€"
-            @blur="updateCompany('rhConfig.grossHourlyRate')" />
+          <div class="col-xs-12 col-md-6">
+            <ni-input caption="Taux horaire brut par défaut" :error="v$.company.rhConfig.grossHourlyRate.$error"
+              :error-message="nbrError('company.rhConfig.grossHourlyRate')" type="number"
+              v-model="company.rhConfig.grossHourlyRate" @focus="saveTmp('rhConfig.grossHourlyRate')" suffix="€"
+              @blur="updateCompany('rhConfig.grossHourlyRate')" />
+          </div>
+          <div class="col-xs-12 col-md-6">
+              <q-checkbox v-model="company.rhConfig.shouldPayHolidays" label="Les jours fériés ne sont pas travaillés"
+                @update:model-value="updateCompany('rhConfig.shouldPayHolidays')" dense class="title" />
+              <div class="text">
+                Si vous cochez cette option, les jours fériés ne seront pas considérés comme des jours à travailler,
+                cela impactera les compteurs d'heures et la paie
+              </div>
+          </div>
         </div>
       </div>
       <div class="q-mb-xl">
@@ -530,3 +540,14 @@ export default {
   },
 };
 </script>
+
+<style lang="sass" scoped>
+.title
+  font-size: 16px
+  font-weight: bold
+  color: $copper-grey-900
+.text
+  font-size: 12px
+  padding-left: 32px
+  color: $copper-grey-600
+</style>

--- a/src/modules/client/pages/ni/config/RhConfig.vue
+++ b/src/modules/client/pages/ni/config/RhConfig.vue
@@ -28,12 +28,10 @@
       <div class="q-mb-xl">
         <p class="text-weight-bold">Contrats prestataires</p>
         <div class="row gutter-profile">
-          <div class="col-xs-12 col-md-6">
-            <ni-input caption="Taux horaire brut par défaut" :error="v$.company.rhConfig.grossHourlyRate.$error"
-              :error-message="nbrError('company.rhConfig.grossHourlyRate')" type="number"
-              v-model="company.rhConfig.grossHourlyRate" @focus="saveTmp('rhConfig.grossHourlyRate')" suffix="€"
-              @blur="updateCompany('rhConfig.grossHourlyRate')" />
-          </div>
+          <ni-input caption="Taux horaire brut par défaut" :error="v$.company.rhConfig.grossHourlyRate.$error"
+            :error-message="nbrError('company.rhConfig.grossHourlyRate')" type="number"
+            v-model="company.rhConfig.grossHourlyRate" @focus="saveTmp('rhConfig.grossHourlyRate')" suffix="€"
+            @blur="updateCompany('rhConfig.grossHourlyRate')" />
           <div class="col-xs-12 col-md-6">
               <q-checkbox v-model="company.rhConfig.shouldPayHolidays" label="Les jours fériés ne sont pas travaillés"
                 @update:model-value="updateCompany('rhConfig.shouldPayHolidays')" dense class="title" />


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client admin

- Cas d'usage : ETQ admin, je peux paramétrer la comptabilité des jours fériés dans les heures travaillées

- Comment tester ? :
   - lancer le script 
   - se connecter avec son compte 
   - sur la page `configuration RH` dans  l'onglet Contrats prestataires la checkbox les jours fériés ne sont pas travaillés` apparait cochée
   - la cocher puis la décocher et verifier que la modification s'effectue en bdd
   - creer une nouvelle structure
   - lui ajouter un administrateur
   - se connecter avec ce compte 
   - sur la page `configuration RH` dans  l'onglet Contrats prestataires la checkbox `les jours fériés ne sont pas travaillés` apparait décochée
   - la cocher puis la décocher et verifier que la modification s'effectue en  bdd

_Si tu as lu cette description, pense a réagir avec un :eye:_
