### PR TITLE
test defining node version

### DIFF
--- a/.github/workflows/endToEnd.js.yml
+++ b/.github/workflows/endToEnd.js.yml
@@ -30,6 +30,10 @@ jobs:
           ref: dev
           path: 'api'
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.18.0
+
       - run: cd api && npm ci
         env:
           DETACHMENT_ALLOWED_COMPANY_IDS : ${{ secrets.DETACHMENT_ALLOWED_COMPANY_IDS }}


### PR DESCRIPTION
- [ ] J'ai vérifié la fonctionnalité sur mobile -np
- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

Les tests cassent sur la PR de MES. Je ne sais pas trop pourquoi ils ne cassaient pas avant, mais je me suis demandée si ce n'était pas parce qu'on ne précisait pas sous quel version de node il fallait être. En ajoutant cette info, ca refonctionne (j'ai teste de lancer les github action en mettant comme base branche dev et master et les deux fonctionnent). 

_Si tu as lu cette description, pense à réagir avec un :eye:_