### PR TITLE
COM-2848: remove dates on slot

### DIFF
--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -66,7 +66,8 @@
     <slot-edition-modal v-model="editionModal" :edited-course-slot="editedCourseSlot" :step-types="stepTypes"
       :validations="v$.editedCourseSlot" @hide="resetEditionModal" :loading="modalLoading" @delete="deleteCourseSlot"
       @submit="updateCourseSlot" :link-error-message="linkErrorMessage" @update="setCourseSlot" :is-admin="isAdmin"
-      :is-vendor-interface="isVendorInterface" :is-only-slot="isOnlySlot" />
+      :is-vendor-interface="isVendorInterface" :is-only-slot="isOnlySlot" :is-planned-slot="isPlannedSlot"
+      @remove-date="removeDates" />
   </div>
 </template>
 
@@ -123,6 +124,7 @@ export default {
       linkErrorMessage: 'Le lien doit commencer par http:// ou https://',
       SLOTS_TO_PLAN_KEY: 'toPlan',
       isOnlySlot: false,
+      isPlannedSlot: false,
     };
   },
   validations () {
@@ -237,12 +239,14 @@ export default {
       };
       if (slot.address) this.editedCourseSlot.address = { ...slot.address };
       this.isOnlySlot = this.setIsOnlySlot(slot.step);
+      this.isPlannedSlot = has(slot, 'startDate');
       this.editionModal = true;
     },
     resetEditionModal () {
       this.editedCourseSlot = {};
       this.v$.editedCourseSlot.$reset();
       this.isOnlySlot = false;
+      this.isPlannedSlot = false;
     },
     formatEditionPayload (courseSlot) {
       const stepType = this.stepTypes.find(item => item.value === courseSlot.step).type;
@@ -304,6 +308,20 @@ export default {
         if (e.data.statusCode === 409) return NotifyWarning('Créneau émargé : impossible de le supprimer.');
         if (e.data.statusCode === 403) return NotifyWarning('Seul créneau de l\'étape : impossible de le supprimer.');
         NotifyNegative('Erreur lors de la suppression du créneau.');
+      } finally {
+        this.modalLoading = false;
+      }
+    },
+    async removeDates (slotId) {
+      try {
+        this.modalLoading = true;
+        await CourseSlots.update(slotId, { startDate: '', endDate: '' });
+        this.$emit('refresh');
+        NotifyPositive('Dates supprimées.');
+        this.editionModal = false;
+      } catch (e) {
+        console.error(e);
+        NotifyNegative('Erreur lors de la suppression des dates.');
       } finally {
         this.modalLoading = false;
       }

--- a/src/core/components/courses/SlotEditionModal.vue
+++ b/src/core/components/courses/SlotEditionModal.vue
@@ -7,6 +7,10 @@
       <ni-button v-if="isAdmin && isVendorInterface" icon="delete" @click="validateDeletion(editedCourseSlot._id)"
         :disable="isOnlySlot" />
     </div>
+    <div class="modal-icon q-mt-sm">
+      <ni-button class="bg-copper-grey-100" color="copper-grey-800" v-if="isPlannedSlot" label="Supprimer la date"
+      @click="validateDatesDeletion(editedCourseSlot)" />
+    </div>
     <ni-datetime-range caption="Dates et heures" :model-value="editedCourseSlot.dates" disable-end-date
       :error="validations.dates.$error" @blur="validations.dates.$touch" @update:model-value="update($event, 'dates')"
       required-field />
@@ -30,6 +34,7 @@ import Input from '@components/form/Input';
 import DateTimeRange from '@components/form/DatetimeRange';
 import SearchAddress from '@components/form/SearchAddress';
 import { NotifyPositive } from '@components/popup/notify';
+import { formatIntervalHourly, formatDate } from '@helpers/date';
 import { ON_SITE, REMOTE } from '@data/constants';
 
 export default {
@@ -44,6 +49,7 @@ export default {
     isAdmin: { type: Boolean, default: false },
     isVendorInterface: { type: Boolean, default: false },
     isOnlySlot: { type: Boolean, default: false },
+    isPlannedSlot: { type: Boolean, default: false },
   },
   components: {
     'ni-button': Button,
@@ -52,7 +58,7 @@ export default {
     'ni-modal': Modal,
     'ni-input': Input,
   },
-  emits: ['hide', 'update:model-value', 'submit', 'delete', 'update'],
+  emits: ['hide', 'update:model-value', 'submit', 'delete', 'update', 'remove-date'],
   data () {
     return {
       ON_SITE,
@@ -60,6 +66,17 @@ export default {
     };
   },
   methods: {
+    validateDatesDeletion (slot) {
+      this.$q.dialog({
+        title: 'Supprimer une date',
+        message: `Êtes-vous sûr(e) de vouloir supprimer la date du  ${formatDate(slot.dates.startDate)}
+          (${formatIntervalHourly(slot.dates)}) ?<br /><br />Le créneau repassera en "à planifier"`,
+        html: true,
+        ok: 'Oui',
+        cancel: 'Non',
+      }).onOk(() => this.removeDates(slot._id))
+        .onCancel(() => NotifyPositive('Suppression annulée.'));
+    },
     validateDeletion (slotId) {
       this.$q.dialog({
         title: 'Confirmation',
@@ -86,6 +103,9 @@ export default {
     },
     getType (step) {
       return step ? this.stepTypes.find(item => item.value === step).type : '';
+    },
+    removeDates (slotId) {
+      this.$emit('remove-date', slotId);
     },
   },
 };


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client rof/admin/coach

- Cas d'usage : je peux supprimer la date d'un créneau

- Comment tester ? :
 - créer un créneau à planifier
 - ouvrir la modale d'édition => pas de bouton de suppression
 - lui ajouter une date et une adresse
 - rouvrir la modale d'édition => bouton de suppression
 - supprimer la date : 
   - le créneau repasse en créneau à planifier  + l'adresse est supprimée
   - en base il y a un historique de suppression avec les heures du créneau supprimées et l'adresse supprimée

_Si tu as lu cette description, pense a réagir avec un :eye:_