### PR TITLE
COM-2957 add margin right to checkbox

### DIFF
--- a/src/modules/client/pages/ni/billing/ClientsBalances.vue
+++ b/src/modules/client/pages/ni/billing/ClientsBalances.vue
@@ -16,10 +16,8 @@
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props" :style="col.style">{{ col.label }}</q-th>
           <q-th auto-width>
-            <div class="q-mr-md">
-              <q-checkbox @update:model-value="selectRows" :model-value="!!selected.length" dense
-                :disable="balancesOption === 2" indeterminate-value="some" />
-            </div>
+            <q-checkbox class="q-mr-md" @update:model-value="selectRows" :model-value="!!selected.length" dense
+              :disable="balancesOption === 2" indeterminate-value="some" />
           </q-th>
         </q-tr>
       </template>
@@ -40,9 +38,7 @@
             <template v-else>{{ col.value }}</template>
           </q-td>
           <q-td v-if="props.row.toPay > 0" align="right" auto-width>
-            <div class="q-mr-md">
-              <q-checkbox v-model="props.selected" dense />
-            </div>
+            <q-checkbox class="q-mr-md" v-model="props.selected" dense />
           </q-td>
           <q-td v-else />
         </q-tr>

--- a/src/modules/client/pages/ni/billing/ClientsBalances.vue
+++ b/src/modules/client/pages/ni/billing/ClientsBalances.vue
@@ -16,8 +16,10 @@
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props" :style="col.style">{{ col.label }}</q-th>
           <q-th auto-width>
-            <q-checkbox @update:model-value="selectRows" :model-value="!!selected.length" dense
-              :disable="balancesOption === 2" indeterminate-value="some" />
+            <div class="q-mr-md">
+              <q-checkbox @update:model-value="selectRows" :model-value="!!selected.length" dense
+                :disable="balancesOption === 2" indeterminate-value="some" />
+            </div>
           </q-th>
         </q-tr>
       </template>
@@ -38,7 +40,9 @@
             <template v-else>{{ col.value }}</template>
           </q-td>
           <q-td v-if="props.row.toPay > 0" align="right" auto-width>
-            <q-checkbox v-model="props.selected" dense />
+            <div class="q-mr-md">
+              <q-checkbox v-model="props.selected" dense />
+            </div>
           </q-td>
           <q-td v-else />
         </q-tr>

--- a/src/modules/client/pages/ni/billing/ToBill.vue
+++ b/src/modules/client/pages/ni/billing/ToBill.vue
@@ -23,9 +23,7 @@
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props" :style="col.style">{{ col.label }}</q-th>
           <th>
-            <div class="q-mr-md">
-              <q-checkbox v-model="props.selected" indeterminate-value="some" dense />
-            </div>
+            <q-checkbox v-model="props.selected" class="q-mr-md" indeterminate-value="some" dense />
           </th>
         </q-tr>
       </template>

--- a/src/modules/client/pages/ni/billing/ToBill.vue
+++ b/src/modules/client/pages/ni/billing/ToBill.vue
@@ -23,7 +23,9 @@
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props" :style="col.style">{{ col.label }}</q-th>
           <th>
-            <q-checkbox v-model="props.selected" indeterminate-value="some" dense />
+            <div class="q-mr-md">
+              <q-checkbox v-model="props.selected" indeterminate-value="some" dense />
+            </div>
           </th>
         </q-tr>
       </template>


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : compani outil / coach

- Cas d'usage : 
  - sur les pages "a facturer" et "balance client", la scrollbar ne cache plus les checkbox de l'entete et du corps des tableaux
  - j'ai mis une div autour car <th> n'a pas l'air d'accepter la prop `class` et sur la doc yen a pas d'autre pour appliquer du style

- Comment tester ? :
  - verifier sur la page  a facturer
  - verifier sur la page balance client

_Si tu as lu cette description, pense à réagir avec un :eye:_
