### PR TITLE
COM-2972 add companiDate

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@quasar/cli": "^1.3.2",
     "@quasar/quasar-app-extension-testing": "^2.0.4",
     "@quasar/quasar-app-extension-testing-e2e-cypress": "^4.1.2",
+    "@types/luxon": "^3.0.0",
     "@vue/cli-service": "^5.0.4",
     "@vue/eslint-config-airbnb": "^6.0.0",
     "eslint": "^8.17.0",
@@ -63,7 +64,7 @@
     "eslint-plugin-vue": "^9.1.0",
     "eslint-webpack-plugin": "^3.1.1",
     "html-loader": "^3.0.1",
-    "luxon": "^2.4.0"
+    "luxon": "^2.5.0"
   },
   "engines": {
     "node": "14.18.0",

--- a/src/core/components/courses/BlendedCourseProfileHeader.vue
+++ b/src/core/components/courses/BlendedCourseProfileHeader.vue
@@ -15,7 +15,7 @@ import ProfileHeader from '@components/ProfileHeader';
 import Button from '@components/Button';
 import { NotifyPositive, NotifyNegative } from '@components/popup/notify';
 import { VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER } from '@data/constants';
-import moment from '@helpers/moment';
+import companiDate from '@helpers/dates/companiDate';
 
 export default {
   name: 'BlendedCourseProfileHeader',
@@ -43,7 +43,7 @@ export default {
     displayArchiveButton () {
       const vendorRole = this.$store.getters['main/getVendorRole'];
       const isAdmin = [VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER].includes(vendorRole);
-      const areAllCourseSlotsEnded = this.course.slots.every(slot => moment().isAfter(slot.endDate)) &&
+      const areAllCourseSlotsEnded = this.course.slots.every(slot => companiDate().isAfter(slot.endDate)) &&
         !this.course.slotsToPlan.length;
 
       return !this.course.archivedAt && areAllCourseSlotsEnded && isAdmin;
@@ -69,7 +69,7 @@ export default {
     },
     async archiveCourse () {
       try {
-        const payload = { archivedAt: new Date() };
+        const payload = { archivedAt: companiDate().toISO() };
         await Courses.update(this.course._id, payload);
 
         NotifyPositive('Formation archivée.');

--- a/src/core/helpers/dates/companiDate.js
+++ b/src/core/helpers/dates/companiDate.js
@@ -1,0 +1,3 @@
+import { CompaniDateFactory, formatMiscToCompaniDate } from './companiDateFactory';
+
+export default (...args) => CompaniDateFactory(formatMiscToCompaniDate(...args));

--- a/src/core/helpers/dates/companiDateFactory.js
+++ b/src/core/helpers/dates/companiDateFactory.js
@@ -1,0 +1,111 @@
+import pick from 'lodash/pick';
+import { DateTime } from './luxon';
+
+export const CompaniDateFactory = (inputDate) => {
+  const _date = inputDate;
+
+  return ({
+    // GETTER
+    get _getDate () {
+      return _date;
+    },
+
+    getUnits (units) {
+      return pick(_date.toObject(), units);
+    },
+
+    weekday () {
+      return _date.weekday - 1;
+      /*  fox luxon:  1 = Monday, 2 = Tuesday, ... 7 = Sunday
+          for us:     0 = Monday, 1 = Tuesday, ... 6 = Sunday. cf constants.js */
+    },
+
+    // DISPLAY
+    format (fmt) {
+      return _date.toFormat(fmt);
+    },
+
+    toDate () {
+      return _date.toUTC().toJSDate();
+    },
+
+    toISO () {
+      return _date.toUTC().toISO();
+    },
+
+    toLocalISO () {
+      return _date.toLocal().toISO();
+    },
+
+    // QUERY
+    isBefore (miscTypeOtherDate, unit = 'millisecond') {
+      const otherDate = formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return _date.startOf(unit) < otherDate.startOf(unit);
+    },
+
+    isAfter (miscTypeOtherDate, unit = 'millisecond') {
+      const otherDate = formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return _date.startOf(unit) > otherDate.startOf(unit);
+    },
+
+    isSame (miscTypeOtherDate, unit = 'millisecond') {
+      const otherDate = formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return _date.hasSame(otherDate, unit);
+    },
+
+    isSameOrBefore (miscTypeOtherDate, unit = 'millisecond') {
+      const otherDate = formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return (_date.hasSame(otherDate, unit) || _date.startOf(unit) < otherDate.startOf(unit));
+    },
+
+    isSameOrAfter (miscTypeOtherDate, unit = 'millisecond') {
+      const otherDate = formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return (_date.hasSame(otherDate, unit) || _date.startOf(unit) > otherDate.startOf(unit));
+    },
+
+    isSameOrBetween (miscTypeFirstDate, miscTypeSecondDate, unit = 'millisecond') {
+      const firstDate = formatMiscToCompaniDate(miscTypeFirstDate);
+      const secondDate = formatMiscToCompaniDate(miscTypeSecondDate);
+
+      return (_date.hasSame(firstDate, unit) || _date.hasSame(secondDate, unit) ||
+        (_date.startOf(unit) > firstDate.startOf(unit) && _date.startOf(unit) < secondDate.startOf(unit)));
+    },
+
+    // MANIPULATE
+    startOf (unit) {
+      return CompaniDateFactory(_date.startOf(unit));
+    },
+
+    endOf (unit) {
+      return CompaniDateFactory(_date.endOf(unit));
+    },
+
+    set (values) {
+      return CompaniDateFactory(_date.set(values));
+    },
+  });
+};
+
+export const formatMiscToCompaniDate = (...args) => {
+  if (!args.length) return DateTime.now();
+
+  if (args.length === 1) {
+    if (args[0] instanceof Object && args[0]._getDate && args[0]._getDate instanceof DateTime) {
+      return args[0]._getDate;
+    }
+    if (args[0] instanceof Date) return DateTime.fromJSDate(args[0]);
+    if (typeof args[0] === 'string' && args[0] !== '') return DateTime.fromISO(args[0]);
+  }
+
+  if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {
+    const options = args[0].endsWith('Z') ? { zone: 'utc' } : {};
+    return DateTime.fromFormat(args[0], args[1], options);
+  }
+
+  return DateTime.invalid('wrong arguments');
+};

--- a/src/core/helpers/dates/luxon.js
+++ b/src/core/helpers/dates/luxon.js
@@ -1,0 +1,7 @@
+import * as luxon from 'luxon';
+
+luxon.Settings.defaultLocale = 'fr';
+luxon.Settings.defaultZone = 'Europe/Paris';
+luxon.Settings.throwOnInvalid = true;
+
+export { DateTime } from 'luxon';


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : tous

- Cas d'usage : 
   - ajout de la factory `companiDate`
   - migration d'un petit fichier pour tester

- Comment tester ? :
   - Sur la page d'une formation, verifier que le bouton "Archiver"
     - OK : apparait lorsque tous les créneaux sont terminés et que lq formation n'est pas encore archivée 
     - KO : n'apparait pas lorsque tous les créneaux sont terminés et que est archivée
     - KO n'aprait pas qd un des créneaux n'est pas passé
   - verifier que les setting s'appliquent bien. Pour ca on peut importer Setting de 'luxon' n'importe ou dans l'app et faire un console.log de chaque `Settings.XXX`.

_Si tu as lu cette description, pense a réagir avec un :eye:_
