### PR TITLE
COM-2812: add companies as possible payers

### DIFF
--- a/src/core/components/courses/ProfileBilling.vue
+++ b/src/core/components/courses/ProfileBilling.vue
@@ -137,6 +137,7 @@ import { strictPositiveNumber, integerNumber, minDate } from '@helpers/vuelidate
 import { formatAndSortOptions, formatPrice } from '@helpers/utils';
 import { formatDate, descendingSortArray } from '@helpers/date';
 import { downloadFile } from '@helpers/file';
+import Companies from '@api/Companies';
 import CourseFundingOrganisations from '@api/CourseFundingOrganisations';
 import CourseBills from '@api/CourseBills';
 import CourseBillingItems from '@api/CourseBillingItems';
@@ -265,14 +266,12 @@ export default {
       return { price, count };
     };
 
-    const refreshCourseFundingOrganisations = async () => {
+    const refreshPayers = async () => {
       try {
         const organisations = await CourseFundingOrganisations.list();
+        const companies = await Companies.list();
         const formattedOrganisationList = formatAndSortOptions(organisations, 'name');
-        const formattedCompanyList = formatAndSortOptions(
-          [{ _id: course.value.company._id, name: course.value.company.name }],
-          'name'
-        );
+        const formattedCompanyList = formatAndSortOptions(companies, 'name');
         payerList.value =
           [
             ...formattedOrganisationList.map(payer => ({ ...payer, type: FUNDING_ORGANISATION })),
@@ -632,7 +631,7 @@ export default {
 
     const created = async () => {
       refreshCourseBills();
-      refreshCourseFundingOrganisations();
+      refreshPayers();
       refreshBillingItems();
     };
 
@@ -677,7 +676,7 @@ export default {
       editedBillingPurchaseErrorMessages,
       canAddBill,
       // Methods
-      refreshCourseFundingOrganisations,
+      refreshPayers,
       resetBillCreationModal,
       resetEditedBill,
       resetMainFeeEditionModal,


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage : sur le profile d'une structure, je peux voir les factures pour lesquelles la structure est le payeur

- Comment tester ? :
 - facturer une formation d'une structure A avec une structure B en payeur
 - la facture apparait sur le profile de la structure A et de la structure B 

_Si tu as lu cette description, pense a réagir avec un :eye:_

