### PR TITLE
COM-2899 hide repetition menu

### DIFF
--- a/src/modules/client/mixins/menuItemsMixin.js
+++ b/src/modules/client/mixins/menuItemsMixin.js
@@ -112,7 +112,6 @@ export const menuItemsMixin = {
           children: [
             { name: 'ni planning auxiliaries', icon: 'date_range', label: 'Auxiliaires' },
             { name: 'ni planning customers', icon: 'date_range', label: 'Bénéficiaires' },
-            { name: 'ni planning repetitions', icon: 'event_repeat', label: 'Gérer les répétitions' },
           ],
         }, {
           ref: 'customers',
@@ -186,7 +185,6 @@ export const menuItemsMixin = {
             { name: 'auxiliaries agenda', icon: 'event', label: 'Le mien' },
             { name: 'ni planning auxiliaries', icon: 'face', label: 'Auxiliaires' },
             { name: 'ni planning customers', icon: 'people', label: 'Bénéficiaires' },
-            { name: 'ni planning repetitions', icon: 'event_repeat', label: 'Gérer les répétitions' },
           ],
         }, {
           ref: 'customers',

--- a/src/modules/client/router/routes.js
+++ b/src/modules/client/router/routes.js
@@ -304,16 +304,6 @@ const routes = [
         },
       },
       {
-        path: 'ni/planning/repetitions',
-        name: 'ni planning repetitions',
-        component: () => import('src/modules/client/pages/ni/planning/RepetitionsPlanning'),
-        props: true,
-        meta: {
-          cookies: ['alenvi_token', 'refresh_token'],
-          parent: 'planning',
-        },
-      },
-      {
         path: 'ni/courses',
         name: 'ni courses',
         component: () => import('src/modules/client/pages/ni/courses/BlendedCoursesDirectory'),


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach/admin/auxiliaire

- Cas d'usage : plus personne n'a acces a la page repetition. 

- Comment tester ? : Verifier qu'on n'a plus acces a la page 

_Si tu as lu cette description, pense a réagir avec un :eye:_
