### PR TITLE
COM-2931: refacto colors

### DIFF
--- a/src/core/components/PictureUploader.vue
+++ b/src/core/components/PictureUploader.vue
@@ -67,9 +67,6 @@ export default {
     pictureLink () {
       return get(this.user, 'picture.link') || null;
     },
-    canvasColor () {
-      return /\/ad\//.test(this.$route.path) ? '#FFEDDA' : '#EEE';
-    },
     noDiacriticLastname () {
       return removeDiacritics(get(this.user, 'identity.lastname') || '');
     },

--- a/src/core/components/table/ResponsiveTable.vue
+++ b/src/core/components/table/ResponsiveTable.vue
@@ -3,7 +3,7 @@
     <q-table v-if="!loading" :rows="data" :columns="columns" :row-key="rowKey" :pagination="pagination"
       binary-state-sort :visible-columns="formattedVisibleColumns" flat :separator="data.length ? separator : 'none'"
       :hide-bottom="hideBottom" :rows-per-page-options="rowsPerPageOptions" class="table-responsive q-pa-sm"
-      @update:pagination="$emit('update:pagination', $event)" @row-click="$emit('row-click')" :color="'#ff0000'">
+      @update:pagination="$emit('update:pagination', $event)" @row-click="$emit('row-click')">
       <template #header="props">
         <slot name="header" :props="props">
           <q-tr :props="props">

--- a/src/css/quasar.variables.sass
+++ b/src/css/quasar.variables.sass
@@ -23,13 +23,13 @@ $copper-100: #DAF2EE
 $copper-50: #F0FAF7
 
 // ORANGE
-$orange-900: #78350F
-$orange-800: #92400E
-$orange-700: #B45309
+$orange-900: #7B341E
+$orange-800: #9C4221
+$orange-700: #C05621
 $orange-600: #DD6B20
-$orange-500: #F5970B
-$orange-400: #F9B233
-$orange-300: #FCC74D
+$orange-500: #ED8936
+$orange-400: #F6A555
+$orange-300: #FBC88D
 $orange-200: #FEE7C8
 $orange-100: #FFF7EB
 $orange-50: #FFFBEB

--- a/src/modules/client/components/planning/Planning.vue
+++ b/src/modules/client/components/planning/Planning.vue
@@ -362,7 +362,7 @@ th:first-child
       padding-bottom: 1rem
 
 .to-assign
-  background-color: rgba(253, 243, 229, 0.5)
+  background-color: rgba(255, 237, 218, 0.5)
 
 .q-page-sticky
   z-index: 20


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de MES](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/mE8PaaeZN7) et [MEP](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/VSKy3bsY9C) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : tous

- Cas d'usage : refacto couleur

- Comment tester ? : vérifier que les composants suivants s'affichent bien au niveau des couleurs : 
  - planning auxilaires (ligne orange "à affecter")
  - les responsivetable (ex: liste des apprenants à une formation, liste des coach, etc)
  - uploader de photo (sur la fiche profil par exemple)
  - plus globalement se balader sur l'app et vérifier que le orange s'affiche bien

_Si tu as lu cette description, pense a réagir avec un :eye:_
