### PR TITLE
COM-3371 update libraries for github actions

### DIFF
--- a/.github/workflows/endToEnd.js.yml
+++ b/.github/workflows/endToEnd.js.yml
@@ -17,14 +17,14 @@ jobs:
       # Check out the repository
       - id: checkout_api
         continue-on-error: true
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'sophiemoustard/compani-api'
           ref: ${{ github.event.pull_request.head.ref }}
           path: 'api'
 
       - if: ${{ steps.checkout_api.outcome != 'success' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'sophiemoustard/compani-api'
           ref: dev
@@ -33,14 +33,14 @@ jobs:
       - run: cd api && npm ci
         env:
           DETACHMENT_ALLOWED_COMPANY_IDS : ${{ secrets.DETACHMENT_ALLOWED_COMPANY_IDS }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: 'webapp'
       - run: cd webapp && npm ci
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           working-directory: ./webapp
           start: npm run start:workflow:api, npm run start:workflow:webapp

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,12 @@ jobs:
     name: Run ESLint
     runs-on: ubuntu-latest
     steps:
-      
+
       # Check out the repository
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       # Install Node.js
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 14.18.0
 


### PR DESCRIPTION
Mise à jour des library `actions/checkout` et `actions/setup-node` car les actions utilisant node12 est bientot déprécié.