### PR TITLE
COM-2821: on small screen space between both buttons

### DIFF
--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -16,12 +16,12 @@
           <q-btn rounded unelevated color="primary" :label="eventTypeLabel" class="q-my-sm" />
           <div class="modal-subtitle buttons-container q-my-sm">
             <ni-button v-if="canCancelOrRestore && !editedEvent.isCancelled" label="Annuler l'intervention"
-              color="copper-grey-800" class="bg-copper-grey-100 q-my-sm" @click="openEventCancellationModal()" />
+              color="copper-grey-800" class="bg-copper-grey-100" @click="openEventCancellationModal()" />
               <ni-button v-else-if="canCancelOrRestore" label="Rétablir l'intervention" color="copper-grey-800"
-              class="bg-copper-grey-100 q-my-sm" @click="openEventRestorationModal()" />
+              class="bg-copper-grey-100" @click="openEventRestorationModal()" />
               <q-btn icon="delete" @click="isRepetition(editedEvent) ? deleteEventRepetition() : deleteEvent()" no-caps
               flat color="copper-grey-400" v-if="canUpdateIntervention" data-cy="event-deletion-button"
-              :disable="historiesLoading" class="q-my-sm" />
+              :disable="historiesLoading" class="q-pr-sm" />
           </div>
         </div>
         <template v-if="editedEvent.type !== ABSENCE">

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -12,9 +12,9 @@
         <ni-banner v-if="editedEvent.isCancelled" icon="info_outline">
           <template #message>Intervention annulée</template>
         </ni-banner>
-        <div class="row modal-subtitle">
+        <div class="row modal-subtitle items-center">
           <q-btn rounded unelevated color="primary" :label="eventTypeLabel" class="q-my-sm" />
-          <div class="modal-subtitle">
+          <div class="modal-subtitle buttons-container q-my-sm">
             <ni-button v-if="canCancelOrRestore && !editedEvent.isCancelled" label="Annuler l'intervention"
               color="copper-grey-800" class="bg-copper-grey-100 q-my-sm" @click="openEventCancellationModal()" />
               <ni-button v-else-if="canCancelOrRestore" label="Rétablir l'intervention" color="copper-grey-800"
@@ -454,4 +454,8 @@ export default {
 .infos
   font-style: italic
   color: $copper-grey-400
+
+.buttons-container
+  @media screen and (max-width: $breakpoint-sm-max)
+    width: 100%
 </style>


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client admin/coach/auxiliaire

- Cas d'usage : sur petit écran les bouton rétablir/annuler et corbeille sont espacés
<img width="251" alt="Capture d’écran 2022-07-01 à 10 12 54" src="https://user-images.githubusercontent.com/70574422/176853799-5e4bf1c9-8d60-4dcf-8325-8e1aed1669cf.png">

- Comment tester ? : 
  - sur grand écran le toggle et les deux boutons sur sur la même ligne
  - sur petit écran les deux boutons son à la ligne et espacés 

_Si tu as lu cette description, pense a réagir avec un :eye:_
