### PR TITLE
Com 2910

### DIFF
--- a/src/core/components/courses/InterlocutorCell.vue
+++ b/src/core/components/courses/InterlocutorCell.vue
@@ -11,7 +11,7 @@
             {{ formatPhone(interlocutor.contact.phone) }}
           </div>
           <div v-else class="row items-center text-14">
-            <div class="dot dot-error" />
+            <div class="dot dot-orange" />
             <div class="text-orange-500">numéro manquant</div>
           </div>
           <div v-if="contact._id === interlocutor._id" class="contact">
@@ -83,6 +83,6 @@ export default {
   display: flex
   align-items: center
   margin-left: -2px
-.dot-error
+.dot-orange
   margin: 0px 4px 0px 0px
 </style>

--- a/src/css/icon.sass
+++ b/src/css/icon.sass
@@ -4,11 +4,11 @@
   border-radius: 50%
   display: inline-block
   margin: 0 20px 0 3px
-  &-active
+  &-green
     background: $green-600
-  &-error
+  &-orange
     background: $orange-500
-  &-archived
+  &-grey
     background: $copper-grey-400
 
 .balance-icon

--- a/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
+++ b/src/modules/client/components/auxiliary/AuxiliaryProfileHeader.vue
@@ -13,7 +13,7 @@
     <div class="row profile-info">
       <div class="col-sm-6 col-xs-12 q-pl-lg">
         <div class="flex-row items-center q-ml-sm">
-          <div :class="['dot', userActivity.active ? 'dot-active' : 'dot-error']" />
+          <div :class="['dot', userActivity.active ? 'dot-green' : 'dot-orange']" />
           <div :class="[userActivity.active ? 'text-green-600' : 'text-orange-700']">{{ userActivity.status }}</div>
         </div>
         <div class="flex-row items-center q-ml-sm">

--- a/src/modules/client/components/customers/CustomerProfileHeader.vue
+++ b/src/modules/client/components/customers/CustomerProfileHeader.vue
@@ -130,9 +130,9 @@ export default {
     },
     getDotClass (value) {
       return {
-        'dot dot-active': value === ACTIVATED,
-        'dot dot-error': value === STOPPED,
-        'dot dot-archived': value === ARCHIVED,
+        'dot dot-green': value === ACTIVATED,
+        'dot dot-orange': value === STOPPED,
+        'dot dot-grey': value === ARCHIVED,
       };
     },
     getDotTextClass (value) {

--- a/src/modules/client/components/customers/infos/ProfileInfo.vue
+++ b/src/modules/client/components/customers/infos/ProfileInfo.vue
@@ -144,7 +144,7 @@
                     @focus="saveTmpSignedAt(getRowIndex(customer.payment.mandates, props.row))" />
                 </template>
                 <template v-else-if="col.name === 'signed'">
-                  <div :class="[{ 'dot dot-active': col.value, 'dot dot-error': !col.value }]" />
+                  <div :class="[{ 'dot dot-green': col.value, 'dot dot-orange': !col.value }]" />
                 </template>
                 <template v-else>{{ col.value }}</template>
               </q-td>
@@ -216,7 +216,7 @@
                     :disable="docLoading || !getDriveId(props.row)" />
                 </template>
                 <template v-else-if="col.name === 'signed'">
-                  <div :class="[{ 'dot dot-active': col.value, 'dot dot-error': !col.value }]" />
+                  <div :class="[{ 'dot dot-green': col.value, 'dot dot-orange': !col.value }]" />
                 </template>
                 <template v-else>{{ col.value }}</template>
               </q-td>

--- a/src/modules/client/components/planning/RepetitionCell.vue
+++ b/src/modules/client/components/planning/RepetitionCell.vue
@@ -20,11 +20,11 @@
       </div>
       <div
         :class="['row', `${repetition.hasConflicts || repetition.hasDuplicateKey ? 'button-container' : ''}`, 'flex']">
-        <div v-if="repetition.hasConflicts" class="row conflict-container">
+        <div v-if="repetition.hasConflicts" class="row warning-container warning-container-conflict">
           <div class="dot dot-orange dot-margin" />
           <div>Conflit</div>
         </div>
-        <div v-if="repetition.hasDuplicateKey" class="row doublon-container">
+        <div v-if="repetition.hasDuplicateKey" class="row warning-container warning-container-doublon">
           <div class="dot dot-grey dot-margin" />
           <div>Doublon</div>
         </div>
@@ -154,18 +154,15 @@ export default {
 .avatar-size
   height: 24px
   width: 24px
-.conflict-container
-  color: $orange-500
+.warning-container
   align-items: center
   justify-content: space-around
   font-size: 14px
   margin: 0px 16px 0px 0px
-.doublon-container
-  color: $copper-grey-500
-  align-items: center
-  justify-content: space-around
-  font-size: 14px
-  margin: 0px 16px 0px 0px
+  &-doublon
+    color: $copper-grey-500
+  &-conflict
+    color: $orange-500
 .dot-margin
   margin: 0px 4px 0px 0px
 .button-container

--- a/src/modules/client/components/planning/RepetitionCell.vue
+++ b/src/modules/client/components/planning/RepetitionCell.vue
@@ -20,11 +20,11 @@
       </div>
       <div :class="['row', `${repetition.hasConflicts ? 'button-container' : ''}`, 'flex']">
         <div v-if="repetition.hasConflicts" class="row conflict-container">
-          <div class="dot dot-error dot-margin" />
+          <div class="dot dot-orange dot-margin" />
           <div>Conflit</div>
         </div>
         <div v-if="repetition.hasDuplicateKey" class="row doublon-container">
-          <div class="dot dot-archived dot-margin" />
+          <div class="dot dot-grey dot-margin" />
           <div>Doublon</div>
         </div>
         <ni-button v-if="canDelete" icon="delete" color="copper-grey-500" @click="deleteRepetition" />

--- a/src/modules/client/components/planning/RepetitionCell.vue
+++ b/src/modules/client/components/planning/RepetitionCell.vue
@@ -18,7 +18,8 @@
           À affecter - {{ repetition.sector.name }}
         </div>
       </div>
-      <div :class="['row', `${repetition.hasConflicts ? 'button-container' : ''}`, 'flex']">
+      <div
+        :class="['row', `${repetition.hasConflicts || repetition.hasDuplicateKey ? 'button-container' : ''}`, 'flex']">
         <div v-if="repetition.hasConflicts" class="row conflict-container">
           <div class="dot dot-orange dot-margin" />
           <div>Conflit</div>

--- a/src/modules/client/components/planning/RepetitionCell.vue
+++ b/src/modules/client/components/planning/RepetitionCell.vue
@@ -28,7 +28,7 @@
           <div class="dot dot-grey dot-margin" />
           <div>Doublon</div>
         </div>
-        <ni-button v-if="canDelete" icon="delete" color="copper-grey-500" @click="deleteRepetition" />
+        <ni-button v-if="canDelete" icon="delete" @click="deleteRepetition" />
       </div>
     </div>
   </q-card>

--- a/src/modules/client/components/planning/RepetitionCell.vue
+++ b/src/modules/client/components/planning/RepetitionCell.vue
@@ -20,13 +20,13 @@
       </div>
       <div
         :class="['row', `${repetition.hasConflicts || repetition.hasDuplicateKey ? 'button-container' : ''}`, 'flex']">
-        <div v-if="repetition.hasConflicts" class="row warning-container warning-container-conflict">
+        <div v-if="repetition.hasConflicts" class="row warning-container">
           <div class="dot dot-orange dot-margin" />
-          <div>Conflit</div>
+          <div class="text-conflict">Conflit</div>
         </div>
-        <div v-if="repetition.hasDuplicateKey" class="row warning-container warning-container-doublon">
+        <div v-if="repetition.hasDuplicateKey" class="row warning-container">
           <div class="dot dot-grey dot-margin" />
-          <div>Doublon</div>
+          <div class="text-doublon">Doublon</div>
         </div>
         <ni-button v-if="canDelete" icon="delete" @click="deleteRepetition" />
       </div>
@@ -159,9 +159,9 @@ export default {
   justify-content: space-around
   font-size: 14px
   margin: 0px 16px 0px 0px
-  &-doublon
+  .text-doublon
     color: $copper-grey-500
-  &-conflict
+  .text-conflict
     color: $orange-500
 .dot-margin
   margin: 0px 4px 0px 0px

--- a/src/modules/client/components/planning/RepetitionCell.vue
+++ b/src/modules/client/components/planning/RepetitionCell.vue
@@ -20,8 +20,12 @@
       </div>
       <div :class="['row', `${repetition.hasConflicts ? 'button-container' : ''}`, 'flex']">
         <div v-if="repetition.hasConflicts" class="row conflict-container">
-          <div class="dot dot-error" />
+          <div class="dot dot-error dot-margin" />
           <div>Conflit</div>
+        </div>
+        <div v-if="repetition.hasDuplicateKey" class="row doublon-container">
+          <div class="dot dot-archived dot-margin" />
+          <div>Doublon</div>
         </div>
         <ni-button v-if="canDelete" icon="delete" color="copper-grey-500" @click="deleteRepetition" />
       </div>
@@ -155,7 +159,13 @@ export default {
   justify-content: space-around
   font-size: 14px
   margin: 0px 16px 0px 0px
-.dot-error
+.doublon-container
+  color: $copper-grey-500
+  align-items: center
+  justify-content: space-around
+  font-size: 14px
+  margin: 0px 16px 0px 0px
+.dot-margin
   margin: 0px 4px 0px 0px
 .button-container
   @media screen and (max-width: $breakpoint-sm-max)

--- a/src/modules/client/pages/ni/auxiliaries/Directory.vue
+++ b/src/modules/client/pages/ni/auxiliaries/Directory.vue
@@ -16,7 +16,7 @@
             color="secondary" size="1rem" />
         </template>
         <template v-else-if="col.name === 'active'">
-          <div :class="{ 'dot dot-active': col.value, 'dot dot-error': !col.value }" />
+          <div :class="{ 'dot dot-green': col.value, 'dot dot-orange': !col.value }" />
         </template>
         <template v-else>{{ col.value }}</template>
       </template>

--- a/src/modules/client/pages/ni/customers/CustomersDirectory.vue
+++ b/src/modules/client/pages/ni/customers/CustomersDirectory.vue
@@ -234,9 +234,9 @@ export default {
     },
     getDotClass (value) {
       return {
-        'dot dot-active': value === ACTIVATED,
-        'dot dot-error': value === STOPPED,
-        'dot dot-archived': value === ARCHIVED,
+        'dot dot-green': value === ACTIVATED,
+        'dot dot-orange': value === STOPPED,
+        'dot dot-grey': value === ARCHIVED,
       };
     },
   },

--- a/src/modules/client/pages/ni/planning/RepetitionsPlanning.vue
+++ b/src/modules/client/pages/ni/planning/RepetitionsPlanning.vue
@@ -18,6 +18,9 @@
                 <div v-if="getConflictsNumber(repetitionList)">
                   &nbsp;- {{ getConflictsNumber(repetitionList) }} conflits
                 </div>
+                <div v-if="getDuplicatesNumber(repetitionList)">
+                  &nbsp;- {{ getDuplicatesNumber(repetitionList) }} doublons
+                </div>
               </div>
             </div>
             <q-icon :name="areDetailsVisible[index] ? 'expand_less' : 'expand_more'" />
@@ -203,6 +206,8 @@ export default {
 
     const getConflictsNumber = repetitionList => repetitionList.filter(rep => rep.hasConflicts).length;
 
+    const getDuplicatesNumber = repetitionList => repetitionList.filter(rep => rep.hasDuplicateKey).length;
+
     watch(selectedPerson, async () => {
       if (selectedPerson.value) await getRepetitions();
     });
@@ -249,6 +254,7 @@ export default {
       showDetails,
       formatQuantity,
       getConflictsNumber,
+      getDuplicatesNumber,
       // Validations
       v$,
     };

--- a/src/modules/vendor/components/programs/cards/CardContainer.vue
+++ b/src/modules/vendor/components/programs/cards/CardContainer.vue
@@ -18,7 +18,7 @@
               </div>
               <div>{{ getTemplateName(draggableCard.template) }}</div>
             </div>
-            <div v-if="!isSelected(draggableCard) && !draggableCard.isValid" :class="{ 'dot dot-error': true }" />
+            <div v-if="!isSelected(draggableCard) && !draggableCard.isValid" :class="{ 'dot dot-orange': true }" />
           </div>
         </template>
       </draggable>
@@ -197,7 +197,7 @@ export default {
       overflow: hidden
       text-overflow: ellipsis
 
-.dot-error
+.dot-orange
   align-self: center
 
 .ghost


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : ETQ Admin client / Coach / Planning referant
 
- Cas d'usage : Sur la page des repetitions d'un beneficiaire les doublons sont visibles

- Comment tester ? : 
  - creer des doublons sur le planning d'un beneficiaire
  - verifier qu'ils apparaissent sur la page de gestion des répétitions 

  - vérifier que l'affichage des points est correct sur: 
    - le répertoire beneficiaire + fiche beneficiaire (statut + onglet infos) 
        - arrêter un beneficiaire puis l'archiver
    -  repertoire auxiliaire + fiche auxiliaire
    - l'onglet organisation d'une formation (numéro manquant)
    - dans le catalogue, dans l'onglet sous-programme 
   
_Si tu as lu cette description, pense a réagir avec un :eye:_
