### PR TITLE
COM-3224 fix creation and edition of credit note

### DIFF
--- a/src/modules/client/pages/ni/billing/CreditNotes.vue
+++ b/src/modules/client/pages/ni/billing/CreditNotes.vue
@@ -443,12 +443,14 @@ export default {
       if (!events || !events.length) return { maxStartDate: '', minEndDate: '' };
 
       const eventsWithCreditNote = this.creditNoteEvents.filter(e => events.includes(e._id));
+      if (!eventsWithCreditNote.length) return { maxStartDate: '', minEndDate: '' };
+
       const endDate = new Date(get(eventsWithCreditNote[eventsWithCreditNote.length - 1], 'endDate'));
       const startDate = new Date(get(eventsWithCreditNote[0], 'startDate'));
 
       return {
-        maxStartDate: getEndOfDay(startDate).toString(),
-        minEndDate: getStartOfDay(endDate).toString(),
+        maxStartDate: getEndOfDay(startDate).toISOString(),
+        minEndDate: getStartOfDay(endDate).toISOString(),
       };
     },
     isValidDate (date) {


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : coach 

- Cas d'usage : je peux creer editer des avoirs d'interventions

- Comment tester ? : 
Verifier que l'on peut creer/editer des avoirs d'intervention

_Note :_
_j'ai verifie qu'il n'y avait pas d'autres appels à toString qui semblaient problematique_
_j'ai l'impression que le probleme etait bien present avant, mais je pense que l'erreur ne nous remontait pas car une date invalide ne remontait pas d'erreur avant alors que maintenant CompaniDate renvoie bien une erreur_

_Si tu as lu cette description, pense à réagir avec un :eye:_
