### PR TITLE
Com 2886

### DIFF
--- a/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
+++ b/src/modules/client/components/customers/billing/ManualBillCreationModal.vue
@@ -52,7 +52,7 @@ import BiColorButton from '@components/BiColorButton';
 import DateInput from '@components/form/DateInput';
 import { REQUIRED_LABEL } from '@data/constants';
 import { formatPrice, formatStringToPrice } from '@helpers/utils';
-import { multiply, add, divide, toString } from '@helpers/numbers';
+import { multiply, add, divide, toString, toFixedToFloat } from '@helpers/numbers';
 import { configMixin } from 'src/modules/client/mixins/configMixin';
 
 export default {
@@ -97,7 +97,7 @@ export default {
       handler () {
         this.totalExclTaxes = this.newManualBill.billingItemList.reduce(
           (acc, bi) => (bi.billingItem
-            ? add(acc, multiply(this.getExclTaxes(bi.unitInclTaxes, bi.vat), bi.count))
+            ? add(acc, this.getExclTaxes(toFixedToFloat(multiply(bi.unitInclTaxes, bi.count)), bi.vat))
             : acc
           ),
           toString(0)

--- a/src/modules/client/components/table/ToBillRow.vue
+++ b/src/modules/client/components/table/ToBillRow.vue
@@ -92,12 +92,6 @@ export default {
       return bill.hours ? `${parseFloat(bill.hours).toFixed(2)}h` : '';
     });
 
-    const getClientName = (customer) => {
-      const { bill } = props;
-      if (!bill.thirdPartyPayer) return formatIdentity(customer.identity, 'Lf');
-      return truncate(bill.thirdPartyPayer.name, 35);
-    };
-
     const netExclTaxes = computed(() => {
       const { bill } = props;
       const exclTaxes = divide(netInclTaxes.value, add(1, divide(bill.vat, 100)));
@@ -112,6 +106,12 @@ export default {
 
       return toEuros(inclTaxesCents - discountCents);
     });
+
+    const getClientName = (customer) => {
+      const { bill } = props;
+      if (!bill.thirdPartyPayer) return formatIdentity(customer.identity, 'Lf');
+      return truncate(bill.thirdPartyPayer.name, 35);
+    };
 
     const setDiscount = ({ value, obj, path }) => {
       obj[path] = !value || isNaN(value) || value < 0 ? 0 : parseFloat(divide(Math.trunc(multiply(value, 100)), 100));

--- a/src/modules/client/components/table/ToBillRow.vue
+++ b/src/modules/client/components/table/ToBillRow.vue
@@ -37,7 +37,7 @@
       <template v-else-if="col.name === 'unitExclTaxes'">{{ formatStringToPrice(bill.unitExclTaxes) }}</template>
       <template v-else-if="col.name === 'discount'">
         <ni-editable-td :props="bill" edited-field="discount" edition-boolean-name="discountEdition"
-          :value="formatPrice(bill.discount)" @disable="disableDiscountEditing()" :ref-name="bill._id"
+          :value="formatPrice(bill.discount)" @disable="update(false, 'discountEdition')" :ref-name="bill._id"
           @click="$emit('discount-click', $event)" @change="setDiscount" suffix="€" />
       </template>
       <template v-else-if="col.name === 'exclTaxes'">{{ formatPrice(netExclTaxes) }}</template>
@@ -118,8 +118,6 @@ export default {
       emit('discount-input');
     };
 
-    const disableDiscountEditing = () => update(false, 'discountEdition');
-
     const update = async (event, prop) => {
       await emit('update:bill', { ...props.bill, [prop]: event });
     };
@@ -143,7 +141,6 @@ export default {
       getLastVersion,
       getClientName,
       setDiscount,
-      disableDiscountEditing,
       update,
       updateDate,
       startDateOptions,

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -206,7 +206,7 @@ export default {
     },
     'editedCreditNote.events': function (previousValue, currentValue) {
       if (!isEqual(previousValue, currentValue) && this.creditNoteType === EVENTS) {
-        const prices = this.computePrices(this.editedCreditNote.events, this.editedCreditNote.customer);
+        const prices = this.computePrices(this.editedCreditNote.events, this.editedCreditNote.customer._id);
         this.editedCreditNote.exclTaxesCustomer = prices.exclTaxesCustomer;
         this.editedCreditNote.inclTaxesCustomer = prices.inclTaxesCustomer;
         this.editedCreditNote.exclTaxesTpp = prices.exclTaxesTpp;


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : admin client

- Cas d'usage : refacto du calcul du HT --> le hors taxe doit etre calculé sur la valeur exacte et non la valeur arrondie. 

- Comment tester ? : tester les factures manuelles/automatiques, les remises et les avoirs. 
Note : un changement notable par rapport à avant : si il y a un changement de tva entre plusieurs evenements, on prendra en compte uniquement la tva la plus recente. Je me suis dit que c'etait une valeur qui changeait peu 🤔 Aussi, je me demande pourquoi on ne conserve pas le HT total dans les factures 🤔 (cela pose probleme uniquement dans le cas de remises j'ai l'impression)

ex de données pour les factures manuelles qui ne fonctionnait pas sur features-big-number : unit 9.11, count 1.13, tva: 5.5
ex de données pour les avoirs (cf ticket jira)
pour la page a facturer, je n'ai pas d'exemple qui ne fonctionne pas sur feature-big-number. 

_Si tu as lu cette description, pense a réagir avec un :eye:_
