### PR TITLE
COM-3001: change default slot

### DIFF
--- a/src/core/components/courses/BlendedCourseProfileHeader.vue
+++ b/src/core/components/courses/BlendedCourseProfileHeader.vue
@@ -15,7 +15,7 @@ import ProfileHeader from '@components/ProfileHeader';
 import Button from '@components/Button';
 import { NotifyPositive, NotifyNegative } from '@components/popup/notify';
 import { VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER } from '@data/constants';
-import companiDate from '@helpers/dates/companiDate';
+import CompaniDate from '@helpers/dates/companiDate';
 
 export default {
   name: 'BlendedCourseProfileHeader',
@@ -43,7 +43,7 @@ export default {
     displayArchiveButton () {
       const vendorRole = this.$store.getters['main/getVendorRole'];
       const isAdmin = [VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER].includes(vendorRole);
-      const areAllCourseSlotsEnded = this.course.slots.every(slot => companiDate().isAfter(slot.endDate)) &&
+      const areAllCourseSlotsEnded = this.course.slots.every(slot => CompaniDate().isAfter(slot.endDate)) &&
         !this.course.slotsToPlan.length;
 
       return !this.course.archivedAt && areAllCourseSlotsEnded && isAdmin;
@@ -69,7 +69,7 @@ export default {
     },
     async archiveCourse () {
       try {
-        const payload = { archivedAt: companiDate().toISO() };
+        const payload = { archivedAt: CompaniDate().toISO() };
         await Courses.update(this.course._id, payload);
 
         NotifyPositive('Formation archivée.');

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -94,6 +94,7 @@ import { getStepTypeLabel } from '@helpers/courses';
 import { formatDate, formatDuration, formatIntervalHourly, getDuration } from '@helpers/date';
 import { frAddress, minDate, maxDate, urlAddress } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
+import CompaniDate from '@helpers/dates/companiDate';
 
 export default {
   name: 'SlotContainer',
@@ -213,8 +214,8 @@ export default {
       }
 
       const defaultDate = {
-        startDate: moment().startOf('d').hours(9).toISOString(),
-        endDate: moment().startOf('d').hours(12).toISOString(),
+        startDate: CompaniDate().set({ hour: 9, minute: 0 }).toISO(),
+        endDate: CompaniDate().set({ hour: 12, minute: 30 }).toISO(),
       };
       editedCourseSlot.value = {
         _id: slot._id,

--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -59,8 +59,8 @@ export default {
     const hourError = ref(false);
 
     const shiftedTime = ref({
-      ...(shiftedMinutes.value / 60 >= 1 && { hour: Math.trunc(shiftedMinutes.value / 60) }),
-      ...(shiftedMinutes.value % 60 > 0 && { minute: shiftedMinutes.value % 60 }),
+      ...(shiftedMinutes.value / 60 >= 1 && { hours: Math.trunc(shiftedMinutes.value / 60) }),
+      ...(shiftedMinutes.value % 60 > 0 && { minutes: shiftedMinutes.value % 60 }),
     });
 
     const rules = computed(() => ({
@@ -97,8 +97,8 @@ export default {
       const companiDateHour = CompaniDate(hour, 'HH:mm').getUnits(['hour', 'minute']);
       return CompaniDate(date).set({
         ...companiDateHour,
-        seconds: 0,
-        milliseconds: 0,
+        second: 0,
+        millisecond: 0,
       }).toISO();
     };
 

--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -24,7 +24,7 @@
 
 <script>
 import get from 'lodash/get';
-import { ref } from 'vue';
+import { ref, toRefs, computed } from 'vue';
 import useVuelidate from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import DateInput from '@components/form/DateInput';
@@ -50,101 +50,116 @@ export default {
     max: { type: String, default: '' },
     startLocked: { type: Boolean, default: false },
     endLocked: { type: Boolean, default: false },
+    shiftedMinutes: { type: Number, default: 210 },
   },
   emits: ['blur', 'update:model-value', 'start-lock-click', 'end-lock-click'],
-  setup () {
+  setup (props, { emit }) {
+    const { modelValue, error, disableEndDate, disableEndHour, shiftedMinutes } = toRefs(props);
+
     const hourError = ref(false);
 
-    return {
-      hourError,
-      v$: useVuelidate(),
-    };
-  },
-  validations () {
-    return {
-      modelValue: {
-        startDate: { required },
-        endDate: { required, minDate: minDate(this.modelValue.startDate) },
-      },
-    };
-  },
-  computed: {
-    hasError () {
-      if (this.error || get(this.v$, 'modelValue.$error.$response')) return true;
-      const { startDate, endDate } = this.modelValue;
+    const shiftedTime = ref({
+      ...(shiftedMinutes.value / 60 >= 1 && { hour: Math.trunc(shiftedMinutes.value / 60) }),
+      ...(shiftedMinutes.value % 60 > 0 && { minute: shiftedMinutes.value % 60 }),
+    });
+
+    const rules = computed(() => ({
+      modelValue: { startDate: { required }, endDate: { required, minDate: minDate(modelValue.value.startDate) } },
+    }));
+
+    const validations = useVuelidate(rules, modelValue);
+
+    const hasError = computed(() => {
+      if (error.value || get(validations.value, 'modelValue.$error.$response')) return true;
+      const { startDate, endDate } = modelValue.value;
 
       return CompaniDate(startDate).isAfter(endDate);
-    },
-    startHour () {
-      return CompaniDate(this.modelValue.startDate).format('HH:mm');
-    },
-    endHour () {
-      return CompaniDate(this.modelValue.endDate).format('HH:mm');
-    },
-    min () {
-      if (CompaniDate(this.modelValue.startDate).format('yyyy/LL/dd')
-        === CompaniDate(this.modelValue.endDate).format('yyyy/LL/dd')) {
-        return this.startHour;
+    });
+
+    const startHour = computed(() => CompaniDate(modelValue.value.startDate).format('HH:mm'));
+
+    const endHour = computed(() => CompaniDate(modelValue.value.endDate).format('HH:mm'));
+
+    const min = computed(() => {
+      if (CompaniDate(modelValue.value.startDate).format('yyyy/LL/dd')
+        === CompaniDate(modelValue.value.endDate).format('yyyy/LL/dd')) {
+        return startHour.value;
       }
       return null;
-    },
-  },
-  methods: {
-    blurHandler () {
-      this.v$.modelValue.$touch();
-      this.$emit('blur');
-    },
-    setDateHours (date, hour) {
+    });
+
+    const blurHandler = () => {
+      validations.value.modelValue.$touch();
+      emit('blur');
+    };
+
+    const setDateHours = (date, hour) => {
       const companiDateHour = CompaniDate(hour, 'HH:mm').getUnits(['hour', 'minute']);
       return CompaniDate(date).set({
         ...companiDateHour,
-        second: 0,
-        millisecond: 0,
+        seconds: 0,
+        milliseconds: 0,
       }).toISO();
-    },
-    update (date, key) {
+    };
+
+    const update = (date, key) => {
       const hoursFields = ['hour', 'minute', 'second', 'millisecond'];
-      const dateObject = CompaniDate(this.modelValue[key]).getUnits(hoursFields);
-      const dates = { ...this.modelValue, [key]: CompaniDate(date).set({ ...dateObject }).toISO() };
-      if (key === 'startDate' && this.disableEndDate) {
-        const endDateObject = CompaniDate(this.modelValue.endDate).getUnits(hoursFields);
+      const dateObject = CompaniDate(modelValue.value[key]).getUnits(hoursFields);
+      const dates = { ...modelValue.value, [key]: CompaniDate(date).set({ ...dateObject }).toISO() };
+      if (key === 'startDate' && disableEndDate.value) {
+        const endDateObject = CompaniDate(modelValue.value.endDate).getUnits(hoursFields);
         dates.endDate = CompaniDate(date).set({ ...endDateObject }).toISO();
       }
       if (key === 'endDate') dates.endDate = CompaniDate(dates.endDate).endOf('day').toISO();
 
-      this.$emit('update:model-value', dates);
-    },
-    updateHours (value, key) {
+      emit('update:model-value', dates);
+    };
+
+    const updateHours = (value, key) => {
       try {
-        this.hourError = false;
-        const dates = { ...this.modelValue };
+        hourError.value = false;
+        const dates = { ...modelValue.value };
 
-        if (key === 'endHour') dates.endDate = this.setDateHours(dates.endDate, value);
+        if (key === 'endHour') dates.endDate = setDateHours(dates.endDate, value);
         if (key === 'startHour') {
-          dates.startDate = this.setDateHours(dates.startDate, value);
+          dates.startDate = setDateHours(dates.startDate, value);
 
-          if (!this.disableEndHour && CompaniDate(value, 'HH:mm').isSameOrAfter(this.endHour)) {
+          if (!disableEndHour.value && CompaniDate(value, 'HH:mm').isSameOrAfter(endHour.value)) {
             const max = CompaniDate(dates.startDate).endOf('day');
-            const shiftedEndDate = CompaniDate(dates.startDate).add({ hours: 2 });
-
+            const shiftedEndDate = CompaniDate(dates.startDate).add(shiftedTime.value);
             dates.endDate = shiftedEndDate.isSameOrBefore(max) ? shiftedEndDate.toISO() : max.toISO();
           }
         }
 
-        this.$emit('update:model-value', dates);
+        emit('update:model-value', dates);
       } catch (e) {
-        this.hourError = true;
+        hourError.value = true;
         if (e.message.startsWith('Invalid DateTime: unparsable') ||
           e.message.startsWith('Invalid DateTime: unit out of range')) return '';
         console.error(e);
       }
-    },
-    startClick () {
-      this.$emit('start-lock-click');
-    },
-    endClick () {
-      this.$emit('end-lock-click');
-    },
+    };
+
+    const startClick = () => emit('start-lock-click');
+
+    const endClick = () => emit('end-lock-click');
+
+    return {
+      // Data
+      shiftedTime,
+      hourError,
+      // Computed
+      hasError,
+      startHour,
+      endHour,
+      min,
+      // Methods
+      blurHandler,
+      update,
+      updateHours,
+      startClick,
+      endClick,
+    };
   },
 };
 </script>

--- a/src/core/helpers/dates/companiDate.js
+++ b/src/core/helpers/dates/companiDate.js
@@ -85,6 +85,12 @@ const CompaniDateFactory = (inputDate) => {
       return CompaniDateFactory(_date.endOf(unit));
     },
 
+    add (amount) {
+      if (amount instanceof Number) throw Error('Invalid argument: expected to be an object, got number');
+
+      return CompaniDateFactory(_date.plus(amount));
+    },
+
     set (values) {
       return CompaniDateFactory(_date.set(values));
     },

--- a/src/core/helpers/dates/companiDate.js
+++ b/src/core/helpers/dates/companiDate.js
@@ -85,12 +85,6 @@ const CompaniDateFactory = (inputDate) => {
       return CompaniDateFactory(_date.endOf(unit));
     },
 
-    add (amount) {
-      if (amount instanceof Number) throw Error('Invalid argument: expected to be an object, got number');
-
-      return CompaniDateFactory(_date.plus(amount));
-    },
-
     set (values) {
       return CompaniDateFactory(_date.set(values));
     },

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -11,7 +11,7 @@
           @update:model-value="updateType($event)" />
         <template v-if="newEvent.type !== ABSENCE">
           <ni-datetime-range caption="Dates et heures de l'évènement" :model-value="newEvent.dates" required-field
-            :error="validations.dates.$error" @blur="validations.dates.$touch" disable-end-date
+            :error="validations.dates.$error" @blur="validations.dates.$touch" disable-end-date :shifted-minutes="120"
             @update:model-value="updateEvent('dates', $event)" :max="customerStoppedDate" />
         </template>
         <template v-if="newEvent.type === INTERVENTION">
@@ -34,7 +34,7 @@
             :error="validations.absence.$error" required-field @blur="validations.absence.$touch"
             :disable="isHourlyAbsence(newEvent)" @update:model-value="updateAbsence($event)" />
           <ni-datetime-range caption="Dates et heures de l'évènement" :model-value="newEvent.dates" required-field
-            :disable-end-date="isAbsenceEndDateDisabled" :error="validations.dates.$error"
+            :disable-end-date="isAbsenceEndDateDisabled" :error="validations.dates.$error" :shifted-minutes="120"
             @blur="validations.dates.$touch" :disable-end-hour="isDailyAbsence(newEvent)"
             :disable-start-hour="isAbsenceStartHourDisabled" @update:model-value="updateEvent('dates', $event)" />
           <q-checkbox v-show="canExtendAbsence" class="q-mb-sm" :model-value="newEvent.isExtendedAbsence"

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -28,7 +28,7 @@
           <ni-datetime-range caption="Dates et heures de l'évènement" :model-value="editedEvent.dates" required-field
             :disable="!canUpdateIntervention || historiesLoading" :error="validations.dates.$error" disable-end-date
             @update:model-value="updateEvent('dates', $event)" @blur="validations.dates.$touch"
-            :disable-start-date="isEventTimeStamped" :max="customerStoppedDate"
+            :disable-start-date="isEventTimeStamped" :max="customerStoppedDate" :shifted-minutes="120"
             :disable-start-hour="!!startDateTimeStamped" :disable-end-hour="!!endDateTimeStamped"
             :start-locked="!!startDateTimeStamped" @start-lock-click="openTimeStampCancellationModal(true)"
             :end-locked="!!endDateTimeStamped" @end-lock-click="openTimeStampCancellationModal(false)" />
@@ -67,7 +67,7 @@
           <ni-select in-modal caption="Nature" :model-value="editedEvent.absenceNature" :options="absenceNatureOptions"
             :error="validations.absenceNature.$error" required-field disable />
           <ni-select in-modal caption="Type d'absence" :model-value="editedEvent.absence" :options="ABSENCE_TYPES"
-            :error="validations.absence.$error" required-field @blur="validations.absence.$touch"
+            :error="validations.absence.$error" required-field @blur="validations.absence.$touch" :shifted-minutes="120"
             :disable="isHourlyAbsence(editedEvent) || historiesLoading" @update:model-value="updateAbsence($event)" />
           <ni-datetime-range caption="Dates et heures de l'évènement" :model-value="editedEvent.dates" required-field
             :disable-end-date="isAbsenceEndDateDisabled" :disable-start-hour="isAbsenceStartHourDisabled"


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client rof/admin/coach/formateur

- Cas d'usage : le créneau par défaut est de 3h30 (9h00-12h30) pour les formations

- Comment tester ? :
- créer et éditer des événements : rien ne change (créneau par défaut 8h-10h => +2h quand on bouge l'heure de début après l'heure de fin)
- éditer créneau formation : 9h-12h30 par défaut => + 3h30 quand on bouge l'heure de début après l'heure de fin

_Si tu as lu cette description, pense à réagir avec un :eye:_
