### PR TITLE
COM-2863 - fix q-checkbox multiple selection

### DIFF
--- a/src/modules/client/pages/ni/billing/ClientsBalances.vue
+++ b/src/modules/client/pages/ni/billing/ClientsBalances.vue
@@ -16,7 +16,7 @@
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props" :style="col.style">{{ col.label }}</q-th>
           <q-th auto-width>
-            <q-checkbox @update:model-value="selectRows(props.selected)" v-model="props.selected" dense
+            <q-checkbox @update:model-value="selectRows(selected)" :model-value="selected.length > 0" dense
               :disable="balancesOption === 2" indeterminate-value="some" />
           </q-th>
         </q-tr>
@@ -141,7 +141,7 @@ export default {
     const resetSelected = () => { selected.value = []; };
 
     const selectRows = (oldValue) => {
-      if (oldValue) selected.value = [];
+      if (oldValue.length) selected.value = [];
       else selected.value = balances.value.filter(bl => bl.toPay > 0);
     };
 

--- a/src/modules/client/pages/ni/billing/ClientsBalances.vue
+++ b/src/modules/client/pages/ni/billing/ClientsBalances.vue
@@ -16,7 +16,7 @@
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props" :style="col.style">{{ col.label }}</q-th>
           <q-th auto-width>
-            <q-checkbox @update:model-value="selectRows(selected)" :model-value="selected.length > 0" dense
+            <q-checkbox @update:model-value="selectRows" :model-value="!!selected.length" dense
               :disable="balancesOption === 2" indeterminate-value="some" />
           </q-th>
         </q-tr>
@@ -140,8 +140,8 @@ export default {
 
     const resetSelected = () => { selected.value = []; };
 
-    const selectRows = (oldValue) => {
-      if (oldValue.length) selected.value = [];
+    const selectRows = () => {
+      if (selected.value.length) selected.value = [];
       else selected.value = balances.value.filter(bl => bl.toPay > 0);
     };
 


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin client

- Cas d'usage : Bug -  sur la page balances clients, lorsque l'on sélectionne la checkbox dans le header du tableau, seuls les beneficiaires 'prelevables' sont selectionnés

- Comment tester ? :
   - dumper la prod en local
   - se placer sur dev 
   - sur la page balances clients, sélectionner la checkbox dans le header du tableau (sélection multiple)
   - prelever les bénéficiaires --> ko
   - se placer sur cette branche 
   - sur la page balances clients, sélectionner la checkbox dans le header du tableau (sélection multiple)
   - prelever les bénéficiaires --> ok 
   - verifier que les bénéficiaires ont bien ete prélevés (sur la fiche beneficiaire --> onglet facturation)

_Si tu as lu cette description, pense a réagir avec un :eye:_
