### PR TITLE
Com 2871

### DIFF
--- a/src/core/components/form/OptionGroup.vue
+++ b/src/core/components/form/OptionGroup.vue
@@ -7,7 +7,7 @@
       </div>
       <q-field dense borderless :error="error" :error-message="errorMessage" class="col-12">
         <q-option-group :model-value="modelValue" :options="options" :readonly="readOnly" :type="type" :inline="inline"
-          :disable="disable" @update:model-value="update" dense />
+          :disable="disable" @update:model-value="update" dense class="q-px-sm" />
       </q-field>
     </div>
   </div>

--- a/src/modules/client/components/planning/EventCancellationModal.vue
+++ b/src/modules/client/components/planning/EventCancellationModal.vue
@@ -1,7 +1,10 @@
 <template>
   <q-dialog :model-value="modelValue" @hide="hide" @update:model-value="$emit('update:model-value')">
     <div class="modal-container-sm modal-padding in-modal">
-      <div class="title q-mb-md">Annuler l'intervention</div>
+      <div class="row justify-between">
+        <div class="title q-mb-md">Annuler l'intervention</div>
+        <q-icon class="cursor-pointer" name="close" size="1.5rem" @close="resetForm" v-close-popup />
+      </div>
       <ni-option-group caption="Qui est à l'origine de l'annulation ?"
         :model-value="editedEvent.cancel.reason" type="radio" :options="cancellationReasons" required-field
         color="copper-500" @update:model-value="updateEventReason($event)" />
@@ -12,7 +15,7 @@
         @update:model-value="updateEventMisc($event)" @blur="validations.misc.$touch"
         :error="validations.misc.$error" />
       <div class="row justify-end q-mb-md">
-        <ni-button label="RETOUR" @click="hide" />
+        <ni-button label="RETOUR" @click="resetForm" />
         <ni-button label="ANNULER L'INTERVENTION" @click="canCancelEvent" />
       </div>
     </div>
@@ -20,10 +23,9 @@
 </template>
 <script>
 
-import get from 'lodash/get';
 import { ref } from 'vue';
 import { useQuasar } from 'quasar';
-import { CANCELLATION_REASONS, CUSTOMER_INITIATIVE, CANCELLATION_OPTIONS } from '@data/constants';
+import { CANCELLATION_REASONS, CANCELLATION_OPTIONS } from '@data/constants';
 import { formatDate, formatHoursWithMinutes } from '@helpers/date';
 import { NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import Button from '@components/Button';
@@ -55,12 +57,19 @@ export default {
     const $q = useQuasar();
     const cancellationReasons = ref(CANCELLATION_REASONS);
     const cancellationOptions = ref(CANCELLATION_OPTIONS);
-    const reason = get(props.editedEvent, 'cancel.reason') || CUSTOMER_INITIATIVE;
-    const condition = get(props.editedEvent, 'cancel.condition');
 
     const hide = () => { emit('hide'); };
+
+    const resetForm = () => {
+      hide();
+      emit('update-event-reason', '');
+      emit('update-event-condition', '');
+    };
+
     const updateEventMisc = (value) => { emit('update-event-misc', value); };
+
     const updateEventReason = (value) => { emit('update-event-reason', value); };
+
     const updateEventCondition = (value) => { emit('update-event-condition', value); };
 
     const formatDateAndHours = (startDate, endDate) => {
@@ -86,11 +95,12 @@ export default {
     };
 
     return {
+      // Data
       cancellationReasons,
       cancellationOptions,
-      reason,
-      condition,
+      // Methods
       hide,
+      resetForm,
       updateEventMisc,
       updateEventReason,
       updateEventCondition,

--- a/src/modules/client/components/planning/EventCancellationModal.vue
+++ b/src/modules/client/components/planning/EventCancellationModal.vue
@@ -1,34 +1,85 @@
 <template>
   <q-dialog :model-value="modelValue" @hide="hide" @update:model-value="$emit('update:model-value')">
-    <div class="modal-container-md modal-padding">
+    <div class="modal-container-sm modal-padding in-modal">
       <div class="title q-mb-md">Annuler l'intervention</div>
+      <ni-option-group caption="Qui est à l'origine de l'annulation ?"
+        :model-value="editedEvent.cancel.reason" type="radio" :options="cancellationReasons" required-field
+        color="copper-500" @update:model-value="updateEventReason($event)" />
+      <ni-option-group caption="Quelles sont les conditions d'annulation ?"
+        :model-value="editedEvent.cancel.condition" type="radio" :options="cancellationOptions" required-field
+        color="copper-500" @update:model-value="updateEventCondition($event)" />
+      <ni-input in-modal type="textarea" :model-value="editedEvent.misc" caption="Notes" required-field last
+        @update:model-value="updateEventMisc($event)" @blur="validations.misc.$touch"
+        :error="validations.misc.$error" />
       <div class="row justify-end q-mb-md">
         <ni-button label="RETOUR" @click="hide" />
-        <ni-button label="ANNULER L'INTERVENTION" @click="() => {}" />
+        <ni-button label="ANNULER L'INTERVENTION" @click="validateCancellation" />
       </div>
     </div>
   </q-dialog>
 </template>
-
 <script>
+
+import get from 'lodash/get';
+import { ref } from 'vue';
 import Button from '@components/Button';
 import Input from '@components/form/Input';
+import { CANCELLATION_REASONS, CUSTOMER_INITIATIVE, CANCELLATION_OPTIONS } from '@data/constants';
+import { NotifyPositive } from '@components/popup/notify';
+import OptionGroup from '../../../../core/components/form/OptionGroup';
 
 export default {
   name: 'EventCancellationModal',
   components: {
     'ni-button': Button,
     'ni-input': Input,
+    'ni-option-group': OptionGroup,
   },
   props: {
     modelValue: { type: Boolean, default: false },
     editedEvent: { type: Object, default: () => ({}) },
+    validations: { type: Object, default: () => ({}) },
   },
-  emits: ['hide', 'update:model-value'],
+  emits: [
+    'hide',
+    'update:model-value',
+    'update-event-misc',
+    'update-event-reason',
+    'update-event-condition',
+    'update-event',
+  ],
+  methods: {
+    validateCancellation () {
+      this.$q.dialog({
+        title: 'Confirmation',
+        message: 'Êtes-vous sûr(e) de vouloir annuler cette intervention ?',
+        ok: true,
+        cancel: 'Annuler',
+      }).onOk(() => NotifyPositive('Evenement annulé'))
+        .onCancel(() => NotifyPositive('Annulation annulée.'));
+    },
+  },
   setup (props, { emit }) {
-    const hide = () => { emit('hide'); };
+    const cancellationReasons = ref(CANCELLATION_REASONS);
+    const cancellationOptions = ref(CANCELLATION_OPTIONS);
+    const reason = get(props.editedEvent, 'cancel.reason') || CUSTOMER_INITIATIVE;
+    const condition = get(props.editedEvent, 'cancel.condition');
 
-    return { hide };
+    const hide = () => { emit('hide'); };
+    const updateEventMisc = (value) => { emit('update-event-misc', value); };
+    const updateEventReason = (value) => { emit('update-event-reason', value); };
+    const updateEventCondition = (value) => { emit('update-event-condition', value); };
+
+    return {
+      cancellationReasons,
+      cancellationOptions,
+      reason,
+      condition,
+      hide,
+      updateEventMisc,
+      updateEventReason,
+      updateEventCondition,
+    };
   },
 };
 </script>

--- a/src/modules/client/components/planning/EventCancellationModal.vue
+++ b/src/modules/client/components/planning/EventCancellationModal.vue
@@ -13,7 +13,7 @@
         :error="validations.misc.$error" />
       <div class="row justify-end q-mb-md">
         <ni-button label="RETOUR" @click="hide" />
-        <ni-button label="ANNULER L'INTERVENTION" @click="validateCancellation" />
+        <ni-button label="ANNULER L'INTERVENTION" @click="canCancelEvent" />
       </div>
     </div>
   </q-dialog>
@@ -22,11 +22,12 @@
 
 import get from 'lodash/get';
 import { ref } from 'vue';
+import { useQuasar } from 'quasar';
+import { CANCELLATION_REASONS, CUSTOMER_INITIATIVE, CANCELLATION_OPTIONS } from '@data/constants';
+import { NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import Button from '@components/Button';
 import Input from '@components/form/Input';
-import { CANCELLATION_REASONS, CUSTOMER_INITIATIVE, CANCELLATION_OPTIONS } from '@data/constants';
-import { NotifyPositive } from '@components/popup/notify';
-import OptionGroup from '../../../../core/components/form/OptionGroup';
+import OptionGroup from '@components/form/OptionGroup';
 
 export default {
   name: 'EventCancellationModal',
@@ -46,20 +47,10 @@ export default {
     'update-event-misc',
     'update-event-reason',
     'update-event-condition',
-    'update-event',
+    'cancel-event',
   ],
-  methods: {
-    validateCancellation () {
-      this.$q.dialog({
-        title: 'Confirmation',
-        message: 'Êtes-vous sûr(e) de vouloir annuler cette intervention ?',
-        ok: true,
-        cancel: 'Annuler',
-      }).onOk(() => NotifyPositive('Evenement annulé'))
-        .onCancel(() => NotifyPositive('Annulation annulée.'));
-    },
-  },
   setup (props, { emit }) {
+    const $q = useQuasar();
     const cancellationReasons = ref(CANCELLATION_REASONS);
     const cancellationOptions = ref(CANCELLATION_OPTIONS);
     const reason = get(props.editedEvent, 'cancel.reason') || CUSTOMER_INITIATIVE;
@@ -70,6 +61,21 @@ export default {
     const updateEventReason = (value) => { emit('update-event-reason', value); };
     const updateEventCondition = (value) => { emit('update-event-condition', value); };
 
+    const cancelEvent = () => { emit('cancel-event'); };
+
+    const canCancelEvent = () => {
+      props.validations.$touch();
+      if (props.validations.$error) return NotifyWarning('Champ(s) invalide(s)');
+
+      $q.dialog({
+        title: 'Confirmation',
+        message: 'Êtes-vous sûr(e) de vouloir annuler l\'intervention  ?',
+        ok: true,
+        cancel: 'Annuler',
+      }).onOk(() => cancelEvent())
+        .onCancel(() => NotifyPositive('Annulation annulée.'));
+    };
+
     return {
       cancellationReasons,
       cancellationOptions,
@@ -79,6 +85,8 @@ export default {
       updateEventMisc,
       updateEventReason,
       updateEventCondition,
+      canCancelEvent,
+      cancelEvent,
     };
   },
 };

--- a/src/modules/client/components/planning/EventCancellationModal.vue
+++ b/src/modules/client/components/planning/EventCancellationModal.vue
@@ -24,6 +24,7 @@ import get from 'lodash/get';
 import { ref } from 'vue';
 import { useQuasar } from 'quasar';
 import { CANCELLATION_REASONS, CUSTOMER_INITIATIVE, CANCELLATION_OPTIONS } from '@data/constants';
+import { formatDate, formatHoursWithMinutes } from '@helpers/date';
 import { NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import Button from '@components/Button';
 import Input from '@components/form/Input';
@@ -40,6 +41,7 @@ export default {
     modelValue: { type: Boolean, default: false },
     editedEvent: { type: Object, default: () => ({}) },
     validations: { type: Object, default: () => ({}) },
+    customerName: { type: String, default: '' },
   },
   emits: [
     'hide',
@@ -61,6 +63,11 @@ export default {
     const updateEventReason = (value) => { emit('update-event-reason', value); };
     const updateEventCondition = (value) => { emit('update-event-condition', value); };
 
+    const formatDateAndHours = (startDate, endDate) => {
+      const date = formatDate(startDate);
+      return `${date} (${formatHoursWithMinutes(startDate)} - ${formatHoursWithMinutes(endDate)})`;
+    };
+
     const cancelEvent = () => { emit('cancel-event'); };
 
     const canCancelEvent = () => {
@@ -69,7 +76,9 @@ export default {
 
       $q.dialog({
         title: 'Confirmation',
-        message: 'Êtes-vous sûr(e) de vouloir annuler l\'intervention  ?',
+        message: `Êtes-vous sûr(e) de vouloir annuler l'intervention du
+          ${formatDateAndHours(props.editedEvent.dates.startDate, props.editedEvent.dates.endDate)}
+          chez ${props.customerName}?`,
         ok: true,
         cancel: 'Annuler',
       }).onOk(() => cancelEvent())

--- a/src/modules/client/components/planning/EventCancellationModal.vue
+++ b/src/modules/client/components/planning/EventCancellationModal.vue
@@ -7,10 +7,10 @@
       </div>
       <ni-option-group caption="Qui est à l'origine de l'annulation ?"
         :model-value="editedEvent.cancel.reason" type="radio" :options="cancellationReasons" required-field
-        color="copper-500" @update:model-value="updateEventReason($event)" />
+        color="copper-500" @update:model-value="updateCancellationReason($event)" />
       <ni-option-group caption="Quelles sont les conditions d'annulation ?"
         :model-value="editedEvent.cancel.condition" type="radio" :options="cancellationOptions" required-field
-        color="copper-500" @update:model-value="updateEventCondition($event)" />
+        color="copper-500" @update:model-value="updateCancellationCondition($event)" />
       <ni-input in-modal type="textarea" :model-value="editedEvent.misc" caption="Notes" required-field last
         @update:model-value="updateEventMisc($event)" @blur="validations.misc.$touch"
         :error="validations.misc.$error" />
@@ -49,8 +49,8 @@ export default {
     'hide',
     'update:model-value',
     'update-event-misc',
-    'update-event-reason',
-    'update-event-condition',
+    'update-cancellation-reason',
+    'update-cancellation-condition',
     'cancel-event',
   ],
   setup (props, { emit }) {
@@ -62,15 +62,15 @@ export default {
 
     const resetForm = () => {
       hide();
-      emit('update-event-reason', '');
-      emit('update-event-condition', '');
+      emit('update-cancellation-reason', '');
+      emit('update-cancellation-condition', '');
     };
 
     const updateEventMisc = (value) => { emit('update-event-misc', value); };
 
-    const updateEventReason = (value) => { emit('update-event-reason', value); };
+    const updateCancellationReason = (value) => { emit('update-cancellation-reason', value); };
 
-    const updateEventCondition = (value) => { emit('update-event-condition', value); };
+    const updateCancellationCondition = (value) => { emit('update-cancellation-condition', value); };
 
     const formatDateAndHours = (startDate, endDate) => {
       const date = formatDate(startDate);
@@ -102,8 +102,8 @@ export default {
       hide,
       resetForm,
       updateEventMisc,
-      updateEventReason,
-      updateEventCondition,
+      updateCancellationReason,
+      updateCancellationCondition,
       canCancelEvent,
       cancelEvent,
     };

--- a/src/modules/client/components/planning/EventCancellationModal.vue
+++ b/src/modules/client/components/planning/EventCancellationModal.vue
@@ -1,0 +1,39 @@
+<template>
+  <q-dialog :model-value="modelValue" @hide="hide" @update:model-value="$emit('update:model-value')">
+    <div class="modal-container-md modal-padding">
+      <div class="title q-mb-md">Annuler l'intervention</div>
+      <div class="row justify-end q-mb-md">
+        <ni-button label="RETOUR" @click="hide" />
+        <ni-button label="ANNULER L'INTERVENTION" @click="() => {}" />
+      </div>
+    </div>
+  </q-dialog>
+</template>
+
+<script>
+import Button from '@components/Button';
+import Input from '@components/form/Input';
+
+export default {
+  name: 'EventCancellationModal',
+  components: {
+    'ni-button': Button,
+    'ni-input': Input,
+  },
+  props: {
+    modelValue: { type: Boolean, default: false },
+    editedEvent: { type: Object, default: () => ({}) },
+  },
+  emits: ['hide', 'update:model-value'],
+  setup (props, { emit }) {
+    const hide = () => { emit('hide'); };
+
+    return { hide };
+  },
+};
+</script>
+
+<style lang="sass" scoped>
+.title
+  font-size: 20px
+</style>

--- a/src/modules/client/components/planning/EventCancellationModal.vue
+++ b/src/modules/client/components/planning/EventCancellationModal.vue
@@ -1,25 +1,20 @@
 <template>
-  <q-dialog :model-value="modelValue" @hide="hide" @update:model-value="$emit('update:model-value')">
-    <div class="modal-container-sm modal-padding in-modal">
-      <div class="row justify-between">
-        <div class="title q-mb-md">Annuler l'intervention</div>
-        <q-icon class="cursor-pointer" name="close" size="1.5rem" @close="resetForm" v-close-popup />
-      </div>
-      <ni-option-group caption="Qui est à l'origine de l'annulation ?"
-        :model-value="editedEvent.cancel.reason" type="radio" :options="cancellationReasons" required-field
-        color="copper-500" @update:model-value="updateCancellationReason($event)" />
-      <ni-option-group caption="Quelles sont les conditions d'annulation ?"
-        :model-value="editedEvent.cancel.condition" type="radio" :options="cancellationOptions" required-field
-        color="copper-500" @update:model-value="updateCancellationCondition($event)" />
-      <ni-input in-modal type="textarea" :model-value="editedEvent.misc" caption="Notes" required-field last
-        @update:model-value="updateEventMisc($event)" @blur="validations.misc.$touch"
-        :error="validations.misc.$error" />
-      <div class="row justify-end q-mb-md">
-        <ni-button label="RETOUR" @click="resetForm" />
-        <ni-button label="ANNULER L'INTERVENTION" @click="canCancelEvent" />
-      </div>
+  <ni-modal :model-value="modelValue" @hide="hide" @update:model-value="$emit('update:model-value')"
+    title="Annuler l'intervention">
+    <ni-option-group caption="Qui est à l'origine de l'annulation ?"
+      :model-value="editedEvent.cancel.reason" type="radio" :options="cancellationReasons" required-field
+      color="copper-500" @update:model-value="updateCancellationReason($event)" />
+    <ni-option-group caption="Quelles sont les conditions d'annulation ?"
+      :model-value="editedEvent.cancel.condition" type="radio" :options="cancellationOptions" required-field
+      color="copper-500" @update:model-value="updateCancellationCondition($event)" />
+    <ni-input in-modal type="textarea" :model-value="editedEvent.misc" caption="Notes" required-field last
+      @update:model-value="updateEventMisc($event)" @blur="validations.misc.$touch"
+      :error="validations.misc.$error" />
+    <div class="row justify-end q-mb-md">
+      <ni-button label="RETOUR" @click="resetForm" />
+      <ni-button label="ANNULER L'INTERVENTION" @click="canCancelEvent" />
     </div>
-  </q-dialog>
+  </ni-modal>
 </template>
 <script>
 
@@ -31,6 +26,7 @@ import { NotifyPositive, NotifyWarning } from '@components/popup/notify';
 import Button from '@components/Button';
 import Input from '@components/form/Input';
 import OptionGroup from '@components/form/OptionGroup';
+import Modal from '@components/modal/Modal';
 
 export default {
   name: 'EventCancellationModal',
@@ -38,6 +34,7 @@ export default {
     'ni-button': Button,
     'ni-input': Input,
     'ni-option-group': OptionGroup,
+    'ni-modal': Modal,
   },
   props: {
     modelValue: { type: Boolean, default: false },

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -134,12 +134,15 @@
       @cancel-time-stamping="cancelTimeStamping" :start="isStartCancellation"
       :validations="v$.timeStampCancellationReason" :v-model:reason="timeStampCancellationReason" />
     <ni-event-cancellation-modal v-model="eventCancellationModal" :edited-event="editedEvent"
-      @hide="resetEventCancellationModal" />
+      @hide="resetEventCancellationModal" @update-event-misc="updateEvent('misc', $event)" :validations="validations"
+      @update-event-reason="updateEvent('cancel.reason', $event)"
+      @update-event-condition="updateEvent('cancel.condition', $event)" />
   </q-dialog>
 </template>
 
 <script>
 import get from 'lodash/get';
+import set from 'lodash/set';
 import { ref } from 'vue';
 import useVuelidate from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
@@ -172,15 +175,16 @@ export default {
   setup () {
     const eventCancellationModal = ref(false);
 
-    const openEventCancellationModal = () => eventCancellationModal.value = true;
+    const openEventCancellationModal = () => { eventCancellationModal.value = true; };
 
-    const resetEventCancellationModal = () => eventCancellationModal.value = false;
+    const resetEventCancellationModal = () => { eventCancellationModal.value = false; };
     return {
       // Data
       eventCancellationModal,
       // Methods
       openEventCancellationModal,
       resetEventCancellationModal,
+      set,
       // Validations
       v$: useVuelidate(),
     };
@@ -298,6 +302,8 @@ export default {
       this.displayHistory = !this.displayHistory;
     },
     updateEvent (path, value) {
+      console.log('path', path);
+      console.log('value', value);
       this.$emit('update-event', { path, value });
     },
     toggleCancellationForm (value) {

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -136,7 +136,8 @@
     <ni-event-cancellation-modal v-model="eventCancellationModal" :edited-event="editedEvent"
       @hide="closeEventCancellationModal" @update-event-misc="updateEvent('misc', $event)" :validations="validations"
       @update-event-reason="updateEvent('cancel.reason', $event)"
-      @update-event-condition="updateEvent('cancel.condition', $event)" @cancel-event="cancelEvent" />
+      @update-event-condition="updateEvent('cancel.condition', $event)" @cancel-event="cancelEvent"
+      :customer-name="customerFullName" />
   </q-dialog>
 </template>
 
@@ -266,6 +267,10 @@ export default {
     },
     customerStoppedDate () {
       return get(this.selectedCustomer, 'stoppedAt') || '';
+    },
+    customerFullName () {
+      return `${get(this.selectedCustomer, 'identity.firstname')} ${get(this.selectedCustomer, 'identity.lastname')}` ||
+        '';
     },
     startDateTimeStamped () {
       return this.eventHistories

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -13,7 +13,7 @@
           <q-btn rounded unelevated color="primary" :label="eventTypeLabel" />
           <div class="modal-subtitle">
             <ni-button v-if="canCancel && !editedEvent.isCancelled" label="Annuler l'intervention"
-              @click="openEventCancellationModal()" color="copper-grey-800" />
+              color="copper-grey-800" class="bg-copper-grey-100" @click="openEventCancellationModal()"  />
             <q-btn icon="delete" @click="isRepetition(editedEvent) ? deleteEventRepetition() : deleteEvent()" no-caps
               flat color="copper-grey-400" v-if="canUpdateIntervention" data-cy="event-deletion-button"
               :disable="historiesLoading" />

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -13,7 +13,7 @@
           <q-btn rounded unelevated color="primary" :label="eventTypeLabel" />
           <div class="modal-subtitle">
             <ni-button v-if="canCancel && !editedEvent.isCancelled" label="Annuler l'intervention"
-              color="copper-grey-800" class="bg-copper-grey-100" @click="openEventCancellationModal()"  />
+              color="copper-grey-800" class="bg-copper-grey-100" @click="openEventCancellationModal()" />
             <q-btn icon="delete" @click="isRepetition(editedEvent) ? deleteEventRepetition() : deleteEvent()" no-caps
               flat color="copper-grey-400" v-if="canUpdateIntervention" data-cy="event-deletion-button"
               :disable="historiesLoading" />
@@ -132,12 +132,11 @@
     </div>
     <ni-history-cancellation-modal v-model="historyCancellationModal" @hide="resetHistoryCancellationModal"
       @cancel-time-stamping="cancelTimeStamping" :start="isStartCancellation"
-      :validations="v$.timeStampCancellationReason" :v-model:reason="timeStampCancellationReason" />
+      :validations="v$.timeStampCancellationReason" v-model:reason="timeStampCancellationReason" />
     <ni-event-cancellation-modal v-model="eventCancellationModal" :edited-event="editedEvent"
-      @hide="closeEventCancellationModal" @update-event-misc="updateEvent('misc', $event)" :validations="validations"
-      @update-event-reason="updateEvent('cancel.reason', $event)"
-      @update-event-condition="updateEvent('cancel.condition', $event)" @cancel-event="cancelEvent"
-      :customer-name="customerFullName" />
+      :validations="validations" :customer-name="customerFullName" @update-event-misc="updateEvent('misc', $event)"
+      @update-cancellation-reason="updateEvent('cancel.reason', $event)" @hide="closeEventCancellationModal"
+      @update-cancellation-condition="updateEvent('cancel.condition', $event)" @cancel-event="cancelEvent" />
   </q-dialog>
 </template>
 

--- a/src/modules/client/components/planning/HistoryCancellationModal.vue
+++ b/src/modules/client/components/planning/HistoryCancellationModal.vue
@@ -22,7 +22,6 @@
 <script>
 import Button from '@components/Button';
 import Input from '@components/form/Input';
-import { planningModalMixin } from 'src/modules/client/mixins/planningModalMixin';
 
 export default {
   name: 'HistoryCancellationModal',

--- a/src/modules/client/components/planning/HistoryCancellationModal.vue
+++ b/src/modules/client/components/planning/HistoryCancellationModal.vue
@@ -22,6 +22,7 @@
 <script>
 import Button from '@components/Button';
 import Input from '@components/form/Input';
+import { planningModalMixin } from 'src/modules/client/mixins/planningModalMixin';
 
 export default {
   name: 'HistoryCancellationModal',

--- a/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -33,8 +33,8 @@
       :customers="customers" @hide="resetEditionForm" @delete-document="validateDocumentDeletion"
       @document-uploaded="documentUploaded" @submit="validateEventEdition" @delete-event="validateEventDeletion"
       @delete-event-repetition="validationDeletionEventRepetition" :person-key="personKey" @close="closeEditionModal"
-      :event-histories="editedEventHistories" :histories-loading="historiesLoading"
-      @refresh-histories="refreshHistories" @update-event="setEvent" />
+      :event-histories="editedEventHistories" :histories-loading="historiesLoading" @update-event="setEvent"
+      @refresh-histories="refreshHistories" />
   </q-page>
 </template>
 
@@ -76,7 +76,15 @@ export default {
     const customers = ref([]);
     const { newEvent, editedEvent, eventValidation } = usePlanningAction(personKey, customers);
 
-    return { personKey, newEvent, editedEvent, customers, eventValidation };
+    return {
+      // Data
+      personKey,
+      newEvent,
+      editedEvent,
+      customers,
+      // Validations
+      eventValidation
+    };
   },
   mixins: [planningTimelineMixin, planningActionMixin],
   data () {

--- a/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -83,7 +83,7 @@ export default {
       editedEvent,
       customers,
       // Validations
-      eventValidation
+      eventValidation,
     };
   },
   mixins: [planningTimelineMixin, planningActionMixin],


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Rmq: Je n'ai pas réussi a faire fonctionner les validations sur la modale d'annulation. J'ouvre la PR sans les validations et les ajouterai dans une seconde PR

- Périmètre interfaces / rôles : ETQ Auxiliaire / Coach / Admin je peux annuler une intervention

- Cas d'usage : on a retravaillé la manière d'annuler un evenement. Avant on avait un checkbox, ajd on a ajouté un bouton qui ouvre une succession de modale selon ce qu'entre l'utilisateur. 

- Comment tester ? :
   - annuler une intervention 

_Si tu as lu cette description, pense a réagir avec un :eye:_
