### PR TITLE
COM-2970 - allow negative discount

### DIFF
--- a/src/modules/client/components/table/ToBillRow.vue
+++ b/src/modules/client/components/table/ToBillRow.vue
@@ -114,7 +114,7 @@ export default {
     };
 
     const setDiscount = ({ value, obj, path }) => {
-      obj[path] = !value || isNaN(value) || value < 0 ? 0 : parseFloat(divide(Math.trunc(multiply(value, 100)), 100));
+      obj[path] = !value || isNaN(value) ? 0 : parseFloat(divide(Math.trunc(multiply(value, 100)), 100));
       emit('discount-input');
     };
 


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Admin client

- Cas d'usage : Sur la page A facturer, je peux enregistrer une remise négative

- Comment tester ? :
  - Sur la page A facturer, je peux enregistrer une remise négative
  - Sur le PDF de la facture, la remise apparait en positif et incrémente le montant final

_Si tu as lu cette description, pense a réagir avec un :eye:_
