### PR TITLE
COM-2877: move usefull docs section

### DIFF
--- a/src/core/components/courses/CourseInfoLink.vue
+++ b/src/core/components/courses/CourseInfoLink.vue
@@ -2,7 +2,7 @@
   <div class="course-link">
     <ni-bi-color-button icon="file_download" label="Convocation papier" :disable="disableLink" size="16px"
       @click="$emit('download')" />
-    <ni-button color="primary" :disable="disableLink" icon="link" label="Obtenir un lien de partage"
+    <ni-button color="primary" :disable="disableLink" icon="link" label="Lien de partage"
       @click="copy" />
 </div>
 </template>

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -1,29 +1,21 @@
 <template>
   <div v-if="course">
-    <div class="q-mb-xl">
-      <div v-if="isClientInterface && isCourseInter" class="q-mb-lg">
-        <p class="text-weight-bold">Informations pratiques</p>
-        <ni-banner v-if="followUpDisabled">
-          <template #message>{{ missingInfoMsg }}</template>
-        </ni-banner>
-        <ni-course-info-link :disable-link="disableDocDownload" @download="downloadConvocation" />
+    <div class="profile-container q-mb-xl">
+      <ni-bi-color-button v-if="isIntraOrVendor" class="button-history" icon="history" label="Historique"
+        @click="toggleHistory" />
+      <div v-if="isIntraOrVendor" class="row gutter-profile">
+        <ni-input caption="Informations complémentaires" v-model.trim="course.misc"
+          @blur="updateCourse('misc')" @focus="saveTmp('misc')" :disable="isArchived" />
       </div>
-      <div v-else class="profile-container">
-        <ni-bi-color-button class="button-history" icon="history" label="Historique" @click="toggleHistory" />
-        <div class="row gutter-profile">
-          <ni-input caption="Informations complémentaires" v-model.trim="course.misc"
-            @blur="updateCourse('misc')" @focus="saveTmp('misc')" :disable="isArchived" />
-        </div>
-        <p class="text-weight-bold table-title">Interlocuteurs</p>
-        <div class="interlocutor-container">
-          <interlocutor-cell :interlocutor="course.salesRepresentative" caption="Référent Compani"
-            :open-edition-modal="openSalesRepresentativeModal" :disable="isArchived" />
-          <interlocutor-cell v-if="!!course.trainer._id" :interlocutor="course.trainer" caption="Intervenant(e)"
-            :open-edition-modal="() => openTrainerModal('Modifier l\'')" :disable="isArchived" />
-          <ni-button v-else-if="canUpdateTrainer" color="primary" icon="add" class="add-trainer"
-            label="Ajouter un(e) intervenant(e)" :disable="interlocutorModalLoading || isArchived"
-            @click="() => openTrainerModal('Ajouter un(e) ')" />
-        </div>
+      <p class="text-weight-bold table-title">Interlocuteurs</p>
+      <div class="interlocutor-container">
+        <interlocutor-cell :interlocutor="course.salesRepresentative" caption="Référent Compani"
+          :open-edition-modal="openSalesRepresentativeModal" :disable="isArchived" />
+        <interlocutor-cell v-if="!!course.trainer._id" :interlocutor="course.trainer" caption="Intervenant(e)"
+          :open-edition-modal="() => openTrainerModal('Modifier l\'')" :disable="isArchived" />
+        <ni-button v-else-if="canUpdateTrainer" color="primary" icon="add" class="add-trainer"
+          label="Ajouter un(e) intervenant(e)" :disable="interlocutorModalLoading || isArchived"
+          @click="() => openTrainerModal('Ajouter un(e) ')" />
       </div>
     </div>
     <ni-slot-container :can-edit="canEditSlots" :loading="courseLoading" @refresh="refreshCourse" :is-admin="isAdmin"
@@ -72,21 +64,21 @@
         <ni-bi-color-button icon="mdi-cellphone-message" :disable="disableSms" @click="openSmsModal"
           label="Envoyer un SMS de convocation ou de rappel aux stagiaires" size="16px" />
       </div>
-      <div class="q-mb-xl">
-        <p class="text-weight-bold">Documents utiles</p>
-        <div class="q-mb-sm">
-          <ni-banner v-if="followUpDisabled">
-            <template #message>
-              Il manque {{ formatQuantity('information', followUpMissingInfo.length ) }}
-              pour assurer le suivi de la formation : {{ followUpMissingInfo.join(', ') }}.
-            </template>
-          </ni-banner>
-          <ni-course-info-link :disable-link="disableDocDownload" @download="downloadConvocation" />
-        </div>
-        <div v-if="isIntraOrVendor">
-          <ni-bi-color-button icon="file_download" label="Feuilles d'émargement vierges"
-            :disable="disableDocDownload" @click="downloadAttendanceSheet" size="16px" />
-        </div>
+    </div>
+    <div class="q-mb-xl">
+      <p class="text-weight-bold">Documents utiles</p>
+      <div class="q-mb-sm">
+        <ni-banner v-if="followUpDisabled">
+          <template #message>
+            Il manque {{ formatQuantity('information', followUpMissingInfo.length ) }}
+            pour assurer le suivi de la formation : {{ followUpMissingInfo.join(', ') }}.
+          </template>
+        </ni-banner>
+        <ni-course-info-link :disable-link="disableDocDownload" @download="downloadConvocation" />
+      </div>
+      <div v-if="isIntraOrVendor">
+        <ni-bi-color-button icon="file_download" label="Feuilles d'émargement vierges"
+          :disable="disableDocDownload" @click="downloadAttendanceSheet" size="16px" />
       </div>
     </div>
 

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -45,15 +45,6 @@
         </div>
       </div>
       <div class="q-mb-xl">
-        <ni-banner v-if="followUpDisabled">
-          <template #message>
-            Il manque {{ formatQuantity('information', followUpMissingInfo.length ) }}
-            pour assurer le suivi de la formation : {{ followUpMissingInfo.join(', ') }}.
-          </template>
-        </ni-banner>
-        <ni-course-info-link :disable-link="disableDocDownload" @download="downloadConvocation" />
-      </div>
-      <div class="q-mb-xl">
         <p class="text-weight-bold">Envoi de SMS</p>
         <p>Historique d'envoi </p>
         <ni-responsive-table :data="smsSent" :columns="smsSentColumns" v-model:pagination="pagination" class="q-mb-md"
@@ -80,6 +71,22 @@
         </ni-banner>
         <ni-bi-color-button icon="mdi-cellphone-message" :disable="disableSms" @click="openSmsModal"
           label="Envoyer un SMS de convocation ou de rappel aux stagiaires" size="16px" />
+      </div>
+      <div class="q-mb-xl">
+        <p class="text-weight-bold">Documents utiles</p>
+        <div class="q-mb-sm">
+          <ni-banner v-if="followUpDisabled">
+            <template #message>
+              Il manque {{ formatQuantity('information', followUpMissingInfo.length ) }}
+              pour assurer le suivi de la formation : {{ followUpMissingInfo.join(', ') }}.
+            </template>
+          </ni-banner>
+          <ni-course-info-link :disable-link="disableDocDownload" @download="downloadConvocation" />
+        </div>
+        <div v-if="isIntraOrVendor">
+          <ni-bi-color-button icon="file_download" label="Feuilles d'émargement vierges"
+            :disable="disableDocDownload" @click="downloadAttendanceSheet" size="16px" />
+        </div>
       </div>
     </div>
 

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -9,7 +9,7 @@
             pour assurer le suivi de la formation : {{ followUpMissingInfo.join(', ') }}.
           </template>
         </ni-banner>
-        <ni-bi-color-button icon="file_download" label="Feuilles d'émargement"
+        <ni-bi-color-button icon="file_download" label="Feuilles d'émargement vierges"
           :disable="disableDocDownload" @click="downloadAttendanceSheet" size="16px" />
       </div>
       <attendance-table :course="course" />

--- a/src/core/components/courses/ProfileTraineeFollowUp.vue
+++ b/src/core/components/courses/ProfileTraineeFollowUp.vue
@@ -69,14 +69,9 @@ import QuestionnaireAnswersCell from '@components/courses/QuestionnaireAnswersCe
 import BiColorButton from '@components/BiColorButton';
 import Banner from '@components/Banner';
 import { SURVEY, OPEN_QUESTION, QUESTION_ANSWER, E_LEARNING } from '@data/constants';
-import {
-  upperCaseFirstLetter,
-  formatIdentity,
-  formatQuantity,
-  readAPIResponseWithTypeArrayBuffer,
-} from '@helpers/utils';
+import { upperCaseFirstLetter, formatIdentity, formatQuantity } from '@helpers/utils';
 import { formatDate, ascendingSort, getTotalDuration, getDuration, formatIntervalHourly } from '@helpers/date';
-import { downloadZip, downloadFile } from '@helpers/file';
+import { downloadZip } from '@helpers/file';
 import { traineeFollowUpTableMixin } from '@mixins/traineeFollowUpTableMixin';
 import { courseMixin } from '@mixins/courseMixin';
 
@@ -191,22 +186,6 @@ export default {
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement des attestations.');
-      } finally {
-        this.pdfLoading = false;
-      }
-    },
-    async downloadAttendanceSheet () {
-      if (this.disableDocDownload) return;
-
-      try {
-        this.pdfLoading = true;
-        const pdf = await Courses.downloadAttendanceSheet(this.course._id);
-        downloadFile(pdf, 'emargement.pdf', 'application/octet-stream');
-      } catch (e) {
-        console.error(e);
-        const decodedRep = readAPIResponseWithTypeArrayBuffer(e);
-        if (decodedRep.statusCode === 404 && decodedRep.message) return NotifyNegative(decodedRep.message);
-        NotifyNegative('Erreur lors du téléchargement de la feuille d\'émargement.');
       } finally {
         this.pdfLoading = false;
       }


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client admin/rof/coach

- Cas d'usage : sur l'onglet organisation j'ai une section Documents Utiles avec la convocation et les feuilles d'émargement

- Comment tester ? :
  - sur une formation intra, en bas de l'onglet organisation je peux télécharger la convocation et les feuilles d'émargement, dans l'onglet suivi des stagiaires je peux toujours télécharger les feuilles d'émargement 

_Si tu as lu cette description, pense a réagir avec un :eye:_
