### PR TITLE
Com 3224

### DIFF
--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -212,7 +212,7 @@ export default {
       this.updateEvent('extension', '');
     },
     'newEvent.auxiliary': async function () {
-      if (this.newEvent.auxiliary) {
+      if (this.newEvent.auxiliary && this.newEvent.isExtendedAbsence) {
         this.auxiliaryAbsences = await Events.list({ auxiliary: this.newEvent.auxiliary, type: ABSENCE });
       } else {
         this.auxiliaryAbsences = [];
@@ -284,7 +284,7 @@ export default {
       this.updateEvent('address', event);
       this.deleteClassFocus();
     },
-    async updateCheckBox (event) {
+    async updateCheckBox () {
       if (!this.newEvent.isExtendedAbsence) {
         this.updateEvent('extension', '');
         this.auxiliaryAbsences = await Events.list({ auxiliary: this.selectedAuxiliary._id, type: ABSENCE });

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -131,7 +131,7 @@ export default {
   emits: ['update-event', 'close', 'reset', 'delete-document', 'document-uploaded', 'submit'],
   data () {
     return {
-      extendedAbsenceOptions: [],
+      auxiliaryAbsences: [],
     };
   },
   computed: {
@@ -186,6 +186,16 @@ export default {
     auxiliariesOptions () {
       return this.getAuxiliariesOptions(this.newEvent);
     },
+    extendedAbsenceOptions () {
+      return this.auxiliaryAbsences
+        .filter(e => e.absence === this.newEvent.absence &&
+            CompaniDate(e.startDate).isBefore(this.newEvent.dates.startDate))
+        .sort(descendingSort('startDate'))
+        .map(a => ({
+          label: `${CompaniDate(a.startDate).format('dd/LL/yyyy')} - ${CompaniDate(a.endDate).format('dd/LL/yyyy')}`,
+          value: a._id,
+        }));
+    },
   },
   watch: {
     selectedAuxiliary (value) {
@@ -198,11 +208,16 @@ export default {
         this.updateEvent('repetition.frequency', NEVER);
       }
     },
-    'newEvent.absence': function () {
-      this.getAbsences();
-    },
     'newEvent.dates.startDate': function () {
-      this.getAbsences();
+      this.updateEvent('extension', '');
+    },
+    'newEvent.auxiliary': async function () {
+      if (this.newEvent.auxiliary) {
+        this.auxiliaryAbsences = await Events.list({ auxiliary: this.newEvent.auxiliary, type: ABSENCE });
+      } else {
+        this.auxiliaryAbsences = [];
+      }
+      this.updateEvent('extension', '');
     },
   },
   methods: {
@@ -214,7 +229,6 @@ export default {
       this.$emit('close');
     },
     reset (partialReset, type) {
-      this.extendedAbsenceOptions = [];
       this.$emit('reset', { partialReset, type });
     },
     deleteDocument (value) {
@@ -263,6 +277,7 @@ export default {
     updateAbsence (event) {
       this.updateEvent('absence', event);
       this.updateEvent('isExtendedAbsence', false);
+      this.updateEvent('extension', '');
       this.setDateHours(this.newEvent, 'newEvent');
     },
     updateCustomerAddress (event) {
@@ -270,21 +285,11 @@ export default {
       this.deleteClassFocus();
     },
     async updateCheckBox (event) {
-      if (!this.newEvent.isExtendedAbsence) await this.getAbsences();
+      if (!this.newEvent.isExtendedAbsence) {
+        this.updateEvent('extension', '');
+        this.auxiliaryAbsences = await Events.list({ auxiliary: this.selectedAuxiliary._id, type: ABSENCE });
+      }
       this.updateEvent('isExtendedAbsence', !this.newEvent.isExtendedAbsence);
-    },
-    async getAbsences () {
-      this.updateEvent('extension', '');
-      const auxiliaryEvents = await Events.list({ auxiliary: this.selectedAuxiliary._id, type: ABSENCE });
-
-      this.extendedAbsenceOptions = auxiliaryEvents
-        .filter(e => e.absence === this.newEvent.absence &&
-            CompaniDate(e.startDate).isBefore(this.newEvent.dates.startDate))
-        .sort(descendingSort('startDate'))
-        .map(a => ({
-          label: `${CompaniDate(a.startDate).format('dd/LL/yyyy')} - ${CompaniDate(a.endDate).format('dd/LL/yyyy')}`,
-          value: a._id,
-        }));
     },
   },
 };

--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -443,12 +443,14 @@ export default {
       if (!events || !events.length) return { maxStartDate: '', minEndDate: '' };
 
       const eventsWithCreditNote = this.creditNoteEvents.filter(e => events.includes(e._id));
+      if (!eventsWithCreditNote.length) return { maxStartDate: '', minEndDate: '' };
+
       const endDate = new Date(get(eventsWithCreditNote[eventsWithCreditNote.length - 1], 'endDate'));
       const startDate = new Date(get(eventsWithCreditNote[0], 'startDate'));
 
       return {
-        maxStartDate: getEndOfDay(startDate).toString(),
-        minEndDate: getStartOfDay(endDate).toString(),
+        maxStartDate: getEndOfDay(startDate).toISOString(),
+        minEndDate: getStartOfDay(endDate).toISOString(),
       };
     },
     isValidDate (date) {


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach 

- Cas d'usage : je peux creer editer des avoirs d'interventions

- Comment tester ? : 
Verifier que l'on peut creer/editer des avoirs d'intervention

_Note :_
_j'ai verifie qu'il n'y avait pas d'autres appels à toString qui semblaient problematique_
_j'ai l'impression que le probleme etait bien present avant, mais je pense que l'erreur ne nous remontait pas car une date invalide ne remontait pas d'erreur avant alors que maintenant CompaniDate renvoie bien une erreur_

_Si tu as lu cette description, pense à réagir avec un :eye:_
