### PR TITLE
COM-2983: can't show activity on non-elearning step

### DIFF
--- a/src/modules/vendor/components/programs/ProfileContent.vue
+++ b/src/modules/vendor/components/programs/ProfileContent.vue
@@ -12,9 +12,9 @@
         :disabled="$q.platform.is.mobile || isPublished(subProgram)" item-key="_id">
         <template #item="{element: step, index: stepIndex}">
           <q-card flat class="step q-mb-sm">
-            <q-card-section class="step-head cursor-pointer row" :id="step._id"
-              :class="{ 'step-lock': isLocked(step) }">
-              <div class="step-info" @click="showActivities(step._id)">
+            <q-card-section :id="step._id" :class="{ 'step-lock': isLocked(step), 'step-head row': true,
+              'cursor-pointer': step.type === E_LEARNING }">
+              <div class="step-info" @click="showActivities(step._id, step.type)">
                 <q-item-section side>
                   <q-icon :name="getStepTypeIcon(step.type)" size="sm" color="copper-grey-500" />
                 </q-item-section>
@@ -131,7 +131,7 @@ import SubPrograms from '@api/SubPrograms';
 import Steps from '@api/Steps';
 import Input from '@components/form/Input';
 import { NotifyNegative, NotifyWarning, NotifyPositive } from '@components/popup/notify';
-import { ACTIVITY_TYPES, PUBLISHED, PUBLISHED_DOT_ACTIVE, PUBLISHED_DOT_WARNING } from '@data/constants';
+import { ACTIVITY_TYPES, PUBLISHED, PUBLISHED_DOT_ACTIVE, PUBLISHED_DOT_WARNING, E_LEARNING } from '@data/constants';
 import { getStepTypeLabel, getStepTypeIcon } from '@helpers/courses';
 import { formatQuantity } from '@helpers/utils';
 import { formatDurationFromFloat } from '@helpers/date';
@@ -337,7 +337,8 @@ export default {
       const type = ACTIVITY_TYPES.find(t => t.value === value);
       return type ? type.label : '';
     };
-    const showActivities = (stepId) => {
+    const showActivities = (stepId, stepType = E_LEARNING) => {
+      if (stepType !== E_LEARNING) return null;
       areActivitiesVisible.value[stepId] = !areActivitiesVisible.value[stepId];
     };
 
@@ -472,6 +473,7 @@ export default {
       PUBLISHED,
       PUBLISHED_DOT_ACTIVE,
       PUBLISHED_DOT_WARNING,
+      E_LEARNING,
       modalLoading,
       subProgramCreationModal,
       newSubProgram,

--- a/src/modules/vendor/components/programs/ProfileContent.vue
+++ b/src/modules/vendor/components/programs/ProfileContent.vue
@@ -337,7 +337,7 @@ export default {
       const type = ACTIVITY_TYPES.find(t => t.value === value);
       return type ? type.label : '';
     };
-    const showActivities = (stepId, stepType = E_LEARNING) => {
+    const showActivities = (stepId, stepType) => {
       if (stepType !== E_LEARNING) return null;
       areActivitiesVisible.value[stepId] = !areActivitiesVisible.value[stepId];
     };
@@ -460,7 +460,7 @@ export default {
       await initAreStepsLocked();
 
       if (openedStep.value) {
-        showActivities(openedStep.value);
+        showActivities(openedStep.value, E_LEARNING);
         scrollToOpenedStep(openedStep.value);
         $store.dispatch('program/resetOpenedStep');
       }


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur rof/admin

- Cas d'usage :

- Comment tester ? :
  -  je ne peux pas rajouter une activité à une étape présentielle ou distancielle

_Si tu as lu cette description, pense à réagir avec un :eye:_
