### PR TITLE
Com 2991 time input

### DIFF
--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -92,7 +92,7 @@ import { E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
 import { formatQuantity } from '@helpers/utils';
 import { getStepTypeLabel } from '@helpers/courses';
 import { formatDate, formatDuration, formatIntervalHourly, getDuration } from '@helpers/date';
-import { frAddress, minDate, maxDate, urlAddress, validHour, minHour } from '@helpers/vuelidateCustomVal';
+import { frAddress, minDate, maxDate, urlAddress, validHour, strictMinHour } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
 import CompaniDate from '@helpers/dates/companiDates';
 
@@ -193,7 +193,11 @@ export default {
         dates: {
           startDate: { required },
           startHour: { required, validHour },
-          endHour: { required, validHour, minHour: minHour(get(editedCourseSlot.value, 'dates.startHour')) },
+          endHour: {
+            required,
+            validHour,
+            strictMinHour: strictMinHour(get(editedCourseSlot.value, 'dates.startHour')),
+          },
           endDate: {
             required,
             ...(!!get(editedCourseSlot.value, 'dates.startDate') && {

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -92,7 +92,7 @@ import { E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
 import { formatQuantity } from '@helpers/utils';
 import { getStepTypeLabel } from '@helpers/courses';
 import { formatDate, formatDuration, formatIntervalHourly, getDuration } from '@helpers/date';
-import { frAddress, minDate, maxDate, urlAddress, validHour } from '@helpers/vuelidateCustomVal';
+import { frAddress, minDate, maxDate, urlAddress, validHour, minHour } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
 import CompaniDate from '@helpers/dates/companiDates';
 
@@ -193,7 +193,7 @@ export default {
         dates: {
           startDate: { required },
           startHour: { required, validHour },
-          endHour: { required, validHour },
+          endHour: { required, validHour, minHour: minHour(get(editedCourseSlot.value, 'dates.startHour')) },
           endDate: {
             required,
             ...(!!get(editedCourseSlot.value, 'dates.startDate') && {

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -249,12 +249,12 @@ export default {
     const formatEditionPayload = (courseSlot) => {
       const stepType = stepTypes.value.find(item => item.value === courseSlot.step).type;
 
-      const startHour = courseSlot.dates.startHour.split(':');
-      const endHour = courseSlot.dates.endHour.split(':');
+      const startHour = CompaniDate(courseSlot.dates.startHour, 'HH:mm');
+      const endHour = CompaniDate(courseSlot.dates.endHour, 'HH:mm');
 
       return {
-        startDate: CompaniDate(courseSlot.dates.startDate).set({ hour: startHour[0], minute: startHour[1] }).toISO(),
-        endDate: CompaniDate(courseSlot.dates.endDate).set({ hour: endHour[0], minute: endHour[1] }).toISO(),
+        startDate: CompaniDate(courseSlot.dates.startDate).set(startHour.getUnits(['hour', 'minute'])).toISO(),
+        endDate: CompaniDate(courseSlot.dates.endDate).set(endHour.getUnits(['hour', 'minute'])).toISO(),
         ...(stepType === ON_SITE && get(courseSlot, 'address.fullAddress') && { address: courseSlot.address }),
         ...(stepType === REMOTE && courseSlot.meetingLink && { meetingLink: courseSlot.meetingLink }),
       };

--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -77,12 +77,9 @@ export default {
     };
 
     const updateHours = (value, key) => {
-      const dates = { ...modelValue.value };
+      const dates = { ...modelValue.value, [key]: value };
       try {
-        if (key === 'endHour') dates.endHour = value;
         if (key === 'startHour') {
-          dates.startHour = value;
-
           const startHourDate = CompaniDate(dates.startHour, 'HH:mm');
           const endHourDate = CompaniDate(dates.endHour, 'HH:mm');
           if (!disableEndHour.value && startHourDate.isSameOrAfter(endHourDate)) {

--- a/src/core/components/form/DatetimeRange.vue
+++ b/src/core/components/form/DatetimeRange.vue
@@ -2,17 +2,18 @@
   <div class="col-12 margin-input">
     <div v-if="caption" class="row justify-between">
       <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
-      <q-icon v-if="hasError" name="error_outline" color="secondary" />
+      <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
-    <q-field :error="hourError || hasError" error-message="Date(s) et heure(s) invalide(s)" borderless>
+    <q-field :error="error" error-message="Date(s) et heure(s) invalide(s)" borderless>
       <div class="datetime-container row justify-evenly items-center">
         <ni-date-input :model-value="modelValue.startDate" @update:model-value="update($event, 'startDate')"
           @blur="blurHandler" :disable="disable || disableStartDate" :max="max" class="date-item" />
-        <ni-time-input :model-value="startHour" @update:model-value="updateHours($event, 'startHour')" class="time-item"
-          @blur="blurHandler" :disable="disable || disableStartHour" @lock-click="startClick" :locked="startLocked" />
+        <ni-time-input :model-value="modelValue.startHour" @update:model-value="updateHours($event, 'startHour')"
+          @blur="blurHandler" :disable="disable || disableStartHour" @lock-click="startClick" :locked="startLocked"
+          class="time-item" />
         <p class="delimiter">-</p>
-        <ni-time-input :model-value="endHour" @update:model-value="updateHours($event, 'endHour')" class="time-item"
-          :disable="disable || disableEndHour" :min="min" @lock-click="endClick" :locked="endLocked"
+        <ni-time-input :model-value="modelValue.endHour" @update:model-value="updateHours($event, 'endHour')"
+          :disable="disable || disableEndHour" :min="min" @lock-click="endClick" :locked="endLocked" class="time-item"
           @blur="blurHandler" />
         <ni-date-input :model-value="modelValue.endDate" @update:model-value="update($event, 'endDate')"
           @blur="blurHandler" :min="modelValue.startDate" :disable="disable || disableEndDate" :max="max"
@@ -23,13 +24,9 @@
 </template>
 
 <script>
-import get from 'lodash/get';
 import { ref, toRefs, computed } from 'vue';
-import useVuelidate from '@vuelidate/core';
-import { required } from '@vuelidate/validators';
 import DateInput from '@components/form/DateInput';
 import TimeInput from '@components/form/TimeInput';
-import { minDate } from '@helpers/vuelidateCustomVal';
 import CompaniDate from '@helpers/dates/companiDates';
 
 export default {
@@ -54,104 +51,63 @@ export default {
   },
   emits: ['blur', 'update:model-value', 'start-lock-click', 'end-lock-click'],
   setup (props, { emit }) {
-    const { modelValue, error, disableEndDate, disableEndHour, shiftedMinutes } = toRefs(props);
-
-    const hourError = ref(false);
+    const { modelValue, disableEndDate, disableEndHour, shiftedMinutes } = toRefs(props);
 
     const shiftedTime = ref({
       ...(shiftedMinutes.value / 60 >= 1 && { hours: Math.trunc(shiftedMinutes.value / 60) }),
       ...(shiftedMinutes.value % 60 > 0 && { minutes: shiftedMinutes.value % 60 }),
     });
 
-    const rules = computed(() => ({
-      modelValue: { startDate: { required }, endDate: { required, minDate: minDate(modelValue.value.startDate) } },
-    }));
-
-    const validations = useVuelidate(rules, modelValue);
-
-    const hasError = computed(() => {
-      if (error.value || get(validations.value, 'modelValue.$error.$response')) return true;
-      const { startDate, endDate } = modelValue.value;
-
-      return CompaniDate(startDate).isAfter(endDate);
-    });
-
-    const startHour = computed(() => CompaniDate(modelValue.value.startDate).format('HH:mm'));
-
-    const endHour = computed(() => CompaniDate(modelValue.value.endDate).format('HH:mm'));
-
     const min = computed(() => {
-      if (CompaniDate(modelValue.value.startDate).format('yyyy/LL/dd')
-        === CompaniDate(modelValue.value.endDate).format('yyyy/LL/dd')) {
-        return startHour.value;
+      if (CompaniDate(modelValue.value.startDate).isSame(modelValue.value.endDate, 'day')) {
+        return modelValue.value.startHour;
       }
+
       return null;
     });
 
-    const blurHandler = () => {
-      validations.value.modelValue.$touch();
-      emit('blur');
-    };
-
-    const setDateHours = (date, hour) => {
-      const companiDateHour = CompaniDate(hour, 'HH:mm').getUnits(['hour', 'minute']);
-      return CompaniDate(date).set({
-        ...companiDateHour,
-        second: 0,
-        millisecond: 0,
-      }).toISO();
-    };
+    const blurHandler = () => { emit('blur'); };
 
     const update = (date, key) => {
-      const hoursFields = ['hour', 'minute', 'second', 'millisecond'];
-      const dateObject = CompaniDate(modelValue.value[key]).getUnits(hoursFields);
-      const dates = { ...modelValue.value, [key]: CompaniDate(date).set({ ...dateObject }).toISO() };
-      if (key === 'startDate' && disableEndDate.value) {
-        const endDateObject = CompaniDate(modelValue.value.endDate).getUnits(hoursFields);
-        dates.endDate = CompaniDate(date).set({ ...endDateObject }).toISO();
-      }
+      const dates = { ...modelValue.value, [key]: CompaniDate(date).toISO() };
+      if (key === 'startDate' && disableEndDate.value) dates.endDate = CompaniDate(date).toISO();
       if (key === 'endDate') dates.endDate = CompaniDate(dates.endDate).endOf('day').toISO();
 
       emit('update:model-value', dates);
     };
 
     const updateHours = (value, key) => {
+      const dates = { ...modelValue.value };
       try {
-        hourError.value = false;
-        const dates = { ...modelValue.value };
-
-        if (key === 'endHour') dates.endDate = setDateHours(dates.endDate, value);
+        if (key === 'endHour') dates.endHour = value;
         if (key === 'startHour') {
-          dates.startDate = setDateHours(dates.startDate, value);
+          dates.startHour = value;
 
-          if (!disableEndHour.value && CompaniDate(value, 'HH:mm').isSameOrAfter(endHour.value)) {
-            const max = CompaniDate(dates.startDate).endOf('day');
-            const shiftedEndDate = CompaniDate(dates.startDate).add(shiftedTime.value);
-            dates.endDate = shiftedEndDate.isSameOrBefore(max) ? shiftedEndDate.toISO() : max.toISO();
+          const startHourDate = CompaniDate(dates.startHour, 'HH:mm');
+          const endHourDate = CompaniDate(dates.endHour, 'HH:mm');
+          if (!disableEndHour.value && startHourDate.isSameOrAfter(endHourDate)) {
+            const max = CompaniDate().endOf('day');
+            const shiftedEndDate = startHourDate.add(shiftedTime.value);
+            dates.endHour = shiftedEndDate.isSameOrBefore(max) ? shiftedEndDate.format('HH:mm') : max.format('HH:mm');
           }
         }
-
-        emit('update:model-value', dates);
       } catch (e) {
-        hourError.value = true;
         if (e.message.startsWith('Invalid DateTime: unparsable') ||
           e.message.startsWith('Invalid DateTime: unit out of range')) return '';
         console.error(e);
+      } finally {
+        emit('update:model-value', dates);
       }
     };
 
-    const startClick = () => emit('start-lock-click');
+    const startClick = () => { emit('start-lock-click'); };
 
-    const endClick = () => emit('end-lock-click');
+    const endClick = () => { emit('end-lock-click'); };
 
     return {
       // Data
       shiftedTime,
-      hourError,
       // Computed
-      hasError,
-      startHour,
-      endHour,
       min,
       // Methods
       blurHandler,

--- a/src/core/components/form/TimeInput.vue
+++ b/src/core/components/form/TimeInput.vue
@@ -27,17 +27,13 @@
 </template>
 
 <script>
+import { computed, ref, toRefs } from 'vue';
 import { PLANNING_VIEW_START_HOUR, PLANNING_VIEW_END_HOUR } from '@data/constants';
 import moment from '@helpers/moment';
 
 export default {
   name: 'NiTimeInput',
   emits: ['update:model-value', 'blur', 'lock-click'],
-  data () {
-    return {
-      selectTime: false,
-    };
-  },
   props: {
     modelValue: { type: String, default: '' },
     min: { type: String, default: '' },
@@ -49,8 +45,12 @@ export default {
     requiredField: { type: Boolean, default: false },
     locked: { type: Boolean, default: false },
   },
-  computed: {
-    hoursOptions () {
+  setup (props, { emit }) {
+    const { min } = toRefs(props);
+    const qTimeMenu = ref(null);
+    const selectTime = ref(false);
+
+    const hoursOptions = computed(() => {
       const range = moment.range(
         moment().hours(PLANNING_VIEW_START_HOUR).minutes(0),
         moment().hours(PLANNING_VIEW_END_HOUR).minutes(0)
@@ -61,35 +61,47 @@ export default {
           acc.push({
             label: hour.format('HH:mm'),
             value: hour.format('HH:mm'),
-            disable: this.min !== '' && hour.isSameOrBefore(moment(this.min, 'HH:mm')),
+            disable: min !== '' && hour.isSameOrBefore(moment(min, 'HH:mm')),
           });
           if (hour.format('HH') !== `${PLANNING_VIEW_END_HOUR}`) {
             acc.push({
               label: hour.minutes(30).format('HH:mm'),
               value: hour.minutes(30).format('HH:mm'),
-              disable: this.min !== '' && hour.minutes(30).isSameOrBefore(moment(this.min, 'HH:mm')),
+              disable: min !== '' && hour.minutes(30).isSameOrBefore(moment(min, 'HH:mm')),
             });
           }
           return acc;
         },
         []
       );
-    },
-  },
-  methods: {
-    select (value) {
-      this.update(value);
-      this.$refs.qTimeMenu.hide();
-    },
-    update (value) {
-      this.$emit('update:model-value', value);
-    },
-    onBlur () {
-      this.$emit('blur');
-    },
-    click () {
-      this.$emit('lock-click');
-    },
+    });
+
+    const select = (value) => {
+      update(value);
+      qTimeMenu.value.hide();
+    };
+    const update = (value) => {
+      emit('update:model-value', value);
+    };
+    const onBlur = () => {
+      emit('blur');
+    };
+    const click = () => {
+      emit('lock-click');
+    };
+
+    return {
+      // Data
+      selectTime,
+      qTimeMenu,
+      // computed
+      hoursOptions,
+      // Methods
+      select,
+      update,
+      onBlur,
+      click,
+    };
   },
 };
 </script>

--- a/src/core/components/form/TimeInput.vue
+++ b/src/core/components/form/TimeInput.vue
@@ -5,9 +5,9 @@
       <p :class="['input-caption', { required: requiredField }]">{{ caption }}</p>
       <q-icon v-if="error" name="error_outline" color="secondary" />
     </div>
-    <q-input dense bg-color="white" borderless :model-value="modelValue" @update:model-value="update" :readonly="locked"
+    <q-input dense bg-color="white" borderless :model-value="modelValue" @update:model-value="update"
       :error-message="errorMessage" :error="error" @blur="onBlur" :rules="['time']" mask="time" data-cy="time-input"
-      :disable="disable && !locked" :class="{ borders: inModal }">
+      :disable="disable && !locked" :class="{ borders: inModal }" :readonly="locked" debounce="500">
       <template #append>
         <q-icon v-if="!locked" name="far fa-clock" class="cursor-pointer" @click="selectTime = !selectTime"
           color="copper-grey-500">
@@ -61,13 +61,13 @@ export default {
           acc.push({
             label: hour.format('HH:mm'),
             value: hour.format('HH:mm'),
-            disable: min !== '' && hour.isSameOrBefore(moment(min, 'HH:mm')),
+            disable: min.value !== '' && hour.isSameOrBefore(moment(min.value, 'HH:mm')),
           });
           if (hour.format('HH') !== `${PLANNING_VIEW_END_HOUR}`) {
             acc.push({
               label: hour.minutes(30).format('HH:mm'),
               value: hour.minutes(30).format('HH:mm'),
-              disable: min !== '' && hour.minutes(30).isSameOrBefore(moment(min, 'HH:mm')),
+              disable: min.value !== '' && hour.minutes(30).isSameOrBefore(moment(min.value, 'HH:mm')),
             });
           }
           return acc;
@@ -80,12 +80,15 @@ export default {
       update(value);
       qTimeMenu.value.hide();
     };
+
     const update = (value) => {
       emit('update:model-value', value);
     };
+
     const onBlur = () => {
       emit('blur');
     };
+
     const click = () => {
       emit('lock-click');
     };

--- a/src/core/helpers/date.js
+++ b/src/core/helpers/date.js
@@ -124,8 +124,8 @@ export const getHoursAndMinutes = (value) => {
 
 export const computeHours = ({ hours, minutes }) => Number(hours) + Number(minutes) / 60;
 
-export const formatDateAndHours = (startDate, endDate) => {
-  const date = moment(startDate).format('DD MMMM');
+export const formatDateAndHours = (dates) => {
+  const date = moment(dates.startDate).format('DD MMMM');
 
-  return `${date} (${formatHoursWithMinutes(startDate)} - ${formatHoursWithMinutes(endDate)})`;
+  return `${date} (${dates.startHour.replace(':', 'h')} - ${dates.endHour.replace(':', 'h')})`;
 };

--- a/src/core/helpers/dates/companiDates.js
+++ b/src/core/helpers/dates/companiDates.js
@@ -85,6 +85,11 @@ const CompaniDateFactory = (inputDate) => {
       return CompaniDateFactory(_date.endOf(unit));
     },
 
+    add (amount) {
+      if (amount instanceof Number) throw Error('Invalid argument: expected to be an object, got number');
+      return CompaniDateFactory(_date.plus(amount));
+    },
+
     set (values) {
       return CompaniDateFactory(_date.set(values));
     },

--- a/src/core/helpers/vuelidateCustomVal.js
+++ b/src/core/helpers/vuelidateCustomVal.js
@@ -67,14 +67,20 @@ export const fractionDigits = digits => value => new RegExp(`^\\d*(\\.\\d{0,${di
 
 export const validHour = value => !value || !!value.match(/^[0-1][0-9]:[0-5][0-9]$|^2[0-3]:[0-5][0-9]$/);
 
-export const minHour = min => helpers.withParams(
+export const strictMinHour = min => helpers.withParams(
   { value: min },
-  time => CompaniDate(min, 'HH:mm').isSameOrBefore(CompaniDate(time, 'HH:mm').toISO())
+  time => CompaniDate(min, 'HH:mm').isBefore(CompaniDate(time, 'HH:mm'), 'minute')
 );
 
-export const minDate = min => helpers.withParams({ value: min }, value => !value || new Date(min) <= new Date(value));
+export const minDate = min => helpers.withParams(
+  { value: min },
+  value => !value || CompaniDate(min).isSameOrBefore(CompaniDate(value), 'day')
+);
 
-export const maxDate = max => helpers.withParams({ value: max }, value => !value || new Date(max) >= new Date(value));
+export const maxDate = max => helpers.withParams(
+  { value: max },
+  value => !value || CompaniDate(max).isSameOrAfter(CompaniDate(value), 'day')
+);
 
 export const apeCode = value => !value || /^\d{3,4}[A-Z]$/.test(value);
 

--- a/src/core/helpers/vuelidateCustomVal.js
+++ b/src/core/helpers/vuelidateCustomVal.js
@@ -4,7 +4,8 @@ import { isValidIBAN, isValidBIC } from 'ibantools';
 import { workHealthServices } from '@data/workHealthServices';
 import { urssafCodes } from '@data/urssafCodes';
 import { GAP_ANSWER_MAX_LENGTH } from '@data/constants';
-import { isGreaterThan, isGreaterThanOrEqual } from './numbers';
+import { isGreaterThan, isGreaterThanOrEqual } from '@helpers/numbers';
+import CompaniDate from '@helpers/dates/companiDates';
 
 export const frPhoneNumber = (value) => {
   if (!value) return true;
@@ -65,6 +66,11 @@ export const integerNumber = (value) => {
 export const fractionDigits = digits => value => new RegExp(`^\\d*(\\.\\d{0,${digits}})?$`).test(value);
 
 export const validHour = value => !value || !!value.match(/^[0-1][0-9]:[0-5][0-9]$|^2[0-3]:[0-5][0-9]$/);
+
+export const minHour = min => helpers.withParams(
+  { value: min },
+  time => CompaniDate(min, 'HH:mm').isSameOrBefore(CompaniDate(time, 'HH:mm').toISO())
+);
 
 export const minDate = min => helpers.withParams({ value: min }, value => !value || new Date(min) <= new Date(value));
 

--- a/src/modules/client/components/planning/EventCancellationModal.vue
+++ b/src/modules/client/components/planning/EventCancellationModal.vue
@@ -79,8 +79,7 @@ export default {
 
       $q.dialog({
         title: 'Confirmation',
-        message: `Êtes-vous sûr(e) de vouloir annuler l'intervention du
-          ${formatDateAndHours(props.editedEvent.dates.startDate, props.editedEvent.dates.endDate)}
+        message: `Êtes-vous sûr(e) de vouloir annuler l'intervention du ${formatDateAndHours(props.editedEvent.dates)}
           chez ${props.customerName}&nbsp;?`,
         ok: true,
         html: true,

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -139,7 +139,7 @@ export default {
       if (!this.selectedAuxiliary.contracts || this.selectedAuxiliary.contracts.length === 0) return false;
 
       return this.selectedAuxiliary.contracts.some(contract => CompaniDate(contract.startDate)
-        .isSameOrBefore(this.newEvent.dates.startDate) && !contract.endDate);
+        .isSameOrBefore(this.newEvent.dates.startDate, 'day') && !contract.endDate);
     },
     isRepetitionAllowed () {
       if (!this.newEvent.auxiliary) return true;

--- a/src/modules/client/components/planning/EventEditionModal.vue
+++ b/src/modules/client/components/planning/EventEditionModal.vue
@@ -432,9 +432,8 @@ export default {
     openEventRestorationModal () {
       this.$q.dialog({
         title: 'Confirmation',
-        message: `Êtes vous sûr(e) de vouloir rétablir l’intervention du
-          ${formatDateAndHours(this.editedEvent.dates.startDate, this.editedEvent.dates.endDate)} chez
-          ${this.customerFullName}&nbsp;?`,
+        message: `Êtes vous sûr(e) de vouloir rétablir l’intervention du ${formatDateAndHours(this.editedEvent.dates)}
+          chez ${this.customerFullName}&nbsp;?`,
         html: true,
         ok: 'Oui',
         cancel: 'Non',

--- a/src/modules/client/composables/planningAction.js
+++ b/src/modules/client/composables/planningAction.js
@@ -13,12 +13,12 @@ import {
   OTHER,
   NEVER,
 } from '@data/constants';
-import { frAddress, maxDate, positiveNumber, minDate } from '@helpers/vuelidateCustomVal';
+import { frAddress, maxDate, positiveNumber, minDate, validHour } from '@helpers/vuelidateCustomVal';
 
 export const usePlanningAction = (personKey, customers) => {
   const newEvent = ref({
     type: INTERVENTION,
-    dates: { startDate: '', endDate: '' },
+    dates: { startDate: '', endDate: '', startHour: '', endHour: '' },
     auxiliary: null,
     customer: null,
     subscription: null,
@@ -45,6 +45,8 @@ export const usePlanningAction = (personKey, customers) => {
         endDate: {
           required: requiredIf(newEvent.value.type !== ABSENCE || get(newEvent.value, 'absenceNature') === DAILY),
         },
+        startHour: { required, validHour },
+        endHour: { required, validHour },
       },
       auxiliary: {
         required: requiredIf(newEvent.value.type !== INTERVENTION || personKey === CUSTOMER),

--- a/src/modules/client/composables/planningAction.js
+++ b/src/modules/client/composables/planningAction.js
@@ -13,7 +13,7 @@ import {
   OTHER,
   NEVER,
 } from '@data/constants';
-import { frAddress, maxDate, positiveNumber, minDate, validHour } from '@helpers/vuelidateCustomVal';
+import { frAddress, maxDate, positiveNumber, minDate, validHour, minHour } from '@helpers/vuelidateCustomVal';
 
 export const usePlanningAction = (personKey, customers) => {
   const newEvent = ref({
@@ -46,7 +46,7 @@ export const usePlanningAction = (personKey, customers) => {
           required: requiredIf(newEvent.value.type !== ABSENCE || get(newEvent.value, 'absenceNature') === DAILY),
         },
         startHour: { required, validHour },
-        endHour: { required, validHour },
+        endHour: { required, validHour, minHour: minHour(get(newEvent.value, 'dates.startHour')) },
       },
       auxiliary: {
         required: requiredIf(newEvent.value.type !== INTERVENTION || personKey === CUSTOMER),
@@ -90,7 +90,7 @@ export const usePlanningAction = (personKey, customers) => {
         },
         endDate: { required },
         startHour: { required, validHour },
-        endHour: { required, validHour },
+        endHour: { required, validHour, minHour: minHour(get(editedEvent.value, 'dates.startHour')) },
       },
       auxiliary: { required: requiredIf(editedEvent.value.type !== INTERVENTION) },
       sector: { required: requiredIf(!editedEvent.value.auxiliary) },

--- a/src/modules/client/composables/planningAction.js
+++ b/src/modules/client/composables/planningAction.js
@@ -13,7 +13,7 @@ import {
   OTHER,
   NEVER,
 } from '@data/constants';
-import { frAddress, maxDate, positiveNumber, minDate, validHour, minHour } from '@helpers/vuelidateCustomVal';
+import { frAddress, maxDate, positiveNumber, minDate, validHour, strictMinHour } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
 
 export const usePlanningAction = (personKey, customers) => {
@@ -51,7 +51,7 @@ export const usePlanningAction = (personKey, customers) => {
           }),
         },
         startHour: { required, validHour },
-        endHour: { required, validHour, minHour: minHour(get(newEvent.value, 'dates.startHour')) },
+        endHour: { required, validHour, strictMinHour: strictMinHour(get(newEvent.value, 'dates.startHour')) },
       },
       auxiliary: {
         required: requiredIf(newEvent.value.type !== INTERVENTION || personKey === CUSTOMER),
@@ -101,7 +101,7 @@ export const usePlanningAction = (personKey, customers) => {
           }),
         },
         startHour: { required, validHour },
-        endHour: { required, validHour, minHour: minHour(get(editedEvent.value, 'dates.startHour')) },
+        endHour: { required, validHour, strictMinHour: strictMinHour(get(editedEvent.value, 'dates.startHour')) },
       },
       auxiliary: { required: requiredIf(editedEvent.value.type !== INTERVENTION) },
       sector: { required: requiredIf(!editedEvent.value.auxiliary) },

--- a/src/modules/client/composables/planningAction.js
+++ b/src/modules/client/composables/planningAction.js
@@ -14,6 +14,7 @@ import {
   NEVER,
 } from '@data/constants';
 import { frAddress, maxDate, positiveNumber, minDate, validHour, minHour } from '@helpers/vuelidateCustomVal';
+import moment from '@helpers/moment';
 
 export const usePlanningAction = (personKey, customers) => {
   const newEvent = ref({
@@ -44,6 +45,10 @@ export const usePlanningAction = (personKey, customers) => {
         },
         endDate: {
           required: requiredIf(newEvent.value.type !== ABSENCE || get(newEvent.value, 'absenceNature') === DAILY),
+          ...(!!get(newEvent.value, 'dates.startDate') && { minDate: minDate(newEvent.value.dates.startDate) }),
+          ...(!!get(newEvent.value, 'dates.startDate') && get(newEvent.value, 'type') !== ABSENCE && {
+            maxDate: maxDate(moment(newEvent.value.dates.startDate).endOf('d').toISOString()),
+          }),
         },
         startHour: { required, validHour },
         endHour: { required, validHour, minHour: minHour(get(newEvent.value, 'dates.startHour')) },
@@ -88,7 +93,13 @@ export const usePlanningAction = (personKey, customers) => {
           required,
           maxDate: getCustomerStoppedDate(editedEvent.value) ? maxDate(getCustomerStoppedDate(editedEvent.value)) : '',
         },
-        endDate: { required },
+        endDate: {
+          required,
+          ...(!!get(editedEvent.value, 'dates.startDate') && { minDate: minDate(editedEvent.value.dates.startDate) }),
+          ...(!!get(editedEvent.value, 'dates.startDate') && get(editedEvent.value, 'type') !== ABSENCE && {
+            maxDate: maxDate(moment(editedEvent.value.dates.startDate).endOf('d').toISOString()),
+          }),
+        },
         startHour: { required, validHour },
         endHour: { required, validHour, minHour: minHour(get(editedEvent.value, 'dates.startHour')) },
       },

--- a/src/modules/client/composables/planningAction.js
+++ b/src/modules/client/composables/planningAction.js
@@ -45,9 +45,11 @@ export const usePlanningAction = (personKey, customers) => {
         },
         endDate: {
           required: requiredIf(newEvent.value.type !== ABSENCE || get(newEvent.value, 'absenceNature') === DAILY),
-          ...(!!get(newEvent.value, 'dates.startDate') && { minDate: minDate(newEvent.value.dates.startDate) }),
-          ...(!!get(newEvent.value, 'dates.startDate') && get(newEvent.value, 'type') !== ABSENCE && {
-            maxDate: maxDate(moment(newEvent.value.dates.startDate).endOf('d').toISOString()),
+          ...(!!get(newEvent.value, 'dates.startDate') && {
+            minDate: minDate(newEvent.value.dates.startDate),
+            ...(get(newEvent.value, 'type') !== ABSENCE && {
+              maxDate: maxDate(moment(newEvent.value.dates.startDate).endOf('d').toISOString()),
+            }),
           }),
         },
         startHour: { required, validHour },

--- a/src/modules/client/composables/planningAction.js
+++ b/src/modules/client/composables/planningAction.js
@@ -89,6 +89,8 @@ export const usePlanningAction = (personKey, customers) => {
           maxDate: getCustomerStoppedDate(editedEvent.value) ? maxDate(getCustomerStoppedDate(editedEvent.value)) : '',
         },
         endDate: { required },
+        startHour: { required, validHour },
+        endHour: { required, validHour },
       },
       auxiliary: { required: requiredIf(editedEvent.value.type !== INTERVENTION) },
       sector: { required: requiredIf(!editedEvent.value.auxiliary) },

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -76,7 +76,7 @@ export const planningActionMixin = {
         this.newEvent = {};
       } else {
         const startDate = moment(this.newEvent.dates.startDate).startOf('d').toISOString();
-        const endDate = moment(this.newEvent.dates.endDate).startOf('d').toISOString();
+        const endDate = moment(this.newEvent.dates.startDate).endOf('d').toISOString();
         this.newEvent = {
           ...this.newEvent,
           type,
@@ -89,15 +89,13 @@ export const planningActionMixin = {
           extension: '',
           address: {},
           attachment: {},
-          ...(type === ABSENCE && {
-            absenceNature: DAILY,
-            dates: {
-              startDate,
-              endDate,
-              startHour: moment(startDate.format('HH:mm')),
-              endHour: moment(endDate.format('HH:mm')),
-            },
-          }),
+          ...(type === ABSENCE && { absenceNature: DAILY }),
+          dates: {
+            startDate,
+            endDate,
+            startHour: type === ABSENCE ? moment(startDate).format('HH:mm') : this.newEvent.dates.startHour,
+            endHour: type === ABSENCE ? moment(endDate).format('HH:mm') : this.newEvent.dates.endHour,
+          },
         };
       }
     },

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -23,11 +23,13 @@ import {
   PERSON,
   CUSTOMER,
   WORK_ACCIDENT,
+  CANCEL_EVENT,
+  RESTORE_EVENT,
 } from '@data/constants';
 import { defineAbilitiesFor } from '@helpers/ability';
+import CompaniDate from '@helpers/dates/companiDates';
 import moment from '@helpers/moment';
 import { validationMixin } from '@mixins/validationMixin';
-import { CANCEL_EVENT, RESTORE_EVENT } from '../../../core/data/constants';
 
 export const planningActionMixin = {
   mixins: [validationMixin],
@@ -101,13 +103,14 @@ export const planningActionMixin = {
       this.creationModal = false;
     },
     getPayload (event) {
-      const startHour = event.dates.startHour.split(':');
-      const endHour = event.dates.endHour.split(':');
+      const startHour = CompaniDate(event.dates.startHour, 'HH:mm');
+      const endHour = CompaniDate(event.dates.endHour, 'HH:mm');
+
       const payload = {
         ...pickBy(omit(event, ['dates', '__v', 'company', 'isExtendedAbsence'])),
         ...pick(event, ['isCancelled', 'transportMode', 'misc', 'kmDuringEvent']), // pickBy removes false and '' value
-        startDate: moment(event.dates.startDate).set({ hour: startHour[0], minute: startHour[1] }).toISOString(),
-        endDate: moment(event.dates.endDate).set({ hour: endHour[0], minute: endHour[1] }).toISOString(),
+        startDate: CompaniDate(event.dates.startDate).set(startHour.getUnits(['hour', 'minute'])).toISO(),
+        endDate: CompaniDate(event.dates.endDate).set(endHour.getUnits(['hour', 'minute'])).toISO(),
       };
 
       if (event.auxiliary) delete payload.sector;
@@ -397,13 +400,11 @@ export const planningActionMixin = {
         address: initialEvent.address,
       };
 
-      const startHour = this.editedEvent.dates.startHour.split(':');
-      const endHour = this.editedEvent.dates.endHour.split(':');
+      const startHour = CompaniDate(this.editedEvent.dates.startHour, 'HH:mm');
+      const endHour = CompaniDate(this.editedEvent.dates.endHour, 'HH:mm');
       const formattedEditedEvent = {
-        startDate: moment(this.editedEvent.dates.startDate)
-          .set({ hour: startHour[0], minute: startHour[1] })
-          .toISOString(),
-        endDate: moment(this.editedEvent.dates.endDate).set({ hour: endHour[0], minute: endHour[1] }).toISOString(),
+        startDate: CompaniDate(this.editedEvent.dates.startDate).set(startHour.getUnits(['hour', 'minute'])).toISO(),
+        endDate: CompaniDate(this.editedEvent.dates.endDate).set(endHour.getUnits(['hour', 'minute'])).toISO(),
         serviceId: this.editedEvent.subscription,
         customerId: this.editedEvent.customer,
         address: this.editedEvent.address,

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -75,6 +75,8 @@ export const planningActionMixin = {
         this.creationModal = false;
         this.newEvent = {};
       } else {
+        const startDate = moment(this.newEvent.dates.startDate).startOf('d').toISOString();
+        const endDate = moment(this.newEvent.dates.endDate).startOf('d').toISOString();
         this.newEvent = {
           ...this.newEvent,
           type,
@@ -90,10 +92,10 @@ export const planningActionMixin = {
           ...(type === ABSENCE && {
             absenceNature: DAILY,
             dates: {
-              startDate: moment(this.newEvent.dates.startDate).startOf('d').toISOString(),
-              endDate: moment(this.newEvent.dates.endDate).endOf('d').toISOString(),
-              startHour: '00:00',
-              endHour: '23:59',
+              startDate,
+              endDate,
+              startHour: moment(startDate.format('HH:mm')),
+              endHour: moment(endDate.format('HH:mm')),
             },
           }),
         };

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -90,6 +90,8 @@ export const planningActionMixin = {
             dates: {
               startDate: moment(this.newEvent.dates.startDate).startOf('d').toISOString(),
               endDate: moment(this.newEvent.dates.endDate).endOf('d').toISOString(),
+              startHour: '00:00',
+              endHour: '23:59',
             },
           }),
         };
@@ -99,11 +101,13 @@ export const planningActionMixin = {
       this.creationModal = false;
     },
     getPayload (event) {
+      const startHour = event.dates.startHour.split(':');
+      const endHour = event.dates.endHour.split(':');
       const payload = {
         ...pickBy(omit(event, ['dates', '__v', 'company', 'isExtendedAbsence'])),
         ...pick(event, ['isCancelled', 'transportMode', 'misc', 'kmDuringEvent']), // pickBy removes false and '' value
-        startDate: event.dates.startDate,
-        endDate: event.dates.endDate,
+        startDate: moment(event.dates.startDate).set({ hour: startHour[0], minute: startHour[1] }).toISOString(),
+        endDate: moment(event.dates.endDate).set({ hour: endHour[0], minute: endHour[1] }).toISOString(),
       };
 
       if (event.auxiliary) delete payload.sector;

--- a/src/modules/client/mixins/planningActionMixin.js
+++ b/src/modules/client/mixins/planningActionMixin.js
@@ -282,7 +282,12 @@ export const planningActionMixin = {
         misc,
         ...eventData
       } = cloneDeep(event);
-      const dates = { startDate, endDate };
+      const dates = {
+        startDate,
+        endDate,
+        startHour: moment(startDate).format('HH:mm'),
+        endHour: moment(endDate).format('HH:mm'),
+      };
 
       switch (event.type) {
         case INTERVENTION: {
@@ -391,9 +396,14 @@ export const planningActionMixin = {
         customerId: initialEvent.customer._id,
         address: initialEvent.address,
       };
+
+      const startHour = this.editedEvent.dates.startHour.split(':');
+      const endHour = this.editedEvent.dates.endHour.split(':');
       const formattedEditedEvent = {
-        startDate: this.editedEvent.dates.startDate,
-        endDate: this.editedEvent.dates.endDate,
+        startDate: moment(this.editedEvent.dates.startDate)
+          .set({ hour: startHour[0], minute: startHour[1] })
+          .toISOString(),
+        endDate: moment(this.editedEvent.dates.endDate).set({ hour: endHour[0], minute: endHour[1] }).toISOString(),
         serviceId: this.editedEvent.subscription,
         customerId: this.editedEvent.customer,
         address: this.editedEvent.address,

--- a/src/modules/client/mixins/planningModalMixin.js
+++ b/src/modules/client/mixins/planningModalMixin.js
@@ -182,14 +182,16 @@ export const planningModalMixin = {
         if ([WORK_ACCIDENT, ILLNESS].includes(event.absence)) {
           this.$emit(`update:${eventType}`, {
             ...event,
-            dates: { ...event.dates, endDate: moment(event.dates.endDate).endOf('d').toISOString() },
+            dates: { ...event.dates, endDate: moment(event.dates.endDate).endOf('d').toISOString(), endHour: '23:59' },
           });
         } else {
           this.$emit(`update:${eventType}`, {
             ...event,
             dates: {
               startDate: moment(event.dates.startDate).startOf('d').toISOString(),
+              startHour: '00:00',
               endDate: moment(event.dates.endDate).endOf('d').toISOString(),
+              endHour: '23:59',
             },
           });
         }

--- a/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
+++ b/src/modules/client/pages/auxiliaries/planning/AuxiliaryAgenda.vue
@@ -196,8 +196,10 @@ export default {
         auxiliary: this.selectedAuxiliary._id,
         sector: '',
         dates: {
-          startDate: moment(selectedDay).hours(8).toISOString(),
-          endDate: moment(selectedDay).hours(10).toISOString(),
+          startDate: moment(selectedDay).toISOString(),
+          endDate: moment(selectedDay).toISOString(),
+          startHour: '08:00',
+          endHour: '10:00',
         },
         misc: '',
       };

--- a/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
+++ b/src/modules/client/pages/ni/planning/AuxiliaryPlanning.vue
@@ -289,8 +289,10 @@ export default {
         auxiliary: person ? person._id : '',
         sector: person ? person.sector._id : sectorId,
         dates: {
-          startDate: moment(selectedDay).hours(8).toISOString(),
-          endDate: moment(selectedDay).hours(10).toISOString(),
+          startDate: moment(selectedDay).toISOString(),
+          endDate: moment(selectedDay).toISOString(),
+          startHour: '08:00',
+          endHour: '10:00',
         },
         extension: '',
         misc: '',

--- a/src/modules/client/pages/ni/planning/CustomerPlanning.vue
+++ b/src/modules/client/pages/ni/planning/CustomerPlanning.vue
@@ -225,8 +225,10 @@ export default {
         auxiliary: '',
         sector: '',
         dates: {
-          startDate: moment(selectedDay).hours(8).toISOString(),
-          endDate: moment(selectedDay).hours(10).toISOString(),
+          startDate: moment(selectedDay).toISOString(),
+          endDate: moment(selectedDay).toISOString(),
+          startHour: '08:00',
+          endHour: '10:00',
         },
         misc: '',
       };


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles :

- Cas d'usage : Dans le composant `datetimerange` si je mets une heure au format invalide, j'ai une erreur et je ne peux pas valider la modale

- Comment tester ? :

- Edition des créneaux de formation
- Sur le planning auxiliaire ET sur l'agenda auxiliaire
  - Création d'une intervention
  - Création d'une heure interne
  - Création d'une absence
  - Création d'une indispo
  - Édition d'une intervention
  - Édition d'une heure interne
  - Édition d'une absence
  - Édition d'une indispo
- Sur le planning bénéficiaire
  - Création d'une intervention
  - Édition d'une intervention
- Sur la page des absences :
  - Édition d'une absence
- Coté horaire il faut aussi tester : 
  - l'heure de debut est changé à postérieure a l'heure de fin => l'heur de fin passe a heure de debut + shiftedTime
  - l'heure de debut est changé à postérieure a l'heure de fin => l'heur de fin passe a fin de journée (si debut + shifted > 23h59)
 - Dans la modal de creation et d’édition d’une intervention
    - Si je passe de intervention à absence
        → Les 2 dates sont modifiables et les horaires non 
        → Les horaires passent à “00:00” et “23:59” respectivement
    - Si je passe de absence à intervention
        → Seule la date de debut est modifiable
        → La date de fin est égale a la date de début (mettre initialement l’absence sur plusieurs jours pour bien tester le changement de la date de fin)
        →  Les 2 horaires sont modifiables

_Si tu as lu cette description, pense à réagir avec un :eye:_
