### PR TITLE
Com 3217

### DIFF
--- a/src/core/components/courses/CourseHistory.vue
+++ b/src/core/components/courses/CourseHistory.vue
@@ -33,7 +33,7 @@ import {
   TRAINEE_DELETION,
 } from '@data/constants';
 import Button from '@components/Button';
-import CompaniDates from '@helpers/dates/companiDates';
+import CompaniDate from '@helpers/dates/companiDates';
 import { formatIdentity } from '@helpers/utils';
 
 export default {
@@ -75,8 +75,8 @@ export default {
       }
     },
     historySignature () {
-      const date = CompaniDates(this.courseHistory.createdAt).format('dd/LL');
-      const hour = CompaniDates(this.courseHistory.createdAt).format('HH\'h\'mm');
+      const date = CompaniDate(this.courseHistory.createdAt).format('dd/LL');
+      const hour = CompaniDate(this.courseHistory.createdAt).format('HH\'h\'mm');
       const user = formatIdentity(this.courseHistory.createdBy.identity, 'FL');
 
       return `${user} le ${date} à ${hour}.`;
@@ -90,9 +90,9 @@ export default {
       return get(user, 'picture.link') || DEFAULT_AVATAR;
     },
     getSlotCreationTitle () {
-      const date = CompaniDates(this.courseHistory.slot.startDate).format('dd/LL');
-      const startHour = CompaniDates(this.courseHistory.slot.startDate).format('HH\'h\'mm');
-      const endHour = CompaniDates(this.courseHistory.slot.endDate).format('HH\'h\'mm');
+      const date = CompaniDate(this.courseHistory.slot.startDate).format('dd/LL');
+      const startHour = CompaniDate(this.courseHistory.slot.startDate).format('HH\'h\'mm');
+      const endHour = CompaniDate(this.courseHistory.slot.endDate).format('HH\'h\'mm');
       const infos = `${date} de ${startHour} à ${endHour}`;
 
       return { pre: 'Nouveau', type: 'créneau', post: 'le', infos };
@@ -102,7 +102,7 @@ export default {
         'Pas d\'adresse renseignée.';
     },
     getSlotDeletionTitle () {
-      const date = CompaniDates(this.courseHistory.slot.startDate).format('dd/LL');
+      const date = CompaniDate(this.courseHistory.slot.startDate).format('dd/LL');
 
       return { pre: 'Suppression du', type: 'créneau', post: 'du', infos: date };
     },
@@ -114,20 +114,20 @@ export default {
         address = ` sur ${get(this.courseHistory, 'slot.meetingLink')}`;
       }
 
-      return `Créneau initialement prévu de ${CompaniDates(this.courseHistory.slot.startDate).format('HH\'h\'mm')}`
-        + ` à ${CompaniDates(this.courseHistory.slot.endDate).format('HH\'h\'mm')}${address}`;
+      return `Créneau initialement prévu de ${CompaniDate(this.courseHistory.slot.startDate).format('HH\'h\'mm')}`
+        + ` à ${CompaniDate(this.courseHistory.slot.endDate).format('HH\'h\'mm')}${address}`;
     },
     getSlotEditionTitle () {
       if (this.courseHistory.update.startDate) {
-        const from = CompaniDates(this.courseHistory.update.startDate.from).format('dd/LL');
-        const to = CompaniDates(this.courseHistory.update.startDate.to).format('dd/LL');
+        const from = CompaniDate(this.courseHistory.update.startDate.from).format('dd/LL');
+        const to = CompaniDate(this.courseHistory.update.startDate.to).format('dd/LL');
 
         return { type: 'Créneau', post: ' déplacé du', infos: `${from} au ${to}` };
       }
       if (this.courseHistory.update.startHour) {
-        const date = CompaniDates(this.courseHistory.update.startHour.from).format('dd/LL');
-        const startHour = CompaniDates(this.courseHistory.update.startHour.to).format('HH\'h\'mm');
-        const endHour = CompaniDates(this.courseHistory.update.endHour.to).format('HH\'h\'mm');
+        const date = CompaniDate(this.courseHistory.update.startHour.from).format('dd/LL');
+        const startHour = CompaniDate(this.courseHistory.update.startHour.to).format('HH\'h\'mm');
+        const endHour = CompaniDate(this.courseHistory.update.endHour.to).format('HH\'h\'mm');
 
         return { type: 'Nouvel horaire', post: ' pour le créneau du', infos: `${date} : ${startHour} - ${endHour}` };
       }
@@ -135,8 +135,8 @@ export default {
     getSlotEditionDetails () {
       if (this.courseHistory.update.startDate) return undefined;
 
-      const oldStartHour = CompaniDates(this.courseHistory.update.startHour.from).format('HH\'h\'mm');
-      const oldEndHour = CompaniDates(this.courseHistory.update.endHour.from).format('HH\'h\'mm');
+      const oldStartHour = CompaniDate(this.courseHistory.update.startHour.from).format('HH\'h\'mm');
+      const oldEndHour = CompaniDate(this.courseHistory.update.endHour.from).format('HH\'h\'mm');
 
       return `Créneau initialement prévu de ${oldStartHour} à ${oldEndHour}`;
     },

--- a/src/core/components/courses/CourseHistory.vue
+++ b/src/core/components/courses/CourseHistory.vue
@@ -33,9 +33,8 @@ import {
   TRAINEE_DELETION,
 } from '@data/constants';
 import Button from '@components/Button';
-import moment from '@helpers/moment';
+import CompaniDates from '@helpers/dates/companiDates';
 import { formatIdentity } from '@helpers/utils';
-import { formatHoursWithMinutes } from '@helpers/date';
 
 export default {
   name: 'CourseHistory',
@@ -76,8 +75,8 @@ export default {
       }
     },
     historySignature () {
-      const date = moment(this.courseHistory.createdAt).format('DD/MM');
-      const hour = formatHoursWithMinutes(this.courseHistory.createdAt);
+      const date = CompaniDates(this.courseHistory.createdAt).format('dd/LL');
+      const hour = CompaniDates(this.courseHistory.createdAt).format('HH\'h\'mm');
       const user = formatIdentity(this.courseHistory.createdBy.identity, 'FL');
 
       return `${user} le ${date} à ${hour}.`;
@@ -91,9 +90,9 @@ export default {
       return get(user, 'picture.link') || DEFAULT_AVATAR;
     },
     getSlotCreationTitle () {
-      const date = moment(this.courseHistory.slot.startDate).format('DD/MM');
-      const startHour = formatHoursWithMinutes(this.courseHistory.slot.startDate);
-      const endHour = formatHoursWithMinutes(this.courseHistory.slot.endDate);
+      const date = CompaniDates(this.courseHistory.slot.startDate).format('dd/LL');
+      const startHour = CompaniDates(this.courseHistory.slot.startDate).format('HH\'h\'mm');
+      const endHour = CompaniDates(this.courseHistory.slot.endDate).format('HH\'h\'mm');
       const infos = `${date} de ${startHour} à ${endHour}`;
 
       return { pre: 'Nouveau', type: 'créneau', post: 'le', infos };
@@ -103,9 +102,9 @@ export default {
         'Pas d\'adresse renseignée.';
     },
     getSlotDeletionTitle () {
-      const date = moment(this.courseHistory.slot.startDate).format('DD/MM');
+      const date = CompaniDates(this.courseHistory.slot.startDate).format('dd/LL');
 
-      return { pre: 'Suppression du', type: 'créneau', post: 'du', infos: `${date}` };
+      return { pre: 'Suppression du', type: 'créneau', post: 'du', infos: date };
     },
     getSlotDeletionDetails () {
       let address = '.\r\nPas d\'adresse renseignée.';
@@ -115,20 +114,20 @@ export default {
         address = ` sur ${get(this.courseHistory, 'slot.meetingLink')}`;
       }
 
-      return `Créneau initialement prévu de ${formatHoursWithMinutes(this.courseHistory.slot.startDate)}`
-        + ` à ${formatHoursWithMinutes(this.courseHistory.slot.endDate)}${address}`;
+      return `Créneau initialement prévu de ${CompaniDates(this.courseHistory.slot.startDate).format('HH\'h\'mm')}`
+        + ` à ${CompaniDates(this.courseHistory.slot.endDate).format('HH\'h\'mm')}${address}`;
     },
     getSlotEditionTitle () {
       if (this.courseHistory.update.startDate) {
-        const from = moment(this.courseHistory.update.startDate.from).format('DD/MM');
-        const to = moment(this.courseHistory.update.startDate.to).format('DD/MM');
+        const from = CompaniDates(this.courseHistory.update.startDate.from).format('dd/LL');
+        const to = CompaniDates(this.courseHistory.update.startDate.to).format('dd/LL');
 
         return { type: 'Créneau', post: ' déplacé du', infos: `${from} au ${to}` };
       }
       if (this.courseHistory.update.startHour) {
-        const date = moment(this.courseHistory.update.startHour.from).format('DD/MM');
-        const startHour = formatHoursWithMinutes(this.courseHistory.update.startHour.to);
-        const endHour = formatHoursWithMinutes(this.courseHistory.update.endHour.to);
+        const date = CompaniDates(this.courseHistory.update.startHour.from).format('dd/LL');
+        const startHour = CompaniDates(this.courseHistory.update.startHour.to).format('HH\'h\'mm');
+        const endHour = CompaniDates(this.courseHistory.update.endHour.to).format('HH\'h\'mm');
 
         return { type: 'Nouvel horaire', post: ' pour le créneau du', infos: `${date} : ${startHour} - ${endHour}` };
       }
@@ -136,8 +135,8 @@ export default {
     getSlotEditionDetails () {
       if (this.courseHistory.update.startDate) return undefined;
 
-      const oldStartHour = formatHoursWithMinutes(this.courseHistory.update.startHour.from);
-      const oldEndHour = formatHoursWithMinutes(this.courseHistory.update.endHour.from);
+      const oldStartHour = CompaniDates(this.courseHistory.update.startHour.from).format('HH\'h\'mm');
+      const oldEndHour = CompaniDates(this.courseHistory.update.endHour.from).format('HH\'h\'mm');
 
       return `Créneau initialement prévu de ${oldStartHour} à ${oldEndHour}`;
     },

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -151,8 +151,8 @@ import { defineAbilitiesFor } from '@helpers/ability';
 import { composeCourseName } from '@helpers/courses';
 import { formatQuantity, formatIdentity, formatDownloadName, formatPhoneForPayload } from '@helpers/utils';
 import { downloadFile } from '@helpers/file';
-import moment from '@helpers/moment';
-import { descendingSort, ascendingSort } from '@helpers/date';
+import CompaniDate from '@helpers/dates/companiDates';
+import { descendingSort, ascendingSort } from '@helpers/dates/utils';
 import { strictPositiveNumber, integerNumber } from '@helpers/vuelidateCustomVal';
 import BiColorButton from '@components/BiColorButton';
 import { useCourses } from '@composables/courses';
@@ -255,12 +255,12 @@ export default {
     const canEditTrainees = computed(() => isIntraCourse.value || (!isClientInterface && !isTrainer.value));
 
     const isFinished = computed(() => {
-      const slotsToCome = course.value.slots.filter(slot => moment().isBefore(slot.endDate));
+      const slotsToCome = course.value.slots.filter(slot => CompaniDate().isBefore(slot.endDate));
       return !slotsToCome.length && !course.value.slotsToPlan.length;
     });
 
     const courseNotStartedYet = computed(() => {
-      const slots = course.value.slots.filter(slot => moment().isAfter(slot.endDate));
+      const slots = course.value.slots.filter(slot => CompaniDate().isAfter(slot.endDate));
       return !slots.length;
     });
 
@@ -278,7 +278,7 @@ export default {
     const courseName = computed(() => composeCourseName(course.value));
 
     const noFuturSlotIsPlanned = computed(() => {
-      const futurSlots = course.value.slots.filter(s => s.startDate).filter(s => moment().isBefore(s.startDate));
+      const futurSlots = course.value.slots.filter(s => s.startDate).filter(s => CompaniDate().isBefore(s.startDate));
       return !!course.value.slotsToPlan.length && !futurSlots.length;
     });
 
@@ -432,7 +432,7 @@ export default {
       try {
         smsLoading.value = true;
         const smsList = await Courses.getSMSHistory(course.value._id);
-        smsHistoryList.value = smsList.sort((a, b) => descendingSort(a.date, b.date));
+        smsHistoryList.value = smsList.sort(descendingSort('date'));
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du chargement des sms');
@@ -464,9 +464,9 @@ export default {
     const setConvocationMessage = () => {
       const slots = course.value.slots
         .filter(s => !!s.startDate)
-        .sort((a, b) => ascendingSort(a.startDate, b.startDate));
-      const date = moment(slots[0].startDate).format('DD/MM');
-      const hour = moment(slots[0].startDate).format('HH:mm');
+        .sort(ascendingSort('startDate'));
+      const date = CompaniDate(slots[0].startDate).format('dd/LL');
+      const hour = CompaniDate(slots[0].startDate).format('HH:mm');
 
       newSms.value.content = `Bonjour,\nVous êtes inscrit(e) à la formation ${courseName.value}.\n`
       + `La première session a lieu le ${date} à ${hour}.\nPour le bon déroulement et le suivi `
@@ -478,10 +478,10 @@ export default {
     const setReminderMessage = () => {
       const slots = course.value.slots
         .filter(s => !!s.startDate)
-        .filter(slot => moment().isBefore(slot.endDate))
-        .sort((a, b) => ascendingSort(a.startDate, b.startDate));
-      const date = moment(slots[0].startDate).format('DD/MM');
-      const hour = moment(slots[0].startDate).format('HH:mm');
+        .filter(slot => CompaniDate().isBefore(slot.endDate))
+        .sort(ascendingSort('startDate'));
+      const date = CompaniDate(slots[0].startDate).format('dd/LL');
+      const hour = CompaniDate(slots[0].startDate).format('HH:mm');
 
       newSms.value.content = `Bonjour,\nRAPPEL : vous êtes inscrit(e) à la formation ${courseName.value}.\n`
       + `Votre prochaine session a lieu le ${date} à ${hour}.\nPour le bon déroulement et le suivi `

--- a/src/core/components/courses/ProfileOrganization.vue
+++ b/src/core/components/courses/ProfileOrganization.vue
@@ -152,7 +152,7 @@ import { composeCourseName } from '@helpers/courses';
 import { formatQuantity, formatIdentity, formatDownloadName, formatPhoneForPayload } from '@helpers/utils';
 import { downloadFile } from '@helpers/file';
 import CompaniDate from '@helpers/dates/companiDates';
-import { descendingSort, ascendingSort } from '@helpers/dates/utils';
+import { descendingSortBy, ascendingSortBy } from '@helpers/dates/utils';
 import { strictPositiveNumber, integerNumber } from '@helpers/vuelidateCustomVal';
 import BiColorButton from '@components/BiColorButton';
 import { useCourses } from '@composables/courses';
@@ -432,7 +432,7 @@ export default {
       try {
         smsLoading.value = true;
         const smsList = await Courses.getSMSHistory(course.value._id);
-        smsHistoryList.value = smsList.sort(descendingSort('date'));
+        smsHistoryList.value = smsList.sort(descendingSortBy('date'));
       } catch (e) {
         console.error(e);
         NotifyNegative('Erreur lors du chargement des sms');
@@ -464,7 +464,7 @@ export default {
     const setConvocationMessage = () => {
       const slots = course.value.slots
         .filter(s => !!s.startDate)
-        .sort(ascendingSort('startDate'));
+        .sort(ascendingSortBy('startDate'));
       const date = CompaniDate(slots[0].startDate).format('dd/LL');
       const hour = CompaniDate(slots[0].startDate).format('HH:mm');
 
@@ -479,7 +479,7 @@ export default {
       const slots = course.value.slots
         .filter(s => !!s.startDate)
         .filter(slot => CompaniDate().isBefore(slot.endDate))
-        .sort(ascendingSort('startDate'));
+        .sort(ascendingSortBy('startDate'));
       const date = CompaniDate(slots[0].startDate).format('dd/LL');
       const hour = CompaniDate(slots[0].startDate).format('HH:mm');
 

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -145,17 +145,17 @@ export default {
         .filter(date => !!date)
         .map(slot => CompaniDate(slot.startDate).startOf('day'))
         .sort(ascendingSort);
-      const slotDayDates = [...new Set(slotDatesWithDuplicate)];
+      const slotDates = [...new Set(slotDatesWithDuplicate)];
 
-      const totalDate = slotsToPlanLength + slotDayDates.length;
+      const totalDate = slotsToPlanLength + slotDates.length;
       if (!totalDate) return { title: 'Pas de date prévue', subtitle: '', icon: 'mdi-calendar-remove' };
 
       const slotsToPlanTitle = slotsToPlanLength ? ` dont ${slotsToPlanLength} à planifier, ` : '';
 
       let subtitle = '';
-      if (slotDayDates.length) {
-        const firstSlot = CompaniDate(slotDayDates[0]).format('DDD');
-        const lastSlot = CompaniDate(slotDayDates[slotDayDates.length - 1]).format('DDD');
+      if (slotDates.length) {
+        const firstSlot = CompaniDate(slotDates[0]).format('DDD');
+        const lastSlot = CompaniDate(slotDates[slotDates.length - 1]).format('DDD');
         subtitle = `du ${firstSlot} au ${lastSlot}`;
       }
 

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -141,20 +141,21 @@ export default {
 
     const formatSlotTitle = computed(() => {
       const slotsToPlanLength = course.value.slotsToPlan.length;
-      const courseSlots = groupBy(
-        course.value.slots.filter(slot => !!slot.startDate).sort(ascendingSort('startDate')),
-        s => CompaniDate(s.startDate).format('dd/LL/yyyy')
-      );
-      const slotList = Object.values(courseSlots);
-      const totalDate = slotsToPlanLength + slotList.length;
+      const slotDatesWithDuplicate = course.value.slots
+        .filter(date => !!date)
+        .map(slot => CompaniDate(slot.startDate).startOf('day'))
+        .sort(ascendingSort);
+      const slotDayDates = [...new Set(slotDatesWithDuplicate)];
+
+      const totalDate = slotsToPlanLength + slotDayDates.length;
       if (!totalDate) return { title: 'Pas de date prévue', subtitle: '', icon: 'mdi-calendar-remove' };
 
       const slotsToPlanTitle = slotsToPlanLength ? ` dont ${slotsToPlanLength} à planifier, ` : '';
 
       let subtitle = '';
-      if (slotList.length) {
-        const firstSlot = CompaniDate(slotList[0][0].startDate).format('DDD');
-        const lastSlot = CompaniDate(slotList[slotList.length - 1][0].startDate).format('DDD');
+      if (slotDayDates.length) {
+        const firstSlot = CompaniDate(slotDayDates[0]).format('DDD');
+        const lastSlot = CompaniDate(slotDayDates[slotDayDates.length - 1]).format('DDD');
         subtitle = `du ${firstSlot} au ${lastSlot}`;
       }
 

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -149,8 +149,8 @@ export default {
 
       let subtitle = '';
       if (slotList.length) {
-        const firstSlot = moment(slotList[0][0].startDate).format('LL');
-        const lastSlot = moment(slotList[slotList.length - 1][0].startDate).format('LL');
+        const firstSlot = CompaniDate(slotList[0][0].startDate).format('DDD');
+        const lastSlot = CompaniDate(slotList[slotList.length - 1][0].startDate).format('DDD');
         subtitle = `du ${firstSlot} au ${lastSlot}`;
       }
 
@@ -201,7 +201,7 @@ export default {
           endDate: {
             required,
             ...(!!get(editedCourseSlot.value, 'dates.startDate') && {
-              maxDate: maxDate(moment(editedCourseSlot.value.dates.startDate).endOf('d').toISOString()),
+              maxDate: maxDate(CompaniDate(editedCourseSlot.value.dates.startDate).endOf('day').toISO()),
               minDate: minDate(editedCourseSlot.value.dates.startDate),
             }),
           },

--- a/src/core/components/courses/SlotContainer.vue
+++ b/src/core/components/courses/SlotContainer.vue
@@ -91,7 +91,8 @@ import { useValidations } from '@composables/validations';
 import { E_LEARNING, ON_SITE, REMOTE } from '@data/constants';
 import { formatQuantity } from '@helpers/utils';
 import { getStepTypeLabel } from '@helpers/courses';
-import { formatDate, formatDuration, formatIntervalHourly, getDuration } from '@helpers/date';
+import { formatDuration, formatIntervalHourly, getDuration } from '@helpers/date';
+import { ascendingSort } from '@helpers/dates/utils';
 import { frAddress, minDate, maxDate, urlAddress, validHour, strictMinHour } from '@helpers/vuelidateCustomVal';
 import moment from '@helpers/moment';
 import CompaniDate from '@helpers/dates/companiDates';
@@ -140,7 +141,10 @@ export default {
 
     const formatSlotTitle = computed(() => {
       const slotsToPlanLength = course.value.slotsToPlan.length;
-      const courseSlots = groupBy(course.value.slots.filter(slot => !!slot.startDate), s => formatDate(s.startDate));
+      const courseSlots = groupBy(
+        course.value.slots.filter(slot => !!slot.startDate).sort(ascendingSort('startDate')),
+        s => CompaniDate(s.startDate).format('dd/LL/yyyy')
+      );
       const slotList = Object.values(courseSlots);
       const totalDate = slotsToPlanLength + slotList.length;
       if (!totalDate) return { title: 'Pas de date prévue', subtitle: '', icon: 'mdi-calendar-remove' };
@@ -169,7 +173,10 @@ export default {
       const formattedSlots = [...course.value.slots, ...course.value.slotsToPlan];
       const slotsByStep = groupBy(formattedSlots, 'step');
       const slotsByStepAndDateList = Object.keys(slotsByStep)
-        .map(key => groupBy(slotsByStep[key], s => formatDate(s.startDate) || SLOTS_TO_PLAN_KEY));
+        .map(key => groupBy(
+          slotsByStep[key],
+          s => (s.startDate ? CompaniDate(s.startDate).format('dd/LL/yyyy') : SLOTS_TO_PLAN_KEY)
+        ));
 
       return Object.fromEntries(Object.keys(slotsByStep).map((key, index) => [key, slotsByStepAndDateList[index]]));
     });

--- a/src/core/helpers/dates/utils.js
+++ b/src/core/helpers/dates/utils.js
@@ -1,5 +1,7 @@
 import CompaniDate from './companiDates';
 
-export const ascendingSort = key => (a, b) => (CompaniDate(a[key]).isAfter(b[key]) ? 1 : -1);
+export const ascendingSort = (a, b) => (CompaniDate(a).isAfter(b) ? 1 : -1);
 
-export const descendingSort = key => (a, b) => (CompaniDate(a[key]).isBefore(b[key]) ? 1 : -1);
+export const ascendingSortBy = key => (a, b) => (CompaniDate(a[key]).isAfter(b[key]) ? 1 : -1);
+
+export const descendingSortBy = key => (a, b) => (CompaniDate(a[key]).isBefore(b[key]) ? 1 : -1);

--- a/src/modules/client/components/planning/EventCreationModal.vue
+++ b/src/modules/client/components/planning/EventCreationModal.vue
@@ -107,7 +107,7 @@ import {
   ABSENCE_TYPES,
 } from '@data/constants';
 import CompaniDate from '@helpers/dates/companiDates';
-import { descendingSort } from '@helpers/dates/utils';
+import { descendingSortBy } from '@helpers/dates/utils';
 import { formatIdentityAndDocType } from '@helpers/utils';
 import { planningModalMixin } from 'src/modules/client/mixins/planningModalMixin';
 
@@ -190,7 +190,7 @@ export default {
       return this.auxiliaryAbsences
         .filter(e => e.absence === this.newEvent.absence &&
             CompaniDate(e.startDate).isBefore(this.newEvent.dates.startDate))
-        .sort(descendingSort('startDate'))
+        .sort(descendingSortBy('startDate'))
         .map(a => ({
           label: `${CompaniDate(a.startDate).format('dd/LL/yyyy')} - ${CompaniDate(a.endDate).format('dd/LL/yyyy')}`,
           value: a._id,


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : rof

- Cas d'usage :
   - migration vers companiDate dans les cmp `ProfilOrga` `CourseHistory` et `SlotContainer`

- Comment tester ? :
  - ProfilOrga 
    - Sur la modale d'envoie de sms,
      - Vérifier la date dans les messages de convocation et de rappel
         - que c'est bien le prochain creneau
         - que la date et l'horaire est bonne
      - Verifier que l'ordre des SMS ans l'historique est decroissant
      - Verifier les types de SMS proposés
          - si la formation n’est pas commencé
             - les types dispo sont "convoc", "rappel" et "autre" 
             - par defaut "convocation"
          - si la formation est terminé ou si il n’y a plus que des creneaux a plannifier
             -  le seul type dispo est "autre"
          - sinon
             - les types dispo sont  "rappel" et "autre" 
             - par defaut rappel
 
  - CourseHistory
    - verifier tous les type de messages
      - pour les relecteur.ices de la PR, vous pouvez toucher un peu au code et ajouter du texte dans les formats pour facilement identifier et tester un a un les msg. (ex :
 `CompaniDates(this.courseHistory.slot.startDate).format('HH\'h\'mm ******');` ![Capture d’écran 2022-10-07 à 17 33 40](https://user-images.githubusercontent.com/47056365/194592395-a7620b19-12eb-474a-836b-782ddd95c9e8.png))
      - pour celleux qui testent en deploiement essayer de checker rapidos tous les types de msg.

  - SlotContainer
    - verifier le sous titre du tableau des creneaux : "du 10 octobre 2022 au ..."
       - verifier que c'est bien la date du premier et du dernier creneau
       - verifier que ca s'affiche correctement "JJ mois_en_lettre AAAA"
    - verifier que les creneaux du meme jour se regroupe bien

 - EventCreationModal (a cause du refact de ascendingSort)
    - ajouter plusieurs absences du meme type a une auxilaire, ⚠️ il faut que ce soit une absence prolongeable, genre "congé parental".
    - dans la modal pour créer une nouvelle absence et cliquer sur la checkbox "prolongation"
    - dans le select "absence" les absences precedement créées sont dans l'ordre decroissant

_Si tu as lu cette description, pense à réagir avec un :eye:_
