### PR TITLE
Com 2749

### DIFF
--- a/src/modules/client/components/customers/infos/FundingCreationModal.vue
+++ b/src/modules/client/components/customers/infos/FundingCreationModal.vue
@@ -33,10 +33,10 @@
         type="number" @blur="validations.amountTTC.$touch" :error="validations.amountTTC.$error" required-field
         @update:model-value="update($event, 'amountTTC')" :error-message="amountTtcErrorMessage" />
       <ni-input in-modal v-if="!isFixedFunding" :model-value="newFunding.careHours" @blur="validations.careHours.$touch"
-        caption="Nb. heures prises en charge" type="number" suffix="h" @update:model-value="update($event, 'careHours')"
-        :error="validations.careHours.$error" required-field :error-message="careHoursErrorMessage" />
+        caption="Nb. heures prises en charge par mois" type="number" suffix="h" :error="validations.careHours.$error"
+        @update:model-value="update($event, 'careHours')" required-field :error-message="careHoursErrorMessage" />
       <ni-input in-modal v-if="!isFixedFunding" :model-value="newFunding.customerParticipationRate"
-        caption="Taux de participation" type="number" suffix="%" required-field
+        caption="Taux de participation du bénéficiaire" type="number" suffix="%" required-field
         @blur="validations.customerParticipationRate.$touch" :error="validations.customerParticipationRate.$error"
         @update:model-value="update($event, 'customerParticipationRate')"
         :error-message="customerParticipationRateErrorMessage" />

--- a/src/modules/client/components/customers/infos/FundingDetailsModal.vue
+++ b/src/modules/client/components/customers/infos/FundingDetailsModal.vue
@@ -23,9 +23,7 @@ export default {
     'ni-modal': Modal,
     'ni-funding-grid-table': FundingGridTable,
   },
-  mixins: [
-    fundingMixin,
-  ],
+  mixins: [fundingMixin],
   emits: ['hide', 'update:model-value'],
   computed: {
     visibleColumns () {

--- a/src/modules/client/components/customers/infos/FundingEditionModal.vue
+++ b/src/modules/client/components/customers/infos/FundingEditionModal.vue
@@ -21,11 +21,11 @@
         type="number" @blur="validations.amountTTC.$touch" :error="validations.amountTTC.$error" required-field
         :error-message="amountTtcErrorMessage" @update:model-value="update($event, 'amountTTC')" />
       <ni-input in-modal v-if="!isFixedFunding" :model-value="editedFunding.careHours" required-field suffix="h"
-        caption="Nb. heures prises en charge" :error-message="careHoursErrorMessage" type="number"
+        caption="Nb. heures prises en charge par mois" :error-message="careHoursErrorMessage" type="number"
         :error="validations.careHours.$error" @blur="validations.careHours.$touch"
         @update:model-value="update($event, 'careHours')" />
       <ni-input in-modal v-if="!isFixedFunding" :model-value="editedFunding.customerParticipationRate" type="number"
-        caption="Taux de participation" :error-message="customerParticipationRateErrorMessage"
+        caption="Taux de participation du bénéficiaire" :error-message="customerParticipationRateErrorMessage"
         @blur="validations.customerParticipationRate.$touch" :error="validations.customerParticipationRate.$error"
         required-field suffix="%" @update:model-value="update($event, 'customerParticipationRate')" />
       <ni-option-group :model-value="editedFunding.careDays" :options="daysOptions" caption="Jours pris en charge"

--- a/src/modules/client/components/customers/infos/FundingHistoryModal.vue
+++ b/src/modules/client/components/customers/infos/FundingHistoryModal.vue
@@ -23,9 +23,7 @@ export default {
     'ni-modal': Modal,
     'ni-funding-grid-table': FundingGridTable,
   },
-  mixins: [
-    fundingMixin,
-  ],
+  mixins: [fundingMixin],
   emits: ['hide', 'update:model-value'],
   computed: {
     visibleColumns () {

--- a/src/modules/client/mixins/fundingMixin.js
+++ b/src/modules/client/mixins/fundingMixin.js
@@ -48,14 +48,14 @@ export const fundingMixin = {
         { name: 'unitTTCRate', label: 'Prix unitaire TTC', align: 'left', format: formatPrice, field: 'unitTTCRate' },
         {
           name: 'careHours',
-          label: 'Nb. heures de prise en charge',
+          label: 'Nb. heures de prise en charge par mois',
           align: 'left',
           format: formatHours,
           field: 'careHours',
         },
         {
           name: 'customerParticipationRate',
-          label: 'Tx. participation bénéficiaire',
+          label: 'Tx. participation du bénéficiaire',
           align: 'left',
           format: value => (value ? `${value}%` : '0%'),
           field: 'customerParticipationRate',

--- a/src/modules/client/mixins/fundingMixin.js
+++ b/src/modules/client/mixins/fundingMixin.js
@@ -48,7 +48,7 @@ export const fundingMixin = {
         { name: 'unitTTCRate', label: 'Prix unitaire TTC', align: 'left', format: formatPrice, field: 'unitTTCRate' },
         {
           name: 'careHours',
-          label: 'Nb. heures de prise en charge par mois',
+          label: 'Nb. heures prises en charge par mois',
           align: 'left',
           format: formatHours,
           field: 'careHours',

--- a/src/modules/client/pages/ni/billing/ClientsBalances.vue
+++ b/src/modules/client/pages/ni/billing/ClientsBalances.vue
@@ -279,6 +279,7 @@ export default {
           field: row => (row.thirdPartyPayer ? '' : row.participationRate),
           format: (value, row) => (row.thirdPartyPayer ? '' : roundFrenchPercentage(value)),
           sortable: true,
+          style: 'width: 15%',
         },
         { name: 'billed', label: 'Facturé TTC', align: 'center', field: 'billed', format: val => formatPrice(val) },
         { name: 'paid', label: 'Payé TTC', align: 'center', field: 'paid', format: val => formatPrice(val) },

--- a/src/modules/client/pages/ni/billing/ClientsBalances.vue
+++ b/src/modules/client/pages/ni/billing/ClientsBalances.vue
@@ -188,7 +188,7 @@ export default {
       const csvData = [[
         'Client',
         'Bénéficiaire',
-        'Taux de participation',
+        'Taux de participation du bénéficiaire',
         'Facturé TTC',
         'Payé TTC',
         'Solde',
@@ -274,7 +274,7 @@ export default {
         },
         {
           name: 'participationRate',
-          label: 'Taux de participation',
+          label: 'Taux de participation du bénéficiaire',
           align: 'center',
           field: row => (row.thirdPartyPayer ? '' : row.participationRate),
           format: (value, row) => (row.thirdPartyPayer ? '' : roundFrenchPercentage(value)),


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach / admin client

- Cas d'usage : Messages plus explicites sur les modales de creation, d'édition, de détails et d'historique de financement + sur la page balances clients

- Comment tester ? :
- verifier que les messages sont les bons (`Taux de participation du bénéficiaire` et `Nb. heures prises en charge par mois`) dans la modale 
    - de creation d'un financement 
    - d'édition d'un financement 
    - de détail d'un financement
    - d'historique d'un financemennt
   
- sur la page balances clients vérifier que la colonne a bien été modifiée en `Taux de participation du bénéficiaire` dans le tableau et dans le fichier csv

_Si tu as lu cette description, pense a réagir avec un :eye:_
