### PR TITLE
COM-2834 - use formatStringToPrice

### DIFF
--- a/src/modules/client/pages/ni/billing/TppBillSlips.vue
+++ b/src/modules/client/pages/ni/billing/TppBillSlips.vue
@@ -27,7 +27,7 @@ import BillSlip from '@api/BillSlips';
 import SimpleTable from '@components/table/SimpleTable';
 import TitleHeader from '@components/TitleHeader';
 import { NotifyNegative, NotifyPositive } from '@components/popup/notify';
-import { formatPrice } from '@helpers/utils';
+import { formatStringToPrice } from '@helpers/utils';
 import moment from '@helpers/moment';
 import { downloadDocx } from '@helpers/file';
 
@@ -65,7 +65,7 @@ export default {
           label: 'Montant TTC',
           align: 'left',
           field: 'netInclTaxes',
-          format: value => formatPrice(value),
+          format: value => formatStringToPrice(value),
         },
         { name: 'document', label: '', align: 'left', field: '_id' },
       ],


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client admin 

- Cas d'usage :
   - Je peux télécharger les bordereaux tiers-payeur, les montants affichés sont justes et tiennent compte des remises.  (avant on ne prenait pas en compte les remises, il y avait donc un écart entre le montant total figurant sur le bordereau correspond au montant affiché dans la colonne `Montant TTC` de la page bordereau tiers-payeur )
    - Lorsque je telecharge un avoir sur des interventions, les montants sont justes (`total TTC - total HT = tva`) 

- Comment tester ? :
   - voir sur la PR back 

_Si tu as lu cette description, pense a réagir avec un :eye:_
