### PR TITLE
COM-2843: fix wrong alignment on table

### DIFF
--- a/src/modules/client/pages/ni/courses/BillingProfile.vue
+++ b/src/modules/client/pages/ni/courses/BillingProfile.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page padding class="client-background">
-    <ni-title-header title="Facture" />
+    <ni-title-header title="Factures" />
     <div v-if="loggedUser">
       <profile-billing />
     </div>

--- a/src/modules/vendor/components/companies/ProfileBilling.vue
+++ b/src/modules/vendor/components/companies/ProfileBilling.vue
@@ -88,6 +88,7 @@ import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
+import { Screen } from 'quasar';
 import { ref, computed, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
@@ -353,10 +354,10 @@ export default {
     const getProgramName = (course) => {
       const programName = get(course, 'subProgram.program.name');
       const misc = get(course, 'misc');
-      const screenWidth = window.innerWidth;
       const length = programName.length + misc.length;
-      // table width : 60 % of screen width ; program name column width : 30 % of table width ; letter width : 6px
-      const maxLength = ((30 / 100) * (screenWidth * (60 / 100))) / 6;
+      const tableSize = Screen.width >= 1024 ? Screen.width * (70 / 100) : Screen.width * (90 / 100);
+      // table width : 70(or 90)% of screen width ; program name column width : 30% of table width ; letter width : 6px
+      const maxLength = ((30 / 100) * tableSize) / 6;
       if (length > maxLength) {
         const limit = maxLength - misc.length - 3;
         return `${programName.slice(0, limit)}...`;

--- a/src/modules/vendor/components/companies/ProfileBilling.vue
+++ b/src/modules/vendor/components/companies/ProfileBilling.vue
@@ -355,6 +355,7 @@ export default {
       const misc = get(course, 'misc');
       const screenWidth = window.innerWidth;
       const length = programName.length + misc.length;
+      // table width : 60 % of screen width ; program name column width : 30 % of table width ; letter width : 6px
       const maxLength = ((30 / 100) * (screenWidth * (60 / 100))) / 6;
       if (length > maxLength) {
         const limit = maxLength - misc.length - 3;

--- a/src/modules/vendor/components/companies/ProfileBilling.vue
+++ b/src/modules/vendor/components/companies/ProfileBilling.vue
@@ -11,7 +11,7 @@
                 {{ col.value }}
               </div>
               <div :class="getCourseNameClass(get(props.row, 'course'))" @click="goToCourse(get(props.row, 'course'))">
-                <div class="program ellipsis">{{ `${get(props.row, 'course.subProgram.program.name')}` }}&nbsp;</div>
+                <div class="program">{{ `${getProgramName(get(props.row, 'course'))}` }}&nbsp;</div>
                 <div v-if="get(props.row, 'course.misc')" class="misc">- {{ get(props.row, 'course.misc') }}</div>
               </div>
               <div class="row items-center" v-if="props.row.courseCreditNote">
@@ -350,6 +350,19 @@ export default {
         : 'Mes factures';
     };
 
+    const getProgramName = (course) => {
+      const programName = get(course, 'subProgram.program.name');
+      const misc = get(course, 'misc');
+      const screenWidth = window.innerWidth;
+      const length = programName.length + misc.length;
+      const maxLength = ((30 / 100) * (screenWidth * (60 / 100))) / 6;
+      if (length > maxLength) {
+        const limit = maxLength - misc.length - 3;
+        return `${programName.slice(0, limit)}...`;
+      }
+      return programName;
+    };
+
     watch(company, async () => { if (!courseBills.value.length && company.value) refreshCourseBills(); });
 
     const created = async () => {
@@ -395,6 +408,7 @@ export default {
       goToCourse,
       getCourseNameClass,
       getTableName,
+      getProgramName,
     };
   },
 };
@@ -405,9 +419,10 @@ export default {
   @media screen and (max-width: 767px)
     font-size: 9px
 .program
-  max-width: fit-content
   flex: 1
   color: $copper-grey-600
+  height: 1.5em
+  overflow: hidden
 .misc
   width: max-content
   color: $copper-grey-600


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client rof/admin

- Cas d'usage : les règlements sont bien alignés dans le tableau des factures + rajout d'un s au titre de la page côté client

le bug venait de l’utilisation de white-space:no wrap dans la classe ellipsis qui change l’espacement pour une raison que j’ignore. Or cette props est obligatoire pour que l’ellipsis se fasse en css du coup pour contourner le problème j’ai dû essayer de reproduire l’ellipsis en JS plutôt qu’en CSS

- Comment tester ? :
  - tableau des factures (onglet facturation du menu formation côté client / onglet facturation de la fiche structure côté vendeur : 
  - côté client : le titre de la page est Facture**s**
  - côté client et vendeur lorsque j'ajoute un règlement, le montant de celui-ci est aligné avec la colonne réglé/crédité (tester pour différentes taille d'écran, bien recharger la page à chaque changement de taille)

_Si tu as lu cette description, pense a réagir avec un :eye:_
