### PR TITLE
COM-2893 - fix customereInclTaxese and customerExclTaxes  on creditNotes

### DIFF
--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -187,8 +187,8 @@ export default {
         if (get(this.newCreditNote, 'billingItemList[0].billingItem')) {
           this.newCreditNote.exclTaxesCustomer = this.newCreditNote.billingItemList.reduce(
             (acc, bi) => {
-              const inclTaxes = multiply(bi.unitInclTaxes, bi.count);
-              const biExclTaxes = this.getExclTaxes(toFixedToFloat(inclTaxes), bi.vat);
+              const biInclTaxes = toFixedToFloat(multiply(bi.unitInclTaxes, bi.count));
+              const biExclTaxes = this.getExclTaxes(biInclTaxes, bi.vat);
               return bi.billingItem ? add(acc, biExclTaxes) : acc;
             },
             toString(0)
@@ -220,7 +220,8 @@ export default {
         if (get(this.editedCreditNote, 'billingItemList[0].billingItem')) {
           this.editedCreditNote.exclTaxesCustomer = this.editedCreditNote.billingItemList.reduce(
             (acc, bi) => {
-              const biExclTaxes = this.getExclTaxes(multiply(bi.unitInclTaxes, bi.count), bi.vat);
+              const biInclTaxes = toFixedToFloat(multiply(bi.unitInclTaxes, bi.count));
+              const biExclTaxes = this.getExclTaxes(biInclTaxes, bi.vat);
               return bi.billingItem ? add(acc, biExclTaxes) : acc;
             },
             toString(0)
@@ -228,7 +229,7 @@ export default {
 
           const inclTaxesCustomerString = this.editedCreditNote.billingItemList.reduce(
             (acc, bi) => {
-              const biInclTaxes = multiply(bi.unitInclTaxes, bi.count);
+              const biInclTaxes = toFixedToFloat(multiply(bi.unitInclTaxes, bi.count));
               return bi.billingItem ? add(acc, biInclTaxes) : acc;
             },
             toString(0)

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -187,7 +187,8 @@ export default {
         if (get(this.newCreditNote, 'billingItemList[0].billingItem')) {
           this.newCreditNote.exclTaxesCustomer = this.newCreditNote.billingItemList.reduce(
             (acc, bi) => {
-              const biExclTaxes = this.getExclTaxes(multiply(bi.unitInclTaxes, bi.count), bi.vat);
+              const inclTaxes = multiply(bi.unitInclTaxes, bi.count);
+              const biExclTaxes = toFixedToFloat(this.getExclTaxes(toFixedToFloat(inclTaxes), bi.vat));
               return bi.billingItem ? add(acc, biExclTaxes) : acc;
             },
             toString(0)
@@ -195,7 +196,7 @@ export default {
 
           const inclTaxesCustomerString = this.newCreditNote.billingItemList.reduce(
             (acc, bi) => {
-              const biInclTaxes = multiply(bi.unitInclTaxes, bi.count);
+              const biInclTaxes = toFixedToFloat(multiply(bi.unitInclTaxes, bi.count));
               return bi.billingItem ? add(acc, biInclTaxes) : acc;
             },
             toString(0)

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -188,7 +188,7 @@ export default {
           this.newCreditNote.exclTaxesCustomer = this.newCreditNote.billingItemList.reduce(
             (acc, bi) => {
               const inclTaxes = multiply(bi.unitInclTaxes, bi.count);
-              const biExclTaxes = toFixedToFloat(this.getExclTaxes(toFixedToFloat(inclTaxes), bi.vat));
+              const biExclTaxes = this.getExclTaxes(toFixedToFloat(inclTaxes), bi.vat);
               return bi.billingItem ? add(acc, biExclTaxes) : acc;
             },
             toString(0)

--- a/src/modules/client/pages/ni/billing/ManualBills.vue
+++ b/src/modules/client/pages/ni/billing/ManualBills.vue
@@ -49,7 +49,7 @@ import Bills from '@api/Bills';
 import TitleHeader from '@components/TitleHeader';
 import { NotifyPositive, NotifyNegative, NotifyWarning } from '@components/popup/notify';
 import { MANUAL } from '@data/constants';
-import { multiply, add } from '@helpers/numbers';
+import { multiply, add, toFixedToFloat } from '@helpers/numbers';
 import {
   formatAndSortIdentityOptions,
   formatAndSortOptions,
@@ -127,8 +127,11 @@ export default {
     watch(
       () => newManualBill.value.billingItemList,
       () => {
-        newManualBill.value.netInclTaxes = parseFloat(
-          newManualBill.value.billingItemList.reduce((acc, bi) => add(acc, multiply(bi.unitInclTaxes, bi.count)), 0)
+        newManualBill.value.netInclTaxes = toFixedToFloat(
+          newManualBill.value.billingItemList.reduce((acc, bi) => {
+            const inclTaxes = multiply(bi.unitInclTaxes, bi.count);
+            return add(acc, toFixedToFloat(inclTaxes));
+          }, 0)
         );
       },
       { deep: true }

--- a/src/modules/client/pages/ni/billing/ManualBills.vue
+++ b/src/modules/client/pages/ni/billing/ManualBills.vue
@@ -129,8 +129,8 @@ export default {
       () => {
         newManualBill.value.netInclTaxes = toFixedToFloat(
           newManualBill.value.billingItemList.reduce((acc, bi) => {
-            const inclTaxes = multiply(bi.unitInclTaxes, bi.count);
-            return add(acc, toFixedToFloat(inclTaxes));
+            const biInclTaxes = toFixedToFloat(multiply(bi.unitInclTaxes, bi.count));
+            return add(acc, biInclTaxes);
           }, 0)
         );
       },


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client admin

- Cas d'usage : Les montants figurant sur une facture manuelle et sur un avoir sur des articles de facturation sont justes.

Exemple de combinaison qui donnait des factures / avoirs avec des montants incohérents
<img width="503" alt="Capture d’écran 2022-07-21 à 17 56 12" src="https://user-images.githubusercontent.com/81675019/180259850-0a70404b-e620-49b3-b6da-9c271599bd01.png">


- Comment tester ? :
  - generer une facture manuelle
  - verifieer que tous les montants sont coherents (dans la modale de creation et sur la facture)
  - generer un avoir sur les articles de facturation
  - verifier que tous les montants sont coherents (dans la modale de creation et sur la facture)
  - vérifier que les montants sont justes dans la modale d'édition d'un avoir 

_Si tu as lu cette description, pense a réagir avec un :eye:_
