### PR TITLE
COM-3202: block non image/pdf file upload

### DIFF
--- a/src/core/components/courses/AttendanceSheetAdditionModal.vue
+++ b/src/core/components/courses/AttendanceSheetAdditionModal.vue
@@ -11,7 +11,7 @@
       caption="Participant(e)" :options="traineeOptions" />
     <ni-input in-modal caption="Feuille d'émargement" type="file" @blur="validations.file.$touch" last required-field
       :model-value="newAttendanceSheet.file" @update:model-value="update($event, 'file')"
-      :error="validations.file.$error" />
+      :extensions="[DOC_EXTENSIONS, IMAGE_EXTENSIONS]" :error="validations.file.$error" />
     <template #footer>
       <ni-button class="full-width modal-btn bg-primary" label="Ajouter la feuille d'émargement" :loading="loading"
         icon-right="add" @click="submit" color="white" />
@@ -24,7 +24,7 @@ import Modal from '@components/modal/Modal';
 import Select from '@components/form/Select';
 import Input from '@components/form/Input';
 import Button from '@components/Button';
-import { INTRA } from '@data/constants';
+import { INTRA, DOC_EXTENSIONS, IMAGE_EXTENSIONS } from '@data/constants';
 import { formatAndSortIdentityOptions } from '@helpers/utils';
 import { formatDate } from '@helpers/date';
 import moment from '@helpers/moment';
@@ -48,6 +48,8 @@ export default {
   data () {
     return {
       INTRA,
+      DOC_EXTENSIONS,
+      IMAGE_EXTENSIONS,
     };
   },
   computed: {

--- a/src/core/components/form/Input.vue
+++ b/src/core/components/form/Input.vue
@@ -14,7 +14,7 @@
         <i aria-hidden="true" class="q-icon on-right material-icons self-center relative-position">
           add
           <input ref="inputFile" type="file" @input="updateInputFile" class="input-file absolute-full cursor-pointer"
-            @blur="onBlur">
+            @blur="onBlur" :accept="extensions">
         </i>
       </div>
       <div class="file-error" v-if="error">{{ errorMessage }}</div>
@@ -71,6 +71,7 @@ export default {
     dataCy: { type: String, default: '' },
     inputClass: { type: [Array, String, Object], default: '' },
     noBorder: { type: Boolean, default: false },
+    extensions: { type: Array, default: () => [] },
   },
   emits: ['update:model-value', 'blur', 'focus', 'click', 'keyup-enter'],
   data () {


### PR DESCRIPTION
- [x] J'ai vérifié la fonctionnalité sur mobile
- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur formateur/rof/admin

- Cas d'usage : je ne peux ajouter que des pdf et des images comme feuilles d'émargements

- Comment tester ? :
- essayer d'ajouter un autre type de fichier que image ou pdf comme feuille d'émargement => je ne peux pas
- je peux bien ajouter une image (jpg, png) ou un pdf comme feuille d'émargement

_Si tu as lu cette description, pense à réagir avec un :eye:_
