### PR TITLE
Com 2981

### DIFF
--- a/src/core/components/courses/TraineeTable.vue
+++ b/src/core/components/courses/TraineeTable.vue
@@ -274,6 +274,7 @@ export default {
       } catch (e) {
         console.error(e);
         if (e.status === 409) return NotifyNegative(e.data.message);
+        if (e.status === 403) return NotifyWarning(e.data.message);
         NotifyNegative('Erreur lors de l\'ajout du/de la stagiaire.');
       } finally {
         traineeModalLoading.value = false;

--- a/src/modules/vendor/components/courses/CourseCreationModal.vue
+++ b/src/modules/vendor/components/courses/CourseCreationModal.vue
@@ -40,7 +40,7 @@ import Select from '@components/form/Select';
 import DateInput from '@components/form/DateInput';
 import OptionGroup from '@components/form/OptionGroup';
 import Input from '@components/form/Input';
-import { COURSE_TYPES, REQUIRED_LABEL, INTER_B2B } from '@data/constants';
+import { COURSE_TYPES, REQUIRED_LABEL, INTER_B2B, INTRA } from '@data/constants';
 import { formatAndSortOptions } from '@helpers/utils';
 
 export default {
@@ -112,12 +112,12 @@ export default {
       this.$emit('submit');
     },
     updateType (event) {
+      const omitFields = event === INTER_B2B ? ['company', 'maxTrainees'] : ['company'];
       this.$emit(
         'update:new-course',
         {
-          ...event === INTER_B2B
-            ? omit(this.newCourse, ['company', 'maxTrainees'])
-            : { ...omit(this.newCourse, ['company']), maxTrainees: 8 },
+          ...omit(this.newCourse, omitFields),
+          ...(event === INTRA && { maxTrainees: 8 }),
           type: event,
         }
       );

--- a/src/modules/vendor/components/courses/CourseCreationModal.vue
+++ b/src/modules/vendor/components/courses/CourseCreationModal.vue
@@ -40,7 +40,7 @@ import Select from '@components/form/Select';
 import DateInput from '@components/form/DateInput';
 import OptionGroup from '@components/form/OptionGroup';
 import Input from '@components/form/Input';
-import { COURSE_TYPES, REQUIRED_LABEL } from '@data/constants';
+import { COURSE_TYPES, REQUIRED_LABEL, INTER_B2B } from '@data/constants';
 import { formatAndSortOptions } from '@helpers/utils';
 
 export default {
@@ -112,7 +112,15 @@ export default {
       this.$emit('submit');
     },
     updateType (event) {
-      this.$emit('update:new-course', { ...omit(this.newCourse, ['company', 'maxTrainees']), type: event });
+      this.$emit(
+        'update:new-course',
+        {
+          ...event === INTER_B2B
+            ? omit(this.newCourse, ['company', 'maxTrainees'])
+            : { ...omit(this.newCourse, ['company']), maxTrainees: 8 },
+          type: event,
+        }
+      );
     },
     update (event, prop) {
       this.$emit('update:new-course', { ...this.newCourse, [prop]: event });

--- a/src/modules/vendor/components/courses/CourseCreationModal.vue
+++ b/src/modules/vendor/components/courses/CourseCreationModal.vue
@@ -40,7 +40,7 @@ import Select from '@components/form/Select';
 import DateInput from '@components/form/DateInput';
 import OptionGroup from '@components/form/OptionGroup';
 import Input from '@components/form/Input';
-import { COURSE_TYPES, REQUIRED_LABEL, INTER_B2B, INTRA } from '@data/constants';
+import { COURSE_TYPES, REQUIRED_LABEL, INTRA } from '@data/constants';
 import { formatAndSortOptions } from '@helpers/utils';
 
 export default {
@@ -112,11 +112,10 @@ export default {
       this.$emit('submit');
     },
     updateType (event) {
-      const omitFields = event === INTER_B2B ? ['company', 'maxTrainees'] : ['company'];
       this.$emit(
         'update:new-course',
         {
-          ...omit(this.newCourse, omitFields),
+          ...omit(this.newCourse, ['company', 'maxTrainees']),
           ...(event === INTRA && { maxTrainees: 8 }),
           type: event,
         }

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -32,7 +32,7 @@
 <script>
 import { useMeta } from 'quasar';
 import useVuelidate from '@vuelidate/core';
-import { required } from '@vuelidate/validators';
+import { required, requiredIf } from '@vuelidate/validators';
 import { mapState } from 'vuex';
 import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
@@ -95,10 +95,8 @@ export default {
         subProgram: { required },
         type: { required },
         salesRepresentative: { required },
-        ...(this.isIntraCourse && {
-          maxTrainees: { required, strictPositiveNumber, integerNumber },
-          company: { required },
-        }),
+        ...(this.isIntraCourse && { maxTrainees: { required, strictPositiveNumber, integerNumber } }),
+        company: { required: requiredIf(this.newCourse.type === INTRA) },
       },
       selectedStartDate: { maxDate: this.selectedEndDate ? maxDate(this.selectedEndDate) : '' },
       selectedEndDate: { minDate: this.selectedStartDate ? minDate(this.selectedStartDate) : '' },


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client rof/admin/coach

- Cas d'usage : je ne peux pas ajouter de stagiaires si j'ai déjà atteint le nombre max de stagiaires + boyscout si je jongle avec le toggle de type de formation sur la modale de création, j'ai bien le champ stagiaires max à 8 sur INTRA

- Comment tester ? :
 - ajouter un stagiaire de plus que toléré par une formation
 - sur la modale de création de formation si je change le toggle intra => inter => intra j'ai bien le champ stagiaires max de rempli sur intra 

_Si tu as lu cette description, pense à réagir avec un :eye:_
