### PR TITLE
COM-2980 - add maxTrainees to intra courses

### DIFF
--- a/src/modules/vendor/components/courses/CourseCreationModal.vue
+++ b/src/modules/vendor/components/courses/CourseCreationModal.vue
@@ -19,6 +19,10 @@
         :error="validations.company.$error" @update:model-value="update($event, 'company')" />
       <ni-date-input caption="Date de démarrage souhaitée" :model-value="newCourse.estimatedStartDate" in-modal
         @update:model-value="update($event, 'estimatedStartDate')" />
+      <ni-input v-if="isIntraCourse" in-modal required-field caption="Nombre d'inscrits max"
+        :model-value="newCourse.maxTrainees" @blur="validations.maxTrainees.$touch"
+        :error="validations.maxTrainees.$error" :error-message="maxTraineesErrorMessage"
+        @update:model-value="update($event, 'maxTrainees')" />
       <ni-input in-modal :model-value="newCourse.misc" @update:model-value="update($event.trim(), 'misc')"
         caption="Informations Complémentaires" />
       <template #footer>
@@ -36,7 +40,7 @@ import Select from '@components/form/Select';
 import DateInput from '@components/form/DateInput';
 import OptionGroup from '@components/form/OptionGroup';
 import Input from '@components/form/Input';
-import { COURSE_TYPES } from '@data/constants';
+import { COURSE_TYPES, REQUIRED_LABEL } from '@data/constants';
 import { formatAndSortOptions } from '@helpers/utils';
 
 export default {
@@ -72,6 +76,14 @@ export default {
         .map(p => ({ label: p.name, value: p._id, disable: !get(p, 'subPrograms.length') }))
         .sort((a, b) => a.label.localeCompare(b.label));
     },
+    maxTraineesErrorMessage () {
+      if (get(this.validations, 'maxTrainees.required.$response') === false) return REQUIRED_LABEL;
+      if (get(this.validations, 'maxTrainees.strictPositiveNumber.$response') === false ||
+        get(this.validations, 'maxTrainees.integerNumber.$response') === false) {
+        return 'Nombre non valide';
+      }
+      return '';
+    },
   },
   watch: {
     'newCourse.program': function (value) {
@@ -100,7 +112,7 @@ export default {
       this.$emit('submit');
     },
     updateType (event) {
-      this.$emit('update:new-course', { ...omit(this.newCourse, 'company'), type: event });
+      this.$emit('update:new-course', { ...omit(this.newCourse, ['company', 'maxTrainees']), type: event });
     },
     update (event, prop) {
       this.$emit('update:new-course', { ...this.newCourse, [prop]: event });

--- a/src/modules/vendor/components/courses/CourseCreationModal.vue
+++ b/src/modules/vendor/components/courses/CourseCreationModal.vue
@@ -19,7 +19,7 @@
         :error="validations.company.$error" @update:model-value="update($event, 'company')" />
       <ni-date-input caption="Date de démarrage souhaitée" :model-value="newCourse.estimatedStartDate" in-modal
         @update:model-value="update($event, 'estimatedStartDate')" />
-      <ni-input v-if="isIntraCourse" in-modal required-field caption="Nombre d'inscrits max"
+      <ni-input v-if="isIntraCourse" in-modal required-field type="number" caption="Nombre d'inscrits max"
         :model-value="newCourse.maxTrainees" @blur="validations.maxTrainees.$touch"
         :error="validations.maxTrainees.$error" :error-message="maxTraineesErrorMessage"
         @update:model-value="update($event, 'maxTrainees')" />

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -49,7 +49,7 @@ import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup
 import { INTRA, COURSE_TYPES, BLENDED, TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN } from '@data/constants';
 import { courseFiltersMixin } from '@mixins/courseFiltersMixin';
 import { formatAndSortOptions, formatAndSortIdentityOptions } from '@helpers/utils';
-import { minDate, maxDate } from '@helpers/vuelidateCustomVal';
+import { minDate, maxDate, strictPositiveNumber, integerNumber } from '@helpers/vuelidateCustomVal';
 
 export default {
   name: 'BlendedCoursesDirectory',
@@ -78,6 +78,7 @@ export default {
         type: INTRA,
         salesRepresentative: '',
         estimatedStartDate: '',
+        maxTrainees: 8,
       },
       programs: [],
       courseCreationModal: false,
@@ -92,9 +93,10 @@ export default {
       newCourse: {
         program: { required },
         subProgram: { required },
-        company: { required: requiredIf(this.newCourse.type === INTRA) },
+        company: { required: requiredIf(this.isIntraCourse) },
         type: { required },
         salesRepresentative: { required },
+        ...(this.isIntraCourse && { maxTrainees: { required, strictPositiveNumber, integerNumber } }),
       },
       selectedStartDate: { maxDate: this.selectedEndDate ? maxDate(this.selectedEndDate) : '' },
       selectedEndDate: { minDate: this.selectedStartDate ? minDate(this.selectedStartDate) : '' },
@@ -159,6 +161,7 @@ export default {
         type: INTRA,
         salesRepresentative: '',
         estimatedStartDate: '',
+        maxTrainees: 8,
       };
     },
     async createCourse () {

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -32,7 +32,7 @@
 <script>
 import { useMeta } from 'quasar';
 import useVuelidate from '@vuelidate/core';
-import { required, requiredIf } from '@vuelidate/validators';
+import { required } from '@vuelidate/validators';
 import { mapState } from 'vuex';
 import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
@@ -93,10 +93,12 @@ export default {
       newCourse: {
         program: { required },
         subProgram: { required },
-        company: { required: requiredIf(this.isIntraCourse) },
         type: { required },
         salesRepresentative: { required },
-        ...(this.isIntraCourse && { maxTrainees: { required, strictPositiveNumber, integerNumber } }),
+        ...(this.isIntraCourse && {
+          maxTrainees: { required, strictPositiveNumber, integerNumber },
+          company: { required },
+        }),
       },
       selectedStartDate: { maxDate: this.selectedEndDate ? maxDate(this.selectedEndDate) : '' },
       selectedEndDate: { minDate: this.selectedStartDate ? minDate(this.selectedStartDate) : '' },


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : ROF

- Cas d'usage : depuis le kanban des formations, quand je crée une formation mixte INTRA, je peux définir un nombre max d'inscrits

- Comment tester ? 
    - lancer le script mep66.js 
    - creer une formation mixte intra
         - tester les validations du champ "Nombre d'inscrits max"
    - creer une formation inter   

_Si tu as lu cette description, pense à réagir avec un :eye:_
