### PR TITLE
Com 2895

### DIFF
--- a/src/core/api/GoogleDrive.js
+++ b/src/core/api/GoogleDrive.js
@@ -26,7 +26,7 @@ export default {
   getUploadUrl (driveId) {
     return `${process.env.API_HOSTNAME}/gdrive/${driveId}/upload`;
   },
-  async downloadFileById (driveId, getHtmlFile = false) {
+  async downloadFileById (driveId, name, getHtmlFile = false) {
     const file = await alenviAxios({
       url: `${process.env.API_HOSTNAME}/gdrive/file/${driveId}/download`,
       method: 'GET',
@@ -36,6 +36,7 @@ export default {
     if (getHtmlFile) return file;
     const extension = getExtension(file.data.type);
 
-    return downloadFile(file, `download-${Date.now()}.${extension}`, 'application/octet-stream');
+    const fileName = name ? `${name}.${extension}` : `download-${Date.now()}.${extension}`;
+    return downloadFile(file, fileName, 'application/octet-stream');
   },
 };

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -155,10 +155,10 @@ export default {
   },
   computed: {
     commonDocName () {
-      const clientIdentity = `${this.customerIdentity.lastname}_${this.customerIdentity.firstname}_`;
+      const clientIdentity = `${this.customerIdentity.lastname}_${this.customerIdentity.firstname}`;
       if (this.type === CUSTOMER && this.isCoach) return clientIdentity;
       if (this.type === THIRD_PARTY_PAYER) {
-        return formatDownloadName(`${this.tppName}_${this.isCoach ? clientIdentity : ''}`);
+        return `${this.tppName}${this.isCoach ? ` ${clientIdentity}` : ''}`;
       }
       return '';
     },
@@ -241,7 +241,9 @@ export default {
 
         const pdf = await Bills.getPdf(bill._id);
 
-        downloadFile(pdf, `${this.commonDocName}${bill.number}.pdf`, 'application/octet-stream');
+        const date = formatDate(bill.date, 'DD/MM/YYYY');
+        const fileName = formatDownloadName(`${this.commonDocName} ${bill.number} ${date}.pdf`);
+        downloadFile(pdf, fileName, 'application/octet-stream');
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement de la facture');
@@ -257,7 +259,9 @@ export default {
         this.pdfLoading = true;
         const pdf = await CreditNotes.getPdf(cn._id);
 
-        downloadFile(pdf, `${this.commonDocName}${cn.number}.pdf`, 'application/octet-stream');
+        const date = formatDate(cn.date, 'DD/MM/YYYY');
+        const fileName = formatDownloadName(`${this.commonDocName} ${cn.number} ${date}.pdf`);
+        downloadFile(pdf, fileName, 'application/octet-stream');
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement de l\'avoir');

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -152,9 +152,9 @@ export default {
   },
   computed: {
     commonDocName () {
-      const clientIdentity = `${this.customerIdentity.lastname}_${this.customerIdentity.firstname}`;
+      const clientIdentity = `${this.customerIdentity.lastname} ${this.customerIdentity.firstname}`;
       if (this.type === CUSTOMER) return clientIdentity;
-      return `${this.tppName}${this.isCoach ? ` ${clientIdentity}` : ''}`;
+      return `${this.tppName} ${clientIdentity}`;
     },
   },
   methods: {
@@ -233,7 +233,7 @@ export default {
         const pdf = await Bills.getPdf(bill._id);
 
         const date = formatDate(bill.date, 'DD/MM/YYYY');
-        const fileName = formatDownloadName(`${this.commonDocName} ${bill.number} ${date}.pdf`);
+        const fileName = formatDownloadName(`${date} ${this.commonDocName} ${bill.number}.pdf`);
         downloadFile(pdf, fileName, 'application/octet-stream');
       } catch (e) {
         console.error(e);
@@ -251,7 +251,7 @@ export default {
         const pdf = await CreditNotes.getPdf(cn._id);
 
         const date = formatDate(cn.date, 'DD/MM/YYYY');
-        const fileName = formatDownloadName(`${this.commonDocName} ${cn.number} ${date}.pdf`);
+        const fileName = formatDownloadName(`${date} ${this.commonDocName} ${cn.number}.pdf`);
         downloadFile(pdf, fileName, 'application/octet-stream');
       } catch (e) {
         console.error(e);

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -108,6 +108,8 @@ export default {
     startBalance: { type: Number, default: 0 },
     endBalance: { type: Number, default: 0 },
     loading: { type: Boolean, default: false },
+    customerIdentity: { type: Object, default: () => ({}) },
+    tppName: { type: String, default: '' },
   },
   components: {
     'ni-simple-table': SimpleTable,
@@ -147,6 +149,13 @@ export default {
       pagination: { rowsPerPage: 0 },
       paymentTypes: PAYMENT_OPTIONS.map(op => op.value),
     };
+  },
+  computed: {
+    clientIdentityForDownloadDoc () {
+      const clientIdentity = `${this.customerIdentity.lastname}_${this.customerIdentity.firstname}`;
+      if (this.type === CUSTOMER) return clientIdentity;
+      return `${this.tppName.replaceAll(' ', '_')}_${clientIdentity}`;
+    },
   },
   methods: {
     balanceIconColor (val) {
@@ -220,8 +229,10 @@ export default {
 
       try {
         this.pdfLoading = true;
+
         const pdf = await Bills.getPdf(bill._id);
-        downloadFile(pdf, 'facture.pdf', 'application/octet-stream');
+
+        downloadFile(pdf, `${this.clientIdentityForDownloadDoc}_${bill.number}.pdf`, 'application/octet-stream');
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement de la facture');
@@ -236,7 +247,8 @@ export default {
       try {
         this.pdfLoading = true;
         const pdf = await CreditNotes.getPdf(cn._id);
-        downloadFile(pdf, 'avoir.pdf', 'application/octet-stream');
+
+        downloadFile(pdf, `${this.clientIdentityForDownloadDoc}_${cn.number}.pdf`, 'application/octet-stream');
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement de l\'avoir');

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -95,7 +95,7 @@ import {
   COMPANI,
   MANUAL,
 } from '@data/constants';
-import { formatPrice, truncate } from '@helpers/utils';
+import { formatPrice, truncate, formatDownloadName } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 import { downloadFile } from '@helpers/file';
 
@@ -158,7 +158,7 @@ export default {
       const clientIdentity = `${this.customerIdentity.lastname}_${this.customerIdentity.firstname}_`;
       if (this.type === CUSTOMER && this.isCoach) return clientIdentity;
       if (this.type === THIRD_PARTY_PAYER) {
-        return `${this.tppName.replaceAll(' ', '_')}_${this.isCoach ? clientIdentity : ''}`;
+        return formatDownloadName(`${this.tppName}_${this.isCoach ? clientIdentity : ''}`);
       }
       return '';
     },

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -90,7 +90,6 @@ import {
   REFUND,
   PAYMENT_OPTIONS,
   CUSTOMER,
-  THIRD_PARTY_PAYER,
   PAYMENT,
   COMPANI,
   MANUAL,
@@ -104,9 +103,7 @@ export default {
   props: {
     documents: { type: Array, default: () => [] },
     billingDates: { type: Object, default: () => ({}) },
-    isAdmin: { type: Boolean, default: false },
-    isCoach: { type: Boolean, default: false },
-    isArchived: { type: Boolean, default: false },
+    displayActions: { type: Boolean, default: false },
     type: { type: String, default: CUSTOMER },
     startBalance: { type: Number, default: 0 },
     endBalance: { type: Number, default: 0 },
@@ -156,14 +153,8 @@ export default {
   computed: {
     commonDocName () {
       const clientIdentity = `${this.customerIdentity.lastname}_${this.customerIdentity.firstname}`;
-      if (this.type === CUSTOMER && this.isCoach) return clientIdentity;
-      if (this.type === THIRD_PARTY_PAYER) {
-        return `${this.tppName}${this.isCoach ? ` ${clientIdentity}` : ''}`;
-      }
-      return '';
-    },
-    displayActions () {
-      return this.isAdmin && !this.isArchived;
+      if (this.type === CUSTOMER) return clientIdentity;
+      return `${this.tppName}${this.isCoach ? ` ${clientIdentity}` : ''}`;
     },
   },
   methods: {

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -158,6 +158,7 @@ export default {
     },
   },
   methods: {
+    formatDate,
     balanceIconColor (val) {
       return this.isZero(val) || !this.isNegative(val) ? 'copper-grey-400' : 'secondary';
     },
@@ -175,9 +176,6 @@ export default {
       const paymentOption = PAYMENT_OPTIONS.find(opt => opt.value === payment.type);
       const typeLabel = paymentOption ? ` (${paymentOption.label})` : '';
       return `${titlePrefix}${typeLabel}`;
-    },
-    formatDate (value) {
-      return formatDate(value);
     },
     formatPrice (value) {
       return formatPrice(value);
@@ -232,7 +230,7 @@ export default {
 
         const pdf = await Bills.getPdf(bill._id);
 
-        const date = formatDate(bill.date, 'DD/MM/YYYY');
+        const date = formatDate(bill.date);
         const fileName = formatDownloadName(`${date} ${this.commonDocName} ${bill.number}.pdf`);
         downloadFile(pdf, fileName, 'application/octet-stream');
       } catch (e) {
@@ -250,7 +248,7 @@ export default {
         this.pdfLoading = true;
         const pdf = await CreditNotes.getPdf(cn._id);
 
-        const date = formatDate(cn.date, 'DD/MM/YYYY');
+        const date = formatDate(cn.date);
         const fileName = formatDownloadName(`${date} ${this.commonDocName} ${cn.number}.pdf`);
         downloadFile(pdf, fileName, 'application/octet-stream');
       } catch (e) {

--- a/src/modules/client/components/customers/billing/CustomerBillingTable.vue
+++ b/src/modules/client/components/customers/billing/CustomerBillingTable.vue
@@ -105,6 +105,7 @@ export default {
     documents: { type: Array, default: () => [] },
     billingDates: { type: Object, default: () => ({}) },
     isAdmin: { type: Boolean, default: false },
+    isCoach: { type: Boolean, default: false },
     isArchived: { type: Boolean, default: false },
     type: { type: String, default: CUSTOMER },
     startBalance: { type: Number, default: 0 },
@@ -155,9 +156,9 @@ export default {
   computed: {
     commonDocName () {
       const clientIdentity = `${this.customerIdentity.lastname}_${this.customerIdentity.firstname}_`;
-      if (this.type === CUSTOMER && this.isAdmin) return clientIdentity;
+      if (this.type === CUSTOMER && this.isCoach) return clientIdentity;
       if (this.type === THIRD_PARTY_PAYER) {
-        return `${this.tppName.replaceAll(' ', '_')}_${this.isAdmin ? clientIdentity : ''}`;
+        return `${this.tppName.replaceAll(' ', '_')}_${this.isCoach ? clientIdentity : ''}`;
       }
       return '';
     },

--- a/src/modules/client/components/customers/billing/ProfileBilling.vue
+++ b/src/modules/client/components/customers/billing/ProfileBilling.vue
@@ -14,7 +14,7 @@
       <ni-customer-billing-table :documents="customerDocuments" :billing-dates="billingDates" :type="CUSTOMER"
         @open-edition-modal="openEditionModal" :start-balance="getStartBalance()" :loading="tableLoading"
         :end-balance="getEndBalance(customerDocuments)" :display-actions="isAdmin && !isArchived"
-        @delete="validateRefundDeletion($event, taxCertificates)" />
+        @delete="validateRefundDeletion($event, taxCertificates)" :customer-identity="customer.identity" />
       <div v-if="isAdmin" class="q-mt-md" align="right">
         <ni-button class="add-payment" label="Ajouter un réglement" @click="openPaymentCreationModal(customer)"
           color="white" icon="add" :disable="isArchived" />
@@ -25,7 +25,7 @@
       <ni-customer-billing-table :documents="tpp.documents" :billing-dates="billingDates"
         @open-edition-modal="openEditionModal" :type="THIRD_PARTY_PAYER" :start-balance="getStartBalance(tpp)"
         :end-balance="getEndBalance(tpp.documents, tpp)" :loading="tableLoading" @delete="validateRefundDeletion"
-        :display-actions="isAdmin && !isArchived" />
+        :display-actions="isAdmin && !isArchived" :tpp-name="tpp.name" />
       <div v-if="isAdmin" class="q-mt-md" align="right">
         <ni-button class="add-payment" label="Ajouter un réglement" color="white" icon="add" :disable="isArchived"
           @click="openPaymentCreationModal(customer, tpp.documents[0].thirdPartyPayer)" />

--- a/src/modules/client/components/customers/billing/ProfileBilling.vue
+++ b/src/modules/client/components/customers/billing/ProfileBilling.vue
@@ -13,9 +13,8 @@
       </div>
       <ni-customer-billing-table :documents="customerDocuments" :billing-dates="billingDates" :type="CUSTOMER"
         @open-edition-modal="openEditionModal" :start-balance="getStartBalance()" :loading="tableLoading"
-        :end-balance="getEndBalance(customerDocuments)" :is-admin="isAdmin" :is-coach="isCoach"
-        :is-archived="!isArchived" @delete="validateRefundDeletion($event, taxCertificates)"
-        :customer-identity="customer.identity" />
+        :end-balance="getEndBalance(customerDocuments)" :display-actions="isAdmin && !isArchived"
+        @delete="validateRefundDeletion($event, taxCertificates)" :customer-identity="customer.identity" />
       <div v-if="isAdmin" class="q-mt-md" align="right">
         <ni-button class="add-payment" label="Ajouter un réglement" @click="openPaymentCreationModal(customer)"
           color="white" icon="add" :disable="isArchived" />
@@ -26,8 +25,7 @@
       <ni-customer-billing-table :documents="tpp.documents" :billing-dates="billingDates"
         @open-edition-modal="openEditionModal" :type="THIRD_PARTY_PAYER" :start-balance="getStartBalance(tpp)"
         :end-balance="getEndBalance(tpp.documents, tpp)" :loading="tableLoading" @delete="validateRefundDeletion"
-        :is-admin="isAdmin" :is-coach="isCoach" :is-archived="!isArchived" :tpp-name="tpp.name"
-        :customer-identity="customer.identity" />
+        :display-actions="isAdmin && !isArchived" :tpp-name="tpp.name" :customer-identity="customer.identity" />
       <div v-if="isAdmin" class="q-mt-md" align="right">
         <ni-button class="add-payment" label="Ajouter un réglement" color="white" icon="add" :disable="isArchived"
           @click="openPaymentCreationModal(customer, tpp.documents[0].thirdPartyPayer)" />
@@ -137,7 +135,6 @@ export default {
     const $store = useStore();
     const customer = computed(() => $store.state.customer.customer);
     const clientRole = computed(() => $store.getters['main/getClientRole']);
-    const isCoach = computed(() => COACH_ROLES.includes(clientRole.value));
     const isHelper = computed(() => HELPER === clientRole.value);
     const isAdmin = computed(() => CLIENT_ADMIN === clientRole.value);
 
@@ -170,7 +167,7 @@ export default {
       downloadTaxCertificate,
       validateTaxCertificateDeletion,
       taxCertificatesValidation,
-    } = useTaxCertificates(customer, isCoach);
+    } = useTaxCertificates(customer);
 
     const tableLoading = ref(false);
     const refresh = async () => {
@@ -231,7 +228,6 @@ export default {
       customer,
       taxCertificateFileError,
       taxCertificateYearError,
-      isCoach,
       isAdmin,
       isHelper,
       clientRole,

--- a/src/modules/client/components/customers/billing/ProfileBilling.vue
+++ b/src/modules/client/components/customers/billing/ProfileBilling.vue
@@ -137,6 +137,7 @@ export default {
     const clientRole = computed(() => $store.getters['main/getClientRole']);
     const isHelper = computed(() => HELPER === clientRole.value);
     const isAdmin = computed(() => CLIENT_ADMIN === clientRole.value);
+    const isCoach = computed(() => COACH_ROLES.includes(clientRole.value));
 
     const {
       billingDates,
@@ -230,7 +231,7 @@ export default {
       taxCertificateYearError,
       isAdmin,
       isHelper,
-      clientRole,
+      isCoach,
       // Validations
       v$,
       taxCertificatesValidation,

--- a/src/modules/client/components/customers/billing/ProfileBilling.vue
+++ b/src/modules/client/components/customers/billing/ProfileBilling.vue
@@ -13,7 +13,7 @@
       </div>
       <ni-customer-billing-table :documents="customerDocuments" :billing-dates="billingDates" :type="CUSTOMER"
         @open-edition-modal="openEditionModal" :start-balance="getStartBalance()" :loading="tableLoading"
-        :end-balance="getEndBalance(customerDocuments)" :display-actions="isAdmin && !isArchived"
+        :end-balance="getEndBalance(customerDocuments)" :is-admin="isAdmin" :is-archived="!isArchived"
         @delete="validateRefundDeletion($event, taxCertificates)" :customer-identity="customer.identity" />
       <div v-if="isAdmin" class="q-mt-md" align="right">
         <ni-button class="add-payment" label="Ajouter un réglement" @click="openPaymentCreationModal(customer)"
@@ -25,7 +25,7 @@
       <ni-customer-billing-table :documents="tpp.documents" :billing-dates="billingDates"
         @open-edition-modal="openEditionModal" :type="THIRD_PARTY_PAYER" :start-balance="getStartBalance(tpp)"
         :end-balance="getEndBalance(tpp.documents, tpp)" :loading="tableLoading" @delete="validateRefundDeletion"
-        :display-actions="isAdmin && !isArchived" :tpp-name="tpp.name" />
+        :is-admin="isAdmin" :is-archived="!isArchived" :tpp-name="tpp.name" :customer-identity="customer.identity" />
       <div v-if="isAdmin" class="q-mt-md" align="right">
         <ni-button class="add-payment" label="Ajouter un réglement" color="white" icon="add" :disable="isArchived"
           @click="openPaymentCreationModal(customer, tpp.documents[0].thirdPartyPayer)" />

--- a/src/modules/client/composables/taxCertificates.js
+++ b/src/modules/client/composables/taxCertificates.js
@@ -10,7 +10,7 @@ import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup
 import { REQUIRED_LABEL } from '@data/constants';
 import { downloadFile } from '@helpers/file';
 import moment from '@helpers/moment';
-import { formatIdentity } from '@helpers/utils';
+import { formatIdentity, formatDownloadName } from '@helpers/utils';
 import { validYear } from '@helpers/vuelidateCustomVal';
 
 export const useTaxCertificates = (customer, isCoach) => {
@@ -99,7 +99,9 @@ export const useTaxCertificates = (customer, isCoach) => {
 
   const taxCertificateDocName = (tc, customerIdentity) => {
     const commonDocName = `attestation_fiscale_${tc.year}`;
-    if (isCoach.value) return `${customerIdentity.lastname}_${customerIdentity.firstname}_${commonDocName}`;
+    if (isCoach.value) {
+      return formatDownloadName(`${customerIdentity.lastname}_${customerIdentity.firstname}_${commonDocName}`);
+    }
     return commonDocName;
   };
 

--- a/src/modules/client/composables/taxCertificates.js
+++ b/src/modules/client/composables/taxCertificates.js
@@ -13,7 +13,7 @@ import moment from '@helpers/moment';
 import { formatIdentity, formatDownloadName } from '@helpers/utils';
 import { validYear } from '@helpers/vuelidateCustomVal';
 
-export const useTaxCertificates = (customer, isCoach) => {
+export const useTaxCertificates = (customer) => {
   const $q = useQuasar();
   const taxCertificates = ref([]);
   const taxCertificateModal = ref(false);
@@ -99,10 +99,7 @@ export const useTaxCertificates = (customer, isCoach) => {
 
   const taxCertificateDocName = (tc, customerIdentity) => {
     const commonDocName = `attestation_fiscale ${tc.year}`;
-    if (isCoach.value) {
-      return formatDownloadName(`${customerIdentity.lastname} ${customerIdentity.firstname} ${commonDocName}`);
-    }
-    return formatDownloadName(commonDocName);
+    return formatDownloadName(`${customerIdentity.lastname} ${customerIdentity.firstname} ${commonDocName}`);
   };
 
   const downloadTaxCertificateFromDrive = async (tc) => {

--- a/src/modules/client/composables/taxCertificates.js
+++ b/src/modules/client/composables/taxCertificates.js
@@ -98,11 +98,11 @@ export const useTaxCertificates = (customer, isCoach) => {
   };
 
   const taxCertificateDocName = (tc, customerIdentity) => {
-    const commonDocName = `attestation_fiscale_${tc.year}`;
+    const commonDocName = `attestation_fiscale ${tc.year}`;
     if (isCoach.value) {
-      return formatDownloadName(`${customerIdentity.lastname}_${customerIdentity.firstname}_${commonDocName}`);
+      return formatDownloadName(`${customerIdentity.lastname} ${customerIdentity.firstname} ${commonDocName}`);
     }
-    return commonDocName;
+    return formatDownloadName(commonDocName);
   };
 
   const downloadTaxCertificateFromDrive = async (tc) => {

--- a/src/modules/client/composables/taxCertificates.js
+++ b/src/modules/client/composables/taxCertificates.js
@@ -97,7 +97,7 @@ export const useTaxCertificates = (customer) => {
     }
   };
 
-  const taxCertificateDocName = (tc, customerIdentity) => {
+  const getTaxCertificateDocName = (tc, customerIdentity) => {
     const fileName = `${tc.year} ${customerIdentity.lastname} ${customerIdentity.firstname} attestation_fiscale`;
     return formatDownloadName(fileName);
   };
@@ -108,7 +108,7 @@ export const useTaxCertificates = (customer) => {
 
       await GoogleDrive.downloadFileById(
         get(tc, 'driveFile.driveId'),
-        taxCertificateDocName(tc, customer.value.identity)
+        getTaxCertificateDocName(tc, customer.value.identity)
       );
     } catch (e) {
       console.error(e);
@@ -125,7 +125,7 @@ export const useTaxCertificates = (customer) => {
 
       const pdf = await TaxCertificates.getPdf(tc._id);
 
-      downloadFile(pdf, `${taxCertificateDocName(tc, customer.value.identity)}.pdf`, 'application/octet-stream');
+      downloadFile(pdf, `${getTaxCertificateDocName(tc, customer.value.identity)}.pdf`, 'application/octet-stream');
     } catch (e) {
       console.error(e);
       NotifyNegative('Erreur lors du téléchargement de l\'attestation fiscale');

--- a/src/modules/client/composables/taxCertificates.js
+++ b/src/modules/client/composables/taxCertificates.js
@@ -98,8 +98,8 @@ export const useTaxCertificates = (customer) => {
   };
 
   const taxCertificateDocName = (tc, customerIdentity) => {
-    const commonDocName = `attestation_fiscale ${tc.year}`;
-    return formatDownloadName(`${customerIdentity.lastname} ${customerIdentity.firstname} ${commonDocName}`);
+    const fileName = `${tc.year} ${customerIdentity.lastname} ${customerIdentity.firstname} attestation_fiscale`;
+    return formatDownloadName(fileName);
   };
 
   const downloadTaxCertificateFromDrive = async (tc) => {

--- a/src/modules/client/pages/customers/Subscriptions.vue
+++ b/src/modules/client/pages/customers/Subscriptions.vue
@@ -442,7 +442,7 @@ export default {
         const gcsDriveId = get(this.helper, 'company.customersConfig.templates.gcs.driveId');
         if (!gcsDriveId) return;
 
-        const file = await GoogleDrive.downloadFileById(gcsDriveId, true);
+        const file = await GoogleDrive.downloadFileById(gcsDriveId, 'gcs', true);
 
         this.gcs = file.data;
       } catch (e) {

--- a/src/modules/client/pages/ni/billing/TppBillSlips.vue
+++ b/src/modules/client/pages/ni/billing/TppBillSlips.vue
@@ -9,7 +9,7 @@
             :style="col.style" class="text-capitalize">
             <template v-if="col.name === 'document'">
               <div class="row justify-center table-actions">
-                <q-btn flat round small color="primary" @click="downloadBillSlip(col.value)" icon="file_download" />
+                <q-btn flat round small color="primary" @click="downloadBillSlip(props.row)" icon="file_download" />
               </div>
             </template>
             <template v-else>{{ col.value }}</template>
@@ -102,10 +102,11 @@ export default {
         this.loading = false;
       }
     },
-    async downloadBillSlip (id) {
+    async downloadBillSlip (billSlip) {
       try {
-        const docx = await BillSlip.getDocx(id);
-        downloadDocx(docx, 'bordereau.docx');
+        const docx = await BillSlip.getDocx(billSlip._id);
+        const tppName = billSlip.thirdPartyPayer.name.replaceAll(' ', '_');
+        downloadDocx(docx, `${billSlip.month}_${tppName}_${billSlip.number}.docx`);
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement des bordereaux.');

--- a/src/modules/client/pages/ni/billing/TppBillSlips.vue
+++ b/src/modules/client/pages/ni/billing/TppBillSlips.vue
@@ -108,7 +108,7 @@ export default {
 
         const docx = await BillSlip.getDocx(_id);
 
-        downloadDocx(docx, formatDownloadName(`${month}_${thirdPartyPayer.name}_${number}.docx`));
+        downloadDocx(docx, formatDownloadName(`${month} ${thirdPartyPayer.name} ${number}.docx`));
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement des bordereaux.');

--- a/src/modules/client/pages/ni/billing/TppBillSlips.vue
+++ b/src/modules/client/pages/ni/billing/TppBillSlips.vue
@@ -27,7 +27,7 @@ import BillSlip from '@api/BillSlips';
 import SimpleTable from '@components/table/SimpleTable';
 import TitleHeader from '@components/TitleHeader';
 import { NotifyNegative, NotifyPositive } from '@components/popup/notify';
-import { formatPrice } from '@helpers/utils';
+import { formatPrice, formatDownloadName } from '@helpers/utils';
 import moment from '@helpers/moment';
 import { downloadDocx } from '@helpers/file';
 
@@ -104,9 +104,11 @@ export default {
     },
     async downloadBillSlip (billSlip) {
       try {
-        const docx = await BillSlip.getDocx(billSlip._id);
-        const tppName = billSlip.thirdPartyPayer.name.replaceAll(' ', '_');
-        downloadDocx(docx, `${billSlip.month}_${tppName}_${billSlip.number}.docx`);
+        const { _id, month, thirdPartyPayer, number } = billSlip;
+
+        const docx = await BillSlip.getDocx(_id);
+
+        downloadDocx(docx, formatDownloadName(`${month}_${thirdPartyPayer.name}_${number}.docx`));
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du téléchargement des bordereaux.');


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : client / coach-admin-aidant

- Cas d'usage : Je peux télécharger les factures, avoirs, attestations fiscales et bordereaux tiers payeurs avec un nom plus explicite (1ere PR cote client, il reste des fichiers à gérer) 

- Comment tester ? : 
    - Vérifier qu'ils ont bien le bon nom (j'ai un peu changé par rapport au ticket)
    - Sur la page facturation d'un beneficiaire (cote aidant et coach/admin) 
        - Verifier que les aidants ne peuvent rien modifier
        - Verifier que les coachs 
        - Vérifier que les admins peuvent tout faire 
    -  Vérifier que les aidants peuvent voir correctement les cgs
    - Pour les attestations fiscales : telecharger une attestation fiscale existante (générée automatiquement) + en televerser une (elle existe alors sur le drive) et la telecharger. 

_Si tu as lu cette description, pense a réagir avec un :eye:_
