### PR TITLE
COM-2855 - convert discount into float to format correctly on toBill …

### DIFF
--- a/src/modules/client/components/table/ToBillRow.vue
+++ b/src/modules/client/components/table/ToBillRow.vue
@@ -116,7 +116,7 @@ export default {
     };
 
     const setDiscount = ({ value, obj, path }) => {
-      obj[path] = !value || isNaN(value) || value < 0 ? 0 : divide(Math.trunc(multiply(value, 100)), 100);
+      obj[path] = !value || isNaN(value) || value < 0 ? 0 : parseFloat(divide(Math.trunc(multiply(value, 100)), 100));
       emit('discount-input');
     };
 


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : ETQ admin

- Cas d'usage : Sur la page a facturer, je peux ajouter une remise:
   - si la remise est négative, on enregistre 0,00
   - si la remise a plus de 2 décimales, on tronque pour enregistrer le nbre avec 2 décimales 

- Comment tester ? : ajouter des remises et tester les cas ci-dessus

_Si tu as lu cette description, pense a réagir avec un :eye:_
