### PR TITLE
COM-3219 replace moment with luxon

### DIFF
--- a/src/core/components/courses/AttendanceSheetAdditionModal.vue
+++ b/src/core/components/courses/AttendanceSheetAdditionModal.vue
@@ -26,8 +26,7 @@ import Input from '@components/form/Input';
 import Button from '@components/Button';
 import { INTRA } from '@data/constants';
 import { formatAndSortIdentityOptions } from '@helpers/utils';
-import { formatDate } from '@helpers/date';
-import moment from '@helpers/moment';
+import CompaniDate from '@helpers/dates/companiDates';
 
 export default {
   name: 'AttendanceSheetAdditionModal',
@@ -55,9 +54,9 @@ export default {
       return formatAndSortIdentityOptions(this.course.trainees);
     },
     dateOptions () {
-      const dateOptionsSet = new Set(this.course.slots.map(date => moment(date.startDate).startOf('d').toISOString()));
+      const dateOptionsSet = new Set(this.course.slots.map(date => CompaniDate(date.startDate).startOf('day').toISO()));
 
-      return [...dateOptionsSet].map(date => ({ value: new Date(date), label: formatDate(date) }));
+      return [...dateOptionsSet].map(date => ({ value: date, label: CompaniDate(date).format('dd/LL/yyyy') }));
     },
   },
   methods: {

--- a/src/core/components/courses/BlendedCourseProfileHeader.vue
+++ b/src/core/components/courses/BlendedCourseProfileHeader.vue
@@ -15,7 +15,7 @@ import ProfileHeader from '@components/ProfileHeader';
 import Button from '@components/Button';
 import { NotifyPositive, NotifyNegative } from '@components/popup/notify';
 import { VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER } from '@data/constants';
-import companiDate from '@helpers/dates/companiDates';
+import CompaniDate from '@helpers/dates/companiDates';
 
 export default {
   name: 'BlendedCourseProfileHeader',
@@ -43,7 +43,7 @@ export default {
     displayArchiveButton () {
       const vendorRole = this.$store.getters['main/getVendorRole'];
       const isAdmin = [VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER].includes(vendorRole);
-      const areAllCourseSlotsEnded = this.course.slots.every(slot => companiDate().isAfter(slot.endDate)) &&
+      const areAllCourseSlotsEnded = this.course.slots.every(slot => CompaniDate().isAfter(slot.endDate)) &&
         !this.course.slotsToPlan.length;
 
       return !this.course.archivedAt && areAllCourseSlotsEnded && isAdmin;
@@ -69,7 +69,7 @@ export default {
     },
     async archiveCourse () {
       try {
-        const payload = { archivedAt: companiDate().toISO() };
+        const payload = { archivedAt: CompaniDate().toISO() };
         await Courses.update(this.course._id, payload);
 
         NotifyPositive('Formation archivée.');

--- a/src/core/components/table/AttendanceTable.vue
+++ b/src/core/components/table/AttendanceTable.vue
@@ -104,7 +104,7 @@ import Button from '@components/Button';
 import { NotifyPositive, NotifyNegative, NotifyWarning } from '@components/popup/notify';
 import { DEFAULT_AVATAR, INTRA, INTER_B2B } from '@data/constants';
 import { minArrayLength } from '@helpers/vuelidateCustomVal';
-import moment from '@helpers/moment';
+import CompaniDate from '@helpers/dates/companiDates';
 import { formatDate } from '@helpers/date';
 import { upperCaseFirstLetter, formatIdentity, formatAndSortIdentityOptions } from '@helpers/utils';
 import { defineAbilitiesFor } from '@helpers/ability';
@@ -195,11 +195,11 @@ export default {
           field: '_id',
           align: 'center',
           style: 'width: 80px; min-width: 80px',
-          month: upperCaseFirstLetter(moment(s.startDate).format('MMM')),
-          day: moment(s.startDate).date(),
-          weekDay: upperCaseFirstLetter(moment(s.startDate).format('ddd')),
-          startHour: moment(s.startDate).format('LT'),
-          endHour: moment(s.endDate).format('LT'),
+          month: upperCaseFirstLetter(CompaniDate(s.startDate).format('LLL')),
+          day: CompaniDate(s.startDate).format('d'),
+          weekDay: upperCaseFirstLetter(CompaniDate(s.startDate).format('ccc')),
+          startHour: CompaniDate(s.startDate).format('T'),
+          endHour: CompaniDate(s.endDate).format('T'),
         })),
       ];
     },

--- a/src/core/components/table/TraineeAttendanceCreationModal.vue
+++ b/src/core/components/table/TraineeAttendanceCreationModal.vue
@@ -21,13 +21,12 @@
 
 <script>
 import set from 'lodash/set';
-import moment from '@helpers/moment';
 import Modal from '@components/modal/Modal';
 import Button from '@components/Button';
 import Select from '@components/form/Select';
 import OptionGroup from '@components/form/OptionGroup';
 import { REQUIRED_LABEL } from '@data/constants';
-import { formatDate } from '@helpers/date';
+import CompaniDate from '@helpers/dates/companiDates';
 
 export default {
   name: 'TraineeAttendanceCreationModal',
@@ -55,7 +54,7 @@ export default {
   computed: {
     slotsOptions () {
       return this.course.slots.map(s => ({
-        label: `${formatDate(s.startDate)} ${moment(s.startDate).format('LT')} - ${moment(s.endDate).format('LT')}`,
+        label: `${CompaniDate(s.startDate).format('dd/LL/yyyy T')} - ${CompaniDate(s.endDate).format('T')}`,
         value: s._id,
       }));
     },


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : rof

- Cas d'usage :
   - migration de moment vers luxon sur le tableau des emargements
   - boyscout :
     -  j'ai mis un majuscule a l'importation de `CompaniDate` dans BlendedCOurseProfile
     - j'ai enlevé le new Date() inutile et l'appel a l'ancien formatDate dans AttendanceSheetAdditionModal


- Comment tester ? :
  - Vérifier l’affichage du tableau d’émargement
  - Vérifier l’affichage des dates disponibles pour l’ajout d’une feuille d’émargement 
  - Vérifier l’affichage des créneaux lors de l’ajout d’un stagiaire non inscrit à la formation

_Si tu as lu cette description, pense à réagir avec un :eye:_
