### PR TITLE
COM-2990 dont show notify warning if not in modal for date range

### DIFF
--- a/src/core/components/form/DateRange.vue
+++ b/src/core/components/form/DateRange.vue
@@ -45,6 +45,7 @@ export default {
     error: { type: Boolean, default: false },
     errorMessage: { type: String, default: REQUIRED_LABEL },
     borders: { type: Boolean, default: false },
+    inModal: { type: Boolean, default: false },
   },
   emits: ['update:model-value', 'blur', 'update:error'],
   setup () {
@@ -86,8 +87,10 @@ export default {
       this.$emit('update:model-value', { ...this.modelValue, [key]: value });
     },
     blur () {
-      this.v$.modelValue.$touch();
-      if (this.v$.modelValue.$error) return NotifyWarning('Champ(s) invalide(s)');
+      if (!this.inModal) {
+        this.v$.modelValue.$touch();
+        if (this.v$.modelValue.$error) return NotifyWarning('Champ(s) invalide(s)');
+      }
 
       this.$emit('blur');
     },

--- a/src/modules/client/components/planning/CustomerAbsenceEditionModal.vue
+++ b/src/modules/client/components/planning/CustomerAbsenceEditionModal.vue
@@ -11,7 +11,7 @@
           required-field @update:model-value="update($event, 'absenceType')" />
       </div>
       <div class="q-mx-lg">
-        <ni-date-range borders class="last" caption="Dates de l'absence" @blur="validations.dates.$touch"
+        <ni-date-range borders class="last" caption="Dates de l'absence" @blur="validations.dates.$touch" in-modal
           :model-value="editedCustomerAbsence.dates" @update:model-value="update($event, 'dates')" required-field />
       </div>
       <q-btn class="modal-btn full-width" no-caps color="primary" :loading="loading" label="Editer l'absence"

--- a/src/modules/client/components/planning/DeleteEventsModal.vue
+++ b/src/modules/client/components/planning/DeleteEventsModal.vue
@@ -13,7 +13,7 @@
         :options="customerAbsenceOptions" required-field @blur="v$.deletedEvents.absenceType.$touch"
         :error="v$.deletedEvents.absenceType.$error" />
       <ni-date-range caption="Dates de début et de fin" required-field v-model="deletedEvents" @blur="validateDates"
-        :error="v$.deletedEvents.startDate.$error || v$.deletedEvents.endDate.$error" />
+        :error="v$.deletedEvents.startDate.$error || v$.deletedEvents.endDate.$error" in-modal />
     </template>
     <template v-else>
       <ni-date-input caption="Date d'arrêt des interventions" v-model="deletedEvents.startDate" type="date"


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach/auxiliaire

- Cas d'usage : Dans une modale au blur, on n'affiche pas de Notifywarning

- Comment tester ? : Le notify warning ne s'affiche pas au blur sur les dateRange dans les modales (modification et creation d'une absence beneficiaire). Dans les autres cas, le notify warning s'affiche bien : 
    - Pages d'exports (client et vendeur)
    - Page de facturation sur le profile beneficiaire (ou sur page cote aidant)
    - Page A facturer
    - Tableaux de bords formation
    - Page Absences
    - Page Contrats


_Si tu as lu cette description, pense à réagir avec un :eye:_
