### PR TITLE
Com 2855 discount

### DIFF
--- a/src/core/components/table/EditableTd.vue
+++ b/src/core/components/table/EditableTd.vue
@@ -5,8 +5,7 @@
     </div>
     <q-input v-show="props[editionBooleanName]" :ref="refName" :model-value="props[editedField]"
       @update:model-value="setEdition" type="number" @blur="disableEdition" bg-color="white" dense
-      @keyup.esc="disableEdition" no-parent-field @keyup.enter="disableEdition" borderless :suffix="suffix"
-      :error="error" :error-message="errorMessage" />
+      @keyup.esc="disableEdition" no-parent-field @keyup.enter="disableEdition" borderless :suffix="suffix" />
   </div>
 </template>
 
@@ -20,8 +19,6 @@ export default {
     refName: { type: String, default: '' },
     value: { type: String, default: '' },
     suffix: { type: String, default: '' },
-    error: { type: Boolean, default: false },
-    errorMessage: { type: String, default: '' },
   },
   emits: ['disable', 'change', 'click'],
   methods: {


### PR DESCRIPTION
Fait en pp avec Manon : besoin d'une seule validation

- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin

- Cas d'usage : Je ne peux pas mettre une remise avec + de deux chiffres apres la virgule

- Comment tester ? : Si on met + de deux chiffres apres la virgule, il est tronqué. 
On n'a pas reussi a faire la validation avec Manon et vu qu'on y avait deja passé pas mal de temps on est parti sur ce fonctionnement

_Si tu as lu cette description, pense a réagir avec un :eye:_
