### PR TITLE
Com 2994

### DIFF
--- a/src/core/api/Courses.js
+++ b/src/core/api/Courses.js
@@ -3,12 +3,8 @@ import { WEBAPP, OPERATIONS } from '@data/constants';
 
 export default {
   async list (filterParams) {
-    const params = { ...filterParams, origin: WEBAPP, action: OPERATIONS };
+    const params = { ...filterParams, origin: WEBAPP };
     const courses = await alenviAxios.get(`${process.env.API_HOSTNAME}/courses`, { params });
-    return courses.data.data.courses;
-  },
-  async listUserCourse (params) {
-    const courses = await alenviAxios.get(`${process.env.API_HOSTNAME}/courses/user`, { params });
     return courses.data.data.courses;
   },
   async create (payload) {

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -20,7 +20,8 @@
           @click="() => openTrainerModal('Ajouter un(e) ')" />
         <interlocutor-cell v-if="!!course.companyRepresentative._id" :interlocutor="course.companyRepresentative"
           caption="Référent structure" :open-edition-modal="() => openCompanyRepresentativeModal('Modifier le ')"
-          :disable="isArchived" class="q-mt-lg" can-update :contact="course.contact" />
+          :disable="isArchived" class="q-mt-lg" :can-update="canUpdateInterlocutor || isClientInterface"
+          :contact="course.contact" />
         <ni-button v-else-if="course.type === INTRA" color="primary" icon="add" class="add-interlocutor"
           label="Ajouter un référent structure" :disable="interlocutorModalLoading || isArchived"
           @click="() => openCompanyRepresentativeModal('Ajouter un ')" />
@@ -388,6 +389,11 @@ export default {
 
     const refreshCompanyRepresentatives = async () => {
       try {
+        const loggedUserCompany = get(loggedUser.value, 'company._id');
+        if (isTrainer.value && loggedUserCompany !== course.value.company._id) {
+          companyRepresentativeOptions.value = [formatInterlocutorOption(course.value.companyRepresentative)];
+          return null;
+        }
         const clientUsersFromCompany = course.value.type === INTRA
           ? await Users.list({ role: [COACH, CLIENT_ADMIN], company: course.value.company._id })
           : [];
@@ -739,6 +745,7 @@ export default {
       followUpDisabled,
       isArchived,
       followUpMissingInfo,
+      isClientInterface,
       // Methods
       get,
       formatQuantity,

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -391,8 +391,8 @@ export default {
       try {
         const loggedUserCompany = get(loggedUser.value, 'company._id');
         if (isTrainer.value && loggedUserCompany !== course.value.company._id) {
-          companyRepresentativeOptions.value = [formatInterlocutorOption(course.value.companyRepresentative)];
-          return null;
+          companyRepresentativeOptions.value = [];
+          return;
         }
         const clientUsersFromCompany = course.value.type === INTRA
           ? await Users.list({ role: [COACH, CLIENT_ADMIN], company: course.value.company._id })

--- a/src/core/components/learners/ProfileCourses.vue
+++ b/src/core/components/learners/ProfileCourses.vue
@@ -118,7 +118,7 @@ import has from 'lodash/has';
 import uniqBy from 'lodash/uniqBy';
 import Courses from '@api/Courses';
 import Attendances from '@api/Attendances';
-import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
+import { BLENDED, E_LEARNING, STRICTLY_E_LEARNING, ON_SITE, REMOTE, PEDAGOGY } from '@data/constants';
 import { sortStrings, formatIdentity } from '@helpers/utils';
 import {
   isBetweenOrEqual,
@@ -246,7 +246,7 @@ export default {
     const getUserCourses = async () => {
       try {
         loading.value = true;
-        const userCourses = await Courses.listUserCourse({ traineeId: userProfile.value._id });
+        const userCourses = await Courses.list({ trainee: userProfile.value._id, action: PEDAGOGY });
 
         courses.value = userCourses.map(course => ({
           ...course,

--- a/src/core/data/constants.js
+++ b/src/core/data/constants.js
@@ -360,6 +360,7 @@ export const FORTHCOMING = 'forthcoming';
 export const IN_PROGRESS = 'inProgress';
 export const COMPLETED = 'completed';
 export const OPERATIONS = 'operations';
+export const PEDAGOGY = 'pedagogy';
 
 // SUBPROGRAM
 export const PUBLISHED = 'published';

--- a/src/modules/client/pages/ni/courses/BlendedCoursesDirectory.vue
+++ b/src/modules/client/pages/ni/courses/BlendedCoursesDirectory.vue
@@ -30,7 +30,7 @@ import Select from '@components/form/Select';
 import DirectoryHeader from '@components/DirectoryHeader';
 import Trello from '@components/courses/Trello';
 import { courseFiltersMixin } from '@mixins/courseFiltersMixin';
-import { BLENDED } from '@data/constants';
+import { BLENDED, OPERATIONS } from '@data/constants';
 import { minDate, maxDate } from '@helpers/vuelidateCustomVal';
 
 const metaInfo = { title: 'Catalogue' };
@@ -68,7 +68,11 @@ export default {
   methods: {
     async refreshCourses () {
       try {
-        const courses = await Courses.list({ company: get(this.loggedUser, 'company._id') || '', format: BLENDED });
+        const courses = await Courses.list({
+          company: get(this.loggedUser, 'company._id') || '',
+          format: BLENDED,
+          action: OPERATIONS,
+        });
         this.coursesWithGroupedSlot = this.groupByCourses(courses);
       } catch (e) {
         console.error(e);

--- a/src/modules/client/pages/ni/courses/ELearningCoursesDirectory.vue
+++ b/src/modules/client/pages/ni/courses/ELearningCoursesDirectory.vue
@@ -12,7 +12,7 @@ import { createMetaMixin } from 'quasar';
 import { mapGetters } from 'vuex';
 import DirectoryHeader from '@components/DirectoryHeader';
 import TableList from '@components/table/TableList';
-import { STRICTLY_E_LEARNING } from '@data/constants';
+import { STRICTLY_E_LEARNING, OPERATIONS } from '@data/constants';
 import { eLearningCourseDirectoryMixin } from '@mixins/eLearningCourseDirectoryMixin';
 
 const metaInfo = { title: 'Repertoire formation eLearning' };
@@ -28,7 +28,7 @@ export default {
     ...mapGetters({ company: 'main/getCompany' }),
   },
   async created () {
-    await this.refreshCourseList({ format: STRICTLY_E_LEARNING, company: this.company._id });
+    await this.refreshCourseList({ format: STRICTLY_E_LEARNING, company: this.company._id, action: OPERATIONS });
   },
   methods: {
     goToELearningCourseProfile (row) {

--- a/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/BlendedCoursesDirectory.vue
@@ -46,7 +46,7 @@ import Select from '@components/form/Select';
 import CourseCreationModal from 'src/modules/vendor/components/courses/CourseCreationModal';
 import Trello from '@components/courses/Trello';
 import { NotifyNegative, NotifyPositive, NotifyWarning } from '@components/popup/notify';
-import { INTRA, COURSE_TYPES, BLENDED, TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN } from '@data/constants';
+import { INTRA, COURSE_TYPES, BLENDED, TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN, OPERATIONS } from '@data/constants';
 import { courseFiltersMixin } from '@mixins/courseFiltersMixin';
 import { formatAndSortOptions, formatAndSortIdentityOptions } from '@helpers/utils';
 import { minDate, maxDate, strictPositiveNumber, integerNumber } from '@helpers/vuelidateCustomVal';
@@ -119,7 +119,7 @@ export default {
   methods: {
     async refreshCourses () {
       try {
-        const courses = await Courses.list({ format: BLENDED });
+        const courses = await Courses.list({ format: BLENDED, action: OPERATIONS });
         this.coursesWithGroupedSlot = this.groupByCourses(courses);
       } catch (e) {
         console.error(e);

--- a/src/modules/vendor/pages/ni/management/ELearningCoursesDirectory.vue
+++ b/src/modules/vendor/pages/ni/management/ELearningCoursesDirectory.vue
@@ -11,7 +11,7 @@
 import { createMetaMixin } from 'quasar';
 import DirectoryHeader from '@components/DirectoryHeader';
 import TableList from '@components/table/TableList';
-import { STRICTLY_E_LEARNING } from '@data/constants';
+import { STRICTLY_E_LEARNING, OPERATIONS } from '@data/constants';
 import { eLearningCourseDirectoryMixin } from '@mixins/eLearningCourseDirectoryMixin';
 
 const metaInfo = { title: 'Repertoire formation eLearning' };
@@ -24,7 +24,7 @@ export default {
     'ni-table-list': TableList,
   },
   async created () {
-    await this.refreshCourseList({ format: STRICTLY_E_LEARNING });
+    await this.refreshCourseList({ format: STRICTLY_E_LEARNING, action: OPERATIONS });
   },
   methods: {
     goToCourseProfile (row) {

--- a/src/modules/vendor/pages/trainers/management/BlendedCoursesDirectory.vue
+++ b/src/modules/vendor/pages/trainers/management/BlendedCoursesDirectory.vue
@@ -30,7 +30,7 @@ import Trello from '@components/courses/Trello';
 import DateInput from '@components/form/DateInput';
 import Select from '@components/form/Select';
 import { courseFiltersMixin } from '@mixins/courseFiltersMixin';
-import { BLENDED } from '@data/constants';
+import { BLENDED, OPERATIONS } from '@data/constants';
 import { createMetaMixin } from 'quasar';
 import { minDate, maxDate } from '@helpers/vuelidateCustomVal';
 
@@ -69,7 +69,7 @@ export default {
   methods: {
     async refreshCourses () {
       try {
-        const courses = await Courses.list({ trainer: this.loggedUser._id, format: BLENDED });
+        const courses = await Courses.list({ trainer: this.loggedUser._id, format: BLENDED, action: OPERATIONS });
         this.coursesWithGroupedSlot = this.groupByCourses(courses);
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client rof/admin/coach/formateur

- Cas d'usage : je peux accéder à la liste des formations (générales et d'un utilisateur en particulier)

- Comment tester ? :
- accéder au kanban (côté client en tant que coach, côté vendeur en tant que rof et formateur)
- accéder à la liste des formations elearning (côté client en tant que coach, côté vendeur en tant que rof)
- accéder à la liste des formations d'un apprenant (côté client en tant que coach, côté vendeur en tant que rof)
- boyscout : en tant que formateur je n'ai plus de 403 quand j'accède au profil d'une formation intra + vérifier que je peux toujours modifier le référent structure (côté client en tant que coach, côté vendeur en tant que rof)

_Si tu as lu cette description, pense à réagir avec un :eye:_
